### PR TITLE
SIG-368 send mail Apptimize on category changed

### DIFF
--- a/api/src/signals/django_signals.py
+++ b/api/src/signals/django_signals.py
@@ -9,4 +9,4 @@ from signals.models import Signal
 def post_save_signal(sender, instance, created, **kwargs):
     if created:
         tasks.push_to_sigmax.delay(id=instance.id)
-    tasks.email_to_apptimize.delay(id=instance.id)
+    tasks.email_apptimize.delay(id=instance.id)

--- a/api/src/signals/django_signals.py
+++ b/api/src/signals/django_signals.py
@@ -9,4 +9,4 @@ from signals.models import Signal
 def post_save_signal(sender, instance, created, **kwargs):
     if created:
         tasks.push_to_sigmax.delay(id=instance.id)
-    tasks.email_apptimize.delay(id=instance.id)
+    tasks.send_mail_apptimize.delay(id=instance.id)

--- a/api/src/signals/settings.py
+++ b/api/src/signals/settings.py
@@ -169,16 +169,9 @@ if TESTING:
 # celery  does the sending then then these export should be set before starting
 # the celery working process
 
-# FIXME: Following part should be gone
-EMAIL_INTEGRATION_ADDRESS = os.getenv('EMAIL_INTEGRATION_ADDRESS', None)
-EMAIL_INTEGRATION_ELIGIBLE_MAIN_CATEGORIES = (
-    'Openbaar groen en water',
-    'Wegen/verkeer/straatmeubilair')
-EMAIL_INTEGRATION_ELIGIBLE_SUB_CATEGORIES = ()
-for main_cat in EMAIL_INTEGRATION_ELIGIBLE_MAIN_CATEGORIES:
-    for cat in SUB_CATEGORIES_DICT[main_cat]:
-        EMAIL_INTEGRATION_ELIGIBLE_SUB_CATEGORIES += (cat[2],)
-##
+EMAIL_APPTIMIZE_INTEGRATION_ADDRESS = os.getenv(
+    'EMAIL_APPTIMIZE_INTEGRATION_ADDRESS', None)
+NOREPLY = 'noreply@meldingen.amsterdam.nl'
 
 EMAIL_HOST = os.getenv('EMAIL_HOST')
 EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')

--- a/api/src/signals/tasks.py
+++ b/api/src/signals/tasks.py
@@ -16,7 +16,7 @@ def push_to_sigmax(id):
 
 
 @app.task
-def email_apptimize(id):
+def send_mail_apptimize(id):
     """Send email to Apptimize when applicable.
 
     :param id: Signal object id
@@ -45,7 +45,7 @@ def email_apptimize(id):
         }, indent=4, sort_keys=True, default=str)
 
         send_mail(
-            subject='email',
+            subject='Nieuwe melding op meldingen.amsterdam.nl',
             message=message,
             from_email=settings.NOREPLY,
             recipient_list=(settings.EMAIL_APPTIMIZE_INTEGRATION_ADDRESS, ),

--- a/api/src/signals/tasks.py
+++ b/api/src/signals/tasks.py
@@ -16,7 +16,7 @@ def push_to_sigmax(id):
 
 
 @app.task
-def email_to_apptimize(id):
+def email_apptimize(id):
     """Send email to Apptimize when applicable.
 
     :param id: Signal object id
@@ -25,7 +25,7 @@ def email_to_apptimize(id):
     try:
         signal = Signal.objects.get(id=id)
     except Signal.DoesNotExist as e:
-        log.exception(e.message)
+        log.exception(str(e))
         return
 
     if _is_signal_applicable_for_apptimize(signal):

--- a/api/src/signals/tasks.py
+++ b/api/src/signals/tasks.py
@@ -65,9 +65,9 @@ def _is_signal_applicable_for_apptimize(signal):
         for sub_category in settings.SUB_CATEGORIES_DICT[main_category]:
             eligible_sub_categories += (sub_category[2], )
 
-    is_eligible_for_apptimize = (
-        settings.EMAIL_APPTIMIZE_INTEGRATION_ADDRESS
+    is_applicable_for_apptimize = (
+        settings.EMAIL_APPTIMIZE_INTEGRATION_ADDRESS is not None
         and signal.category.main in eligible_main_categories
         and signal.category.sub in eligible_sub_categories)
 
-    return is_eligible_for_apptimize
+    return is_applicable_for_apptimize

--- a/api/src/signals/tasks.py
+++ b/api/src/signals/tasks.py
@@ -1,4 +1,13 @@
+import json
+import logging
+
+from django.conf import settings
+from django.core.mail import send_mail
+
 from signals.celery import app
+from signals.models import Signal
+
+log = logging.getLogger(__name__)
 
 
 @app.task
@@ -8,4 +17,58 @@ def push_to_sigmax(id):
 
 @app.task
 def email_to_apptimize(id):
-    pass
+    """Send email to Apptimize when applicable.
+
+    :param id: Signal object id
+    :returns:
+    """
+    try:
+        signal = Signal.objects.get(id=id)
+    except Signal.DoesNotExist as e:
+        log.exception(e.message)
+        return
+
+    if _is_signal_applicable_for_apptimize(signal):
+        message = json.dumps({
+            'mora_nummer': signal.id,
+            'signal_id': signal.signal_id,
+            'tijdstip': signal.incident_date_start,
+            'email_melder': signal.reporter.email,
+            'telefoonnummer_melder': signal.reporter.phone,
+            'adres': signal.location.address,
+            'stadsdeel': signal.location.stadsdeel,
+            'categorie': {
+                'hoofdrubriek': signal.category.main,
+                'subrubriek': signal.category.sub,
+            },
+            'omschrijving': signal.text,
+        }, indent=4, sort_keys=True, default=str)
+
+        send_mail(
+            subject='email',
+            message=message,
+            from_email=settings.NOREPLY,
+            recipient_list=(settings.EMAIL_APPTIMIZE_INTEGRATION_ADDRESS, ),
+            fail_silently=False
+        )
+
+
+def _is_signal_applicable_for_apptimize(signal):
+    """Is given `Signal` applicable for Apptimize.
+
+    :param signal: Signal object
+    :returns: bool
+    """
+    eligible_main_categories = ('Openbaar groen en water',
+                                'Wegen/verkeer/straatmeubilair', )
+    eligible_sub_categories = ()
+    for main_category in eligible_main_categories:
+        for sub_category in settings.SUB_CATEGORIES_DICT[main_category]:
+            eligible_sub_categories += (sub_category[2], )
+
+    is_eligible_for_apptimize = (
+        settings.EMAIL_APPTIMIZE_INTEGRATION_ADDRESS
+        and signal.category.main in eligible_main_categories
+        and signal.category.sub in eligible_sub_categories)
+
+    return is_eligible_for_apptimize

--- a/api/src/signals/tasks.py
+++ b/api/src/signals/tasks.py
@@ -49,8 +49,7 @@ def email_apptimize(id):
             message=message,
             from_email=settings.NOREPLY,
             recipient_list=(settings.EMAIL_APPTIMIZE_INTEGRATION_ADDRESS, ),
-            fail_silently=False
-        )
+            fail_silently=False)
 
 
 def _is_signal_applicable_for_apptimize(signal):

--- a/api/src/signals/tests/factories.py
+++ b/api/src/signals/tests/factories.py
@@ -1,15 +1,12 @@
 import pytz
-import factory
 import string
-import random
-from datetime import datetime
 import uuid
 import random
+from datetime import datetime
 
+import factory
 from django.contrib.gis.geos import Point
-
 from factory import fuzzy
-
 
 from signals.models import Signal
 from signals.models import Location
@@ -33,9 +30,22 @@ class SignalFactory(factory.DjangoModelFactory):
     class Meta:
         model = Signal
 
-    signal_id = uuid.uuid4()
+    # This is needed to make the back reference `_signal` on o2o related
+    # objects possible.
+    id = factory.Sequence(lambda n: n)
+
+    signal_id = fuzzy.FuzzyAttribute(uuid.uuid4)
     text = fuzzy.FuzzyText(length=100)
     text_extra = fuzzy.FuzzyText(length=100)
+
+    location = factory.SubFactory('signals.tests.factories.LocationFactory',
+                                  _signal_id=factory.SelfAttribute('..id'))
+    status = factory.SubFactory('signals.tests.factories.StatusFactory',
+                                _signal_id=factory.SelfAttribute('..id'))
+    category = factory.SubFactory('signals.tests.factories.CategoryFactory',
+                                  _signal_id=factory.SelfAttribute('..id'))
+    reporter = factory.SubFactory('signals.tests.factories.ReporterFactory',
+                                  _signal_id=factory.SelfAttribute('..id'))
 
     incident_date_start = fuzzy.FuzzyDateTime(
         datetime(2017, 11, 1, tzinfo=pytz.UTC),

--- a/api/src/signals/tests/factories.py
+++ b/api/src/signals/tests/factories.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 import factory
 from django.contrib.gis.geos import Point
+from django.db.models.signals import pre_save, post_save
 from factory import fuzzy
 
 from signals.models import Signal
@@ -25,6 +26,7 @@ def get_puntje():
     return Point(float(lat), float(lon))
 
 
+@factory.django.mute_signals(pre_save, post_save)
 class SignalFactory(factory.DjangoModelFactory):
 
     class Meta:

--- a/api/src/signals/tests/test_django_signals.py
+++ b/api/src/signals/tests/test_django_signals.py
@@ -9,7 +9,12 @@ class TestDjangoSignals(testcases.TestCase):
 
     @mock.patch('signals.django_signals.tasks')
     def test_post_save_signal_created(self, mocked_tasks):
-        signal = SignalFactory.create()
+        signal = SignalFactory.build()
+        signal.location.save()
+        signal.status.save()
+        signal.reporter.save()
+        signal.category.save()
+        signal.save()  # Triggers Django `post_save` signal.
 
         mocked_tasks.push_to_sigmax.delay.assert_called_once_with(id=signal.id)
         mocked_tasks.send_mail_apptimize.delay.assert_called_once_with(
@@ -18,7 +23,6 @@ class TestDjangoSignals(testcases.TestCase):
     @mock.patch('signals.django_signals.tasks')
     def test_post_save_signal_updated(self, mocked_tasks):
         signal = SignalFactory.create()
-        mocked_tasks.reset_mock()
 
         signal.text = 'Signal is updated'
         signal.save()

--- a/api/src/signals/tests/test_django_signals.py
+++ b/api/src/signals/tests/test_django_signals.py
@@ -12,7 +12,7 @@ class TestDjangoSignals(testcases.TestCase):
         signal = SignalFactory.create()
 
         mocked_tasks.push_to_sigmax.delay.assert_called_once_with(id=signal.id)
-        mocked_tasks.email_to_apptimize.delay.assert_called_once_with(
+        mocked_tasks.email_apptimize.delay.assert_called_once_with(
             id=signal.id)
 
     @mock.patch('signals.django_signals.tasks')
@@ -23,5 +23,5 @@ class TestDjangoSignals(testcases.TestCase):
         signal.text = 'Signal is updated'
         signal.save()
         mocked_tasks.push_to_sigmax.delay.assert_not_called()
-        mocked_tasks.email_to_apptimize.delay.assert_called_once_with(
+        mocked_tasks.email_apptimize.delay.assert_called_once_with(
             id=signal.id)

--- a/api/src/signals/tests/test_django_signals.py
+++ b/api/src/signals/tests/test_django_signals.py
@@ -12,7 +12,7 @@ class TestDjangoSignals(testcases.TestCase):
         signal = SignalFactory.create()
 
         mocked_tasks.push_to_sigmax.delay.assert_called_once_with(id=signal.id)
-        mocked_tasks.email_apptimize.delay.assert_called_once_with(
+        mocked_tasks.send_mail_apptimize.delay.assert_called_once_with(
             id=signal.id)
 
     @mock.patch('signals.django_signals.tasks')
@@ -23,5 +23,5 @@ class TestDjangoSignals(testcases.TestCase):
         signal.text = 'Signal is updated'
         signal.save()
         mocked_tasks.push_to_sigmax.delay.assert_not_called()
-        mocked_tasks.email_apptimize.delay.assert_called_once_with(
+        mocked_tasks.send_mail_apptimize.delay.assert_called_once_with(
             id=signal.id)

--- a/api/src/signals/tests/test_post_api.py
+++ b/api/src/signals/tests/test_post_api.py
@@ -3,18 +3,16 @@ Test posting / updating to basic endpoints and authorization
 """
 import os
 import json
-# Packages
-from rest_framework.test import APITestCase
-from rest_framework.reverse import reverse
-# from . import factories
+
 from django.conf import settings
+from rest_framework.test import APITestCase
+
 from signals.models import Signal
 from signals.models import Location
 from signals.models import Reporter
 from signals.models import Category
 from signals.models import Status
-
-from . import factories
+from signals.tests import factories
 
 
 class PostTestCase(APITestCase):

--- a/api/src/signals/tests/test_post_api.py
+++ b/api/src/signals/tests/test_post_api.py
@@ -54,23 +54,14 @@ class PostTestCase(APITestCase):
         return postjson
 
     def setUp(self):
-        self.s = factories.SignalFactory()
-
-        self.loc = factories.LocationFactory(_signal=self.s)
-        self.status = factories.StatusFactory(_signal=self.s)
-        self.category = factories.CategoryFactory(_signal=self.s)
-        self.reporter = factories.ReporterFactory(_signal=self.s)
-
-        self.s.location = self.loc
-        self.s.status = self.status
-        self.s.category = self.category
-        self.s.reporter = self.reporter
-        self.s.save()
+        self.signal = factories.SignalFactory()
+        self.location = self.signal.location
+        self.status = self.signal.status
+        self.category = self.signal.category
+        self.reporter = self.signal.reporter
 
     def test_post_signal(self):
-        """Post een compleet signaal.
-        """
-
+        """Post een compleet signaal."""
         url = "/signals/signal/"
         postjson = self._get_fixture('post_signal')
         response = self.client.post(url, postjson, format='json')
@@ -123,40 +114,35 @@ class PostTestCase(APITestCase):
         """
         url = "/signals/auth/status/"
         postjson = self._get_fixture('post_status')
-        # signal_url = reverse('signal-auth-detail', args=[self.s.id])
-        postjson['_signal'] = self.s.id
+        postjson['_signal'] = self.signal.id
         response = self.client.post(url, postjson, format='json')
         result = response.json()
         self.assertEqual(response.status_code, 201)
-        self.s.refresh_from_db()
+        self.signal.refresh_from_db()
         # check that current status of signal is now this one
-        self.assertEqual(self.s.status.id, result['id'])
+        self.assertEqual(self.signal.status.id, result['id'])
 
     def test_post_location(self):
-        """We only create new location items
-        """
+        """We only create new location items"""
         url = "/signals/auth/location/"
         postjson = self._get_fixture('post_location')
-        # signal_url = reverse('signal-auth-detail', args=[self.s.id])
-        postjson['_signal'] = self.s.id
+        postjson['_signal'] = self.signal.id
         response = self.client.post(url, postjson, format='json')
         result = response.json()
         self.assertEqual(response.status_code, 201)
-        self.s.refresh_from_db()
+        self.signal.refresh_from_db()
         # check that current location of signal is now this one
-        self.assertEqual(self.s.location.id, result['id'])
+        self.assertEqual(self.signal.location.id, result['id'])
 
     def test_post_category(self):
-        """Category Post
-        """
+        """Category Post"""
         url = "/signals/auth/category/"
         postjson = self._get_fixture('post_category')
-        signal_url = reverse('signal-auth-detail', args=[self.s.id])
-        postjson['_signal'] = self.s.id
+        postjson['_signal'] = self.signal.id
         response = self.client.post(url, postjson, format='json')
         result = response.json()
         self.assertEqual(response.status_code, 201)
-        self.s.refresh_from_db()
+        self.signal.refresh_from_db()
         # check that current location of signal is now this one
-        self.assertEqual(self.s.category.id, result['id'])
-        self.assertEqual(self.s.category.department, "CCA,ASC,WAT")
+        self.assertEqual(self.signal.category.id, result['id'])
+        self.assertEqual(self.signal.category.department, "CCA,ASC,WAT")

--- a/api/src/signals/tests/test_tasks.py
+++ b/api/src/signals/tests/test_tasks.py
@@ -20,8 +20,18 @@ class TestTaskSendToApptimize(TestCase):
         mocked_log.exception.assert_called_once()
         mocked_send_mail.assert_not_called()
 
-    def test_send_to_apptimize_not_applicable(self):
-        pass
+    @mock.patch('signals.tasks.send_mail')
+    @mock.patch('signals.tasks._is_signal_applicable_for_apptimize',
+                return_value=False)
+    def test_send_to_apptimize_not_applicable(
+            self, mocked_is_signal_applicable_for_apptimize, mocked_send_mail):
+        signal = SignalFactory.create()
+
+        email_apptimize(id=signal.id)
+
+        mocked_is_signal_applicable_for_apptimize.assert_called_once_with(
+            signal)
+        mocked_send_mail.assert_not_called()
 
     def test_is_signal_applicable_for_apptimize_true(self):
         pass

--- a/api/src/signals/tests/test_tasks.py
+++ b/api/src/signals/tests/test_tasks.py
@@ -4,7 +4,7 @@ from unittest import mock
 from django.conf import settings
 from django.test import TestCase
 
-from signals.tasks import email_apptimize
+from signals.tasks import send_mail_apptimize
 from signals.tests.factories import SignalFactory
 
 
@@ -13,10 +13,8 @@ class TestTaskSendToApptimize(TestCase):
     @mock.patch('signals.tasks.send_mail')
     @mock.patch('signals.tasks._is_signal_applicable_for_apptimize',
                 return_value=True)
-    def test_send_to_apptimize(
-            self,
-            mocked_is_signal_applicable_for_apptimize,
-            mocked_send_mail):
+    def test_send_mail_apptimize(
+            self, mocked_is_signal_applicable_for_apptimize, mocked_send_mail):
         signal = SignalFactory.create()
         message = json.dumps({
             'mora_nummer': signal.id,
@@ -33,12 +31,12 @@ class TestTaskSendToApptimize(TestCase):
             'omschrijving': signal.text,
         }, indent=4, sort_keys=True, default=str)
 
-        email_apptimize(id=signal.id)
+        send_mail_apptimize(id=signal.id)
 
         mocked_is_signal_applicable_for_apptimize.assert_called_once_with(
             signal)
         mocked_send_mail.assert_called_once_with(
-            subject='email',
+            subject='Nieuwe melding op meldingen.amsterdam.nl',
             message=message,
             from_email=settings.NOREPLY,
             recipient_list=(settings.EMAIL_APPTIMIZE_INTEGRATION_ADDRESS, ),
@@ -46,10 +44,9 @@ class TestTaskSendToApptimize(TestCase):
 
     @mock.patch('signals.tasks.send_mail')
     @mock.patch('signals.tasks.log')
-    def test_send_to_apptimize_no_signal_found(self,
-                                               mocked_log,
-                                               mocked_send_mail):
-        email_apptimize(id=1)  # id `1` shouldn't be found.
+    def test_send_mail_apptimize_no_signal_found(
+            self, mocked_log, mocked_send_mail):
+        send_mail_apptimize(id=1)  # id `1` shouldn't be found.
 
         mocked_log.exception.assert_called_once()
         mocked_send_mail.assert_not_called()
@@ -57,11 +54,11 @@ class TestTaskSendToApptimize(TestCase):
     @mock.patch('signals.tasks.send_mail')
     @mock.patch('signals.tasks._is_signal_applicable_for_apptimize',
                 return_value=False)
-    def test_send_to_apptimize_not_applicable(
+    def test_send_mail_apptimize_not_applicable(
             self, mocked_is_signal_applicable_for_apptimize, mocked_send_mail):
         signal = SignalFactory.create()
 
-        email_apptimize(id=signal.id)
+        send_mail_apptimize(id=signal.id)
 
         mocked_is_signal_applicable_for_apptimize.assert_called_once_with(
             signal)

--- a/api/src/signals/tests/test_tasks.py
+++ b/api/src/signals/tests/test_tasks.py
@@ -1,0 +1,30 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from signals.tasks import email_apptimize
+from signals.tests.factories import SignalFactory
+
+
+class TestTaskSendToApptimize(TestCase):
+
+    def test_send_to_apptimize(self):
+        pass
+
+    @mock.patch('signals.tasks.send_mail')
+    @mock.patch('signals.tasks.log')
+    def test_send_to_apptimize_no_signal_found(self,
+                                               mocked_log,
+                                               mocked_send_mail):
+        email_apptimize(id=1)  # id `1` shouldn't be found.
+        mocked_log.exception.assert_called_once()
+        mocked_send_mail.assert_not_called()
+
+    def test_send_to_apptimize_not_applicable(self):
+        pass
+
+    def test_is_signal_applicable_for_apptimize_true(self):
+        pass
+
+    def test_is_signal_applicable_for_apptimize_false(self):
+        pass


### PR DESCRIPTION
- Implemented `send_mail_apptimize` task
- Updated `SignalFactory` to let it work out-of-the-box
- Apptimize mail is send on create/update of the object (on model `save`)