### PR TITLE
Sig 393 celery beat CSV dumps

### DIFF
--- a/api/src/signals/settings.py
+++ b/api/src/signals/settings.py
@@ -1,3 +1,5 @@
+from celery.schedules import crontab
+
 from signals.messaging.categories import SUB_CATEGORIES_DICT
 from signals.settings_common import *  # noqa F403
 from signals.settings_common import INSTALLED_APPS
@@ -139,6 +141,12 @@ CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL',
                               f'amqp://{RABBITMQ_USER}:{RABBITMQ_PASSWORD}'
                               f'@{RABBITMQ_HOST}/{RABBITMQ_VHOST}')
 CELERY_EMAIL_CHUNK_SIZE = 1
+CELERY_BEAT_SCHEDULE = {
+    'save-csv-files-datawarehouse': {
+        'task': 'signals.tasks.task_save_csv_files_datawarehouse',
+        'schedule': crontab(hour=4),
+    },
+}
 
 if TESTING:
     CELERY_TASK_ALWAYS_EAGER = True

--- a/api/src/signals/tests/utils/test_datawarehouse.py
+++ b/api/src/signals/tests/utils/test_datawarehouse.py
@@ -207,8 +207,10 @@ class TestDatawarehouse(testcases.TestCase):
                 self.assertEqual(row['text'], str(status.text))
                 self.assertEqual(row['user'], str(status.user))
                 self.assertEqual(row['target_api'], '')
-                self.assertEqual(row['state'], status.get_state_display())
+                self.assertEqual(row['state_display'],
+                                 status.get_state_display())
                 self.assertEqual(row['extern'], str(status.extern))
                 self.assertEqual(row['created_at'], str(status.created_at))
                 self.assertEqual(row['updated_at'], str(status.updated_at))
                 self.assertEqual(json.loads(row['extra_properties']), None)
+                self.assertEqual(row['state'], status.state)

--- a/api/src/signals/tests/utils/test_datawarehouse.py
+++ b/api/src/signals/tests/utils/test_datawarehouse.py
@@ -54,6 +54,22 @@ class TestDatawarehouse(testcases.TestCase):
         self.assertTrue(path.exists(statuses_csv))
         self.assertTrue(path.getsize(statuses_csv))
 
+    @mock.patch('signals.utils.datawarehouse.SwiftStorage', autospec=True)
+    def test_save_csv_files_datawarehouse_cleanup_previous_files(
+            self, mocked_swift_storage):
+        mocked_swift_storage_instance = mock.Mock()
+        mocked_swift_storage.return_value = mocked_swift_storage_instance
+
+        datawarehouse.save_csv_files_datawarehouse()
+
+        mocked_swift_storage_instance.delete.assert_has_calls([
+            mock.call(name='signals.csv'),
+            mock.call(name='locations.csv'),
+            mock.call(name='reporters.csv'),
+            mock.call(name='categories.csv'),
+            mock.call(name='statuses.csv'),
+        ])
+
     @override_settings(
         DWH_SWIFT_AUTH_URL='dwh_auth_url',
         DWH_SWIFT_USERNAME='dwh_username',

--- a/api/src/signals/utils/datawarehouse.py
+++ b/api/src/signals/utils/datawarehouse.py
@@ -28,6 +28,7 @@ def save_csv_files_datawarehouse():
         for csv_file_path in csv_files:
             with open(csv_file_path, 'rb') as opened_csv_file:
                 file_name = os.path.basename(opened_csv_file.name)
+                storage.delete(name=file_name)
                 storage.save(name=file_name, content=opened_csv_file)
 
 

--- a/api/src/signals/utils/datawarehouse.py
+++ b/api/src/signals/utils/datawarehouse.py
@@ -255,12 +255,13 @@ def _create_statuses_csv(location):
             'text',
             'user',
             'target_api',
-            'state',
+            'state_display',
             'extern',
             'created_at',
             'updated_at',
             'extra_properties',
             '_signal_id',
+            'state',
         ])
 
         # Writing all `Status` objects to the CSV file.
@@ -276,6 +277,7 @@ def _create_statuses_csv(location):
                 status.updated_at,
                 json.dumps(status.extra_properties),
                 status._signal_id,
+                status.state,
             ])
 
     return csv_file.name


### PR DESCRIPTION
- Celery beat scheduling task `task_save_csv_files_datawarehouse` every night at 4am
- Cleanup previous files on storage backend
- Added state db value to CSV dump for `statuses.csv`