### PR TITLE
Bump version of Datapunt authorization_django

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -15,7 +15,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 cryptography==2.3
 cssselect2==0.2.1
-datapunt-authorization-django==0.2.22
+datapunt-authorization-django==0.2.23
 datapunt-authorization-levels==0.1.3
 debtcollector==1.20.0
 defusedxml==0.5.0


### PR DESCRIPTION
Trivial fix for warning during docker build (supposed version incompatibility).