### PR TITLE
Version bump to 0.6.2. Added created_by where neccessary.

### DIFF
--- a/api/app/signals/__init__.py
+++ b/api/app/signals/__init__.py
@@ -16,11 +16,11 @@ __all__ = ['celery_app', 'VERSION', 'API_VERSIONS', ]
 # `/signals/v1/...` will always have major API version number `1`.
 
 # Application version (Major, minor, patch)
-VERSION = (0, 6, 1)
+VERSION = (0, 6, 2)
 
 # API versions (Major, minor, patch)
 API_VERSIONS = {
-    'v0': (0, 1, 0),
+    'v0': (0, 1, 1),
     'v1': (1, 1, 0),
 }
 


### PR DESCRIPTION
* Overall version 0.6.2
* V0 API version 0.1.1
* V1 API version 1.1.0 (unchanged)