### PR TITLE
Feature/speed up testing

### DIFF
--- a/api/app/tox.ini
+++ b/api/app/tox.ini
@@ -5,7 +5,10 @@ skipsdist = True
 [testenv]
 envdir = {toxworkdir}/test
 sitepackages = True
-deps = -r../requirements.txt
+deps =
+    pytest-xdist==1.24.1
+    pytest-timeout==1.3.2
+    -r../requirements.txt
 basepython = python3
 whitelist_externals =
     pytest
@@ -17,6 +20,7 @@ commands =
     isort: isort --recursive --check-only signals tests
 
 [pytest]
+addopts = -n3
 DJANGO_SETTINGS_MODULE = signals.settings.testing
 python_files =
     test.py

--- a/api/deploy/test/test.sh
+++ b/api/deploy/test/test.sh
@@ -6,8 +6,10 @@ set -x
 
 DIR="$(dirname $0)"
 
+COMMIT_HASH=$(git rev-parse HEAD)
+
 dc() {
-	docker-compose -p signaltest -f ${DIR}/docker-compose.yml $*
+	docker-compose -p ${COMMIT_HASH}_signaltest -f ${DIR}/docker-compose.yml $*
 }
 
 

--- a/api/requirements-root.txt
+++ b/api/requirements-root.txt
@@ -45,5 +45,7 @@ isort
 pytest
 pytest-cov
 pytest-django
+pytest-xdist
+pytest-timeout
 tox
 xmlunittest

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -89,6 +89,8 @@ Pyphen==0.9.4
 pytest==3.7.1
 pytest-cov==2.5.1
 pytest-django==3.3.3
+pytest-xdist==1.24.1
+pytest-timeout==1.3.2
 pytest-flake8==1.0.2
 python-dateutil==2.7.3
 python-keystoneclient==3.17.0


### PR DESCRIPTION
Use the commit hash as part of the docker container name
Make use of pytest-xdist to run test async