### PR TITLE
Version bump to SIA 0.8.0

### DIFF
--- a/api/app/signals/__init__.py
+++ b/api/app/signals/__init__.py
@@ -16,12 +16,12 @@ __all__ = ['celery_app', 'VERSION', 'API_VERSIONS', ]
 # `/signals/v1/...` will always have major API version number `1`.
 
 # Application version (Major, minor, patch)
-VERSION = (0, 7, 2)
+VERSION = (0, 8, 0)
 
 # API versions (Major, minor, patch)
 API_VERSIONS = {
-    'v0': (0, 1, 3),
-    'v1': (1, 2, 1),
+    'v0': (0, 2, 0),
+    'v1': (1, 3, 0),
 }
 
 __version__ = get_version(VERSION)


### PR DESCRIPTION
Updated APIs with HEROPENEN status (affects both V0 and V1) - all backwards compatible. Hence three version bumps.