### PR TITLE
feature/SIG-1140

### DIFF
--- a/api/app/signals/apps/api/v1/serializers.py
+++ b/api/app/signals/apps/api/v1/serializers.py
@@ -198,6 +198,7 @@ class _NestedStatusModelSerializer(serializers.ModelSerializer):
             'user',
             'state',
             'state_display',
+            'target_api',
             'extra_properties',
             'created_at',
         )

--- a/api/app/tests/apps/api/test_api_v1_endpoints.py
+++ b/api/app/tests/apps/api/test_api_v1_endpoints.py
@@ -943,6 +943,23 @@ class TestPrivateSignalViewSet(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         response_json = response.json()
         self.assertJsonSchema(self.list_history_schema, response_json)
 
+    def test_update_status_target_api_SIG1140(self):
+        signal_no_status = SignalFactoryValidLocation.create()
+        self.client.force_authenticate(user=self.superuser)
+
+        detail_endpoint = self.detail_endpoint.format(pk=signal_no_status.id)
+
+        data = {
+            'status': {
+                'state': 'ready to send',
+                'text': 'Te verzenden naar THOR',
+                'target_api': 'sigmax',
+            }
+        }
+        response = self.client.patch(detail_endpoint, data, format='json')
+
+        self.assertEqual(200, response.status_code)
+
     def test_update_status_with_required_text(self):
         """ Status change to 'afgehandeld' (o) requires text. When no text is supplied, a 400 should
         be returned """


### PR DESCRIPTION
FIX for SIG-1140, target_api is now stored correctly when performing aPATCH