### PR TITLE
feature/SIG-2058

### DIFF
--- a/api/app/signals/apps/search/views.py
+++ b/api/app/signals/apps/search/views.py
@@ -37,7 +37,9 @@ class SearchView(DatapuntViewSet):
                 fields=[
                     'id',
                     'text',
-                    'category_assignment.category.name'
+                    'category_assignment.category.name',
+                    'reporter.email',  # SIG-2058 [BE] email, telefoon aan vrij zoeken toevoegen
+                    'reporter.phone'  # SIG-2058 [BE] email, telefoon aan vrij zoeken toevoegen
                 ]
             )
 


### PR DESCRIPTION
**SIG-2058** [BE] email, telefoon aan vrij zoeken toevoegen 

> Mogelijk maken om met vrij zoeken ook in email adres van melder te zoeken en op adres kan zoeken.
> 
> Alleen toevoegen, ranking niet configureren.
> 
