### PR TITLE
feature/SIG-2210

### DIFF
--- a/api/app/signals/apps/users/v1/views/user.py
+++ b/api/app/signals/apps/users/v1/views/user.py
@@ -40,7 +40,7 @@ class UserViewSet(DatapuntViewSetWritable):
     filterset_class = UserFilterSet
 
     # We only allow these methods
-    http_method_names = ['get', 'post', 'patch', 'put', 'head', 'options', 'trace']
+    http_method_names = ['get', 'post', 'patch', 'head', 'options', 'trace']
 
     def create(self, request, *args, **kwargs):
         # If we create a user we want to use the detail serializer


### PR DESCRIPTION
SIG-2210 [BE] PUT op user detail accepteert leeg object. We do not accept PUT anymore, only PATCH when changing a user