### PR TITLE
SIG-2287 fix when rendering the URL for a parent category

### DIFF
--- a/api/app/signals/apps/api/v1/serializers/departments.py
+++ b/api/app/signals/apps/api/v1/serializers/departments.py
@@ -102,9 +102,9 @@ class CategoryDepartmentSerializer(serializers.ModelSerializer):
         """
         SIG-2287 [BE] Afdeling geeft categorie zonder main slug terug
 
-        The category was rendered if it was a child category. So when encountering a parent category the link results in
-        a link with the parent category slug as "None". So before rendering the correct serializer we need to check if
-        we have a parent or a child category.
+        The category was rendered as if it was a child category. So when encountering a parent category the link results
+        in a link with the parent category slug as "None". So before rendering the correct serializer we need to check
+        if we have a parent or a child category.
 
         TODO: When refactoring the TemporaryCategoryHALSerializer and TemporaryParentCategoryHALSerializer serializers
               we also need to take a look at a better solution for this issue.

--- a/api/app/signals/apps/api/v1/serializers/departments.py
+++ b/api/app/signals/apps/api/v1/serializers/departments.py
@@ -2,7 +2,10 @@ from datapunt_api.rest import DisplayField, HALSerializer
 from rest_framework import serializers
 
 from signals.apps.api.v0.serializers import _NestedDepartmentSerializer
-from signals.apps.api.v1.fields import CategoryHyperlinkedIdentityField
+from signals.apps.api.v1.fields import (
+    CategoryHyperlinkedIdentityField,
+    ParentCategoryHyperlinkedIdentityField
+)
 from signals.apps.email_integrations.core.messages import \
     ALL_AFHANDELING_TEXT  # noqa TODO: move to a model
 from signals.apps.signals.models import Category, CategoryDepartment, Department
@@ -33,6 +36,9 @@ def _get_categories_queryset():
 
 
 class TemporaryCategoryHALSerializer(HALSerializer):
+    """
+    TODO: Refactor the TemporaryCategoryHALSerializer and TemporaryParentCategoryHALSerializer serializers
+    """
     serializer_url_field = CategoryHyperlinkedIdentityField
     _display = DisplayField()
     departments = serializers.SerializerMethodField()
@@ -63,8 +69,20 @@ class TemporaryCategoryHALSerializer(HALSerializer):
         ).data
 
 
+class TemporaryParentCategoryHALSerializer(TemporaryCategoryHALSerializer):
+    """
+    SIG-2287 [BE] Afdeling geeft categorie zonder main slug terug
+
+    Added a TemporaryParentCategoryHALSerializer so that we can override the serializer_url_field to render the correct
+    url for a parent category
+
+    TODO: Refactor the TemporaryCategoryHALSerializer and TemporaryParentCategoryHALSerializer serializers
+    """
+    serializer_url_field = ParentCategoryHyperlinkedIdentityField
+
+
 class CategoryDepartmentSerializer(serializers.ModelSerializer):
-    category = TemporaryCategoryHALSerializer(read_only=True, required=False)
+    category = serializers.SerializerMethodField()
     category_id = serializers.PrimaryKeyRelatedField(
         required=True, read_only=False, write_only=True,
         queryset=_get_categories_queryset(), source='category'
@@ -79,6 +97,23 @@ class CategoryDepartmentSerializer(serializers.ModelSerializer):
             'is_responsible',
             'can_view',
         )
+
+    def get_category(self, obj):
+        """
+        SIG-2287 [BE] Afdeling geeft categorie zonder main slug terug
+
+        The category was rendered if it was a child category. So when encountering a parent category the link results in
+        a link with the parent category slug as "None". So before rendering the correct serializer we need to check if
+        we have a parent or a child category.
+
+        TODO: When refactoring the TemporaryCategoryHALSerializer and TemporaryParentCategoryHALSerializer serializers
+              we also need to take a look at a better solution for this issue.
+        """
+        if obj.category.is_parent():
+            serializer_class = TemporaryParentCategoryHALSerializer
+        else:
+            serializer_class = TemporaryCategoryHALSerializer
+        return serializer_class(obj.category, context=self.context).data
 
 
 class PrivateDepartmentSerializerDetail(HALSerializer):

--- a/api/app/tests/apps/api/v1/test_private_departments.py
+++ b/api/app/tests/apps/api/v1/test_private_departments.py
@@ -21,8 +21,8 @@ class TestPrivateDepartmentEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCas
 
         self.department = DepartmentFactory.create()
 
-        self.category = ParentCategoryFactory.create()
-        self.subcategory = CategoryFactory.create(parent=self.category)
+        self.maincategory = ParentCategoryFactory.create()
+        self.subcategory = CategoryFactory.create(parent=self.maincategory)
 
     def test_get_list(self):
         self.client.force_authenticate(user=self.sia_read_write_user)
@@ -165,17 +165,17 @@ class TestPrivateDepartmentEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCas
 
     def test_SIG_2287(self):
         # Connect a parent category to the Department so that we can check the URL generated for this category
-        self.category.departments.add(self.department, through_defaults={'is_responsible': True, 'can_view': True})
+        self.maincategory.departments.add(self.department, through_defaults={'is_responsible': True, 'can_view': True})
 
         # Connect a child category to the Department so that we can check the URL generated for this category
         self.subcategory.departments.add(self.department, through_defaults={'is_responsible': True, 'can_view': True})
 
         # This should be the link of the parent category
-        expected_parent_url = 'http://testserver/signals/v1/public/terms/categories/{}'.format(self.category.slug)
+        expected_parent_url = 'http://testserver/signals/v1/public/terms/categories/{}'.format(self.maincategory.slug)
 
         # This should be the link of the child category
         expected_child_url = 'http://testserver/signals/v1/public/terms/categories/{}/sub_categories/{}'.format(
-            self.category.slug, self.subcategory.slug
+            self.subcategory.parent.slug, self.subcategory.slug
         )
 
         self.client.force_authenticate(user=self.sia_read_write_user)


### PR DESCRIPTION
SIG-2287 [BE] Afdeling geeft categorie zonder main slug terug

Fixed when rendering the URL for a parent category use the correct `serializer_url_field`