### PR TITLE
Change public serialization of signals

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -271,6 +271,47 @@ paths:
       - OAuth2:
         - SIG/ALL
 
+  /signals/v1/public/signals:
+    post:
+      description: Create a new Signal/melding.
+      requestBody:
+        description: Serialized signal data.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1PublicSignalPost'
+      responses:
+        '201':
+          description: New signal created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1PublicSignalDetailGet'
+        '400':
+          description: Bad request, see response body for the reason.
+
+  /signals/v1/public/signals/{signal_id}:
+    get:
+      description: Public data about a Signal/melding.
+      parameters:
+        - name: signal_id
+          in: path
+          description: Public identifier for a Signal/melding
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1PublicSignalDetailGet'
+        '404':
+          description: Signal not found
+
+
   /signals/v1/public/terms/categories:
     get:
       description: Categories known to SIA. **May be changed**
@@ -789,9 +830,7 @@ components:
         sub_category:
           type: string
           format: uri
-        category_url:
-          type: string
-          format: uri
+          example: https://api.data.amsterdam.nl/signals/v1/public/terms/categories/overig/sub_categories/overig
         text:
           type: string
           description: Message to log with category update, will show in logs.
@@ -945,6 +984,43 @@ components:
         extra_properties:
           type: object
           example: {}
+      required:
+        - text
+        - location
+        - incident_date_start
+
+    V1PublicSignalPost:
+      type: object
+      properties:
+        source:
+          type: string
+          example: "online"
+        text:
+          type: string
+          description: The complaint
+          example: Er ligt vuilnis op straat.
+        text_extra:
+          type: string
+          nullable: true
+        location:
+          $ref: '#/components/schemas/_NestedLocationRequestData'
+        category:
+          $ref: '#/components/schemas/_NestedCategoryRequestData'
+        reporter:
+          $ref: '#/components/schemas/_NestedReporterRequestData'
+        incident_date_start:
+          description: Start of nuisance or problem.
+          type: string
+          format: date-time
+          example: "2020-01-01T00:00:00+00:00"
+        incident_date_end:
+          type: string
+          format: date-time
+          example: "2020-01-01T00:00:00+00:00"
+          nullable: true
+        extra_properties:
+          type: array
+          example: []
       required:
         - text
         - location
@@ -1180,6 +1256,46 @@ components:
           format: date-time
           nullable: true
           example: null
+
+    V1PublicSignalDetailGet:
+      description: Detailed JSON serialization of a SIA Signal.
+      type: object
+      properties:
+        _display:
+          description: Textual representation of signal for display purposes.
+          type: string
+          example: SIA-123
+        signal_id:
+          description: Public identifier for SIA signal, use on public detail endpoint.
+          type: string
+          format: uuid
+        created_at:
+          type: string
+          format: date-time
+          example: "2020-01-01T00:00:00+00:00"
+        updated_at:
+          type: string
+          format: date-time
+          example: "2020-01-01T00:00:00+00:00"
+        incident_date_start:
+          type: string
+          format: date-time
+          example: "2020-01-01T00:00:00+00:00"
+        incident_date_end:
+          type: string
+          format: date-time
+          nullable: true
+          example: null
+        status:
+          description: Filtered status of Signal.
+          type: object
+          properties:
+            'state':
+              desciption: Public state code either "OPEN" or "CLOSED".
+              type: string
+            'state_display':
+              desciption: Public state display text.
+              type: string
 
     userCreate:
       type: object

--- a/api/app/signals/apps/api/v1/serializers/signal.py
+++ b/api/app/signals/apps/api/v1/serializers/signal.py
@@ -290,8 +290,8 @@ class PublicSignalSerializerDetail(HALSerializer):
     class Meta:
         model = Signal
         fields = (
-            '_links',
             '_display',
+            'id',
             'signal_id',
             'status',
             'created_at',
@@ -331,7 +331,6 @@ class PublicSignalCreateSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = Signal
         fields = (
-            'signal_id',
             'source',
             'text',
             'text_extra',
@@ -342,12 +341,7 @@ class PublicSignalCreateSerializer(serializers.ModelSerializer):
             'incident_date_end',
             'extra_properties',
         )
-        read_only_fields = (
-            'signal_id',
-        )
         extra_kwargs = {
-            'id': {'label': 'ID'},
-            'signal_id': {'label': 'SIGNAL_ID'},
             'source': {'validators': [SignalSourceValidator()]},
         }
 

--- a/api/app/signals/apps/api/v1/serializers/signal.py
+++ b/api/app/signals/apps/api/v1/serializers/signal.py
@@ -350,13 +350,14 @@ class PublicSignalCreateSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         """Make sure any extra data is rejected"""
-        present_keys = set(self.initial_data)
-        allowed_keys = set(self.fields)
+        if hasattr(self, 'initial_data'):
+            present_keys = set(self.initial_data)
+            allowed_keys = set(self.fields)
 
-        if present_keys - allowed_keys:
-            raise ValidationError('Extra properties present: {}'.format(
-                ', '.join(present_keys - allowed_keys)
-            ))
+            if present_keys - allowed_keys:
+                raise ValidationError('Extra properties present: {}'.format(
+                    ', '.join(present_keys - allowed_keys)
+                ))
         return data
 
     def create(self, validated_data):

--- a/api/app/signals/apps/api/v1/serializers/signal.py
+++ b/api/app/signals/apps/api/v1/serializers/signal.py
@@ -292,7 +292,6 @@ class PublicSignalSerializerDetail(HALSerializer):
         fields = (
             '_links',
             '_display',
-            'id',
             'signal_id',
             'status',
             'created_at',
@@ -332,6 +331,7 @@ class PublicSignalCreateSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = Signal
         fields = (
+            'signal_id',
             'source',
             'text',
             'text_extra',
@@ -341,6 +341,9 @@ class PublicSignalCreateSerializer(serializers.ModelSerializer):
             'incident_date_start',
             'incident_date_end',
             'extra_properties',
+        )
+        read_only_fields = (
+            'signal_id',
         )
         extra_kwargs = {
             'id': {'label': 'ID'},

--- a/api/app/signals/apps/api/v1/serializers/signal.py
+++ b/api/app/signals/apps/api/v1/serializers/signal.py
@@ -2,6 +2,7 @@ import os
 
 from datapunt_api.rest import DisplayField, HALSerializer
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from signals.apps.api.generics.permissions import SIAPermissions
 from signals.apps.api.generics.permissions.base import (
@@ -18,7 +19,6 @@ from signals.apps.api.v1.fields import (
 )
 from signals.apps.api.v1.fields.extra_properties import SignalExtraPropertiesField
 from signals.apps.api.v1.serializers.nested import (
-    _NestedAttachmentModelSerializer,
     _NestedCategoryModelSerializer,
     _NestedLocationModelSerializer,
     _NestedNoteModelSerializer,
@@ -308,14 +308,13 @@ class PublicSignalSerializerDetail(HALSerializer):
 class PublicSignalCreateSerializer(serializers.ModelSerializer):
     """
     This serializer allows anonymous users to report `signals.Signals`.
+
+    Note: this is only used in the creation of new Signal instances, not to
+    create the response body after a succesfull POST.
     """
     location = _NestedLocationModelSerializer()
     reporter = _NestedReporterModelSerializer()
-    status = _NestedStatusModelSerializer(required=False)
     category = _NestedCategoryModelSerializer(source='category_assignment')
-    priority = _NestedPriorityModelSerializer(required=False, read_only=True)
-    attachments = _NestedAttachmentModelSerializer(many=True, read_only=True)
-    type = _NestedTypeModelSerializer(source='type_assignment', read_only=True)
 
     extra_properties = SignalExtraPropertiesField(
         required=False,
@@ -333,33 +332,15 @@ class PublicSignalCreateSerializer(serializers.ModelSerializer):
     class Meta(object):
         model = Signal
         fields = (
-            'id',
-            'signal_id',
             'source',
             'text',
             'text_extra',
             'location',
             'category',
             'reporter',
-            'status',
-            'priority',
-            'type',
-            'created_at',
-            'updated_at',
             'incident_date_start',
             'incident_date_end',
-            'image',
-            'attachments',
             'extra_properties',
-        )
-        read_only_fields = (
-            'id',
-            'signal_id',
-            'created_at',
-            'updated_at',
-            'status',
-            'image',
-            'attachments',
         )
         extra_kwargs = {
             'id': {'label': 'ID'},
@@ -367,12 +348,18 @@ class PublicSignalCreateSerializer(serializers.ModelSerializer):
             'source': {'validators': [SignalSourceValidator()]},
         }
 
-    def create(self, validated_data):
-        if validated_data.get('status') is not None:
-            raise serializers.ValidationError("Status cannot be set on initial creation")
-        if validated_data.get('type') is not None:
-            raise serializers.ValidationError("Type cannot be set on initial creation")
+    def validate(self, data):
+        """Make sure any extra data is rejected"""
+        present_keys = set(self.initial_data)
+        allowed_keys = set(self.fields)
 
+        if present_keys - allowed_keys:
+            raise ValidationError('Extra properties present: {}'.format(
+                ', '.join(present_keys - allowed_keys)
+            ))
+        return data
+
+    def create(self, validated_data):
         location_data = validated_data.pop('location')
         reporter_data = validated_data.pop('reporter')
         category_assignment_data = validated_data.pop('category_assignment')

--- a/api/app/signals/apps/api/v1/serializers/signal.py
+++ b/api/app/signals/apps/api/v1/serializers/signal.py
@@ -292,6 +292,7 @@ class PublicSignalSerializerDetail(HALSerializer):
         fields = (
             '_links',
             '_display',
+            'id',
             'signal_id',
             'status',
             'created_at',

--- a/api/app/signals/apps/api/v1/views/signal.py
+++ b/api/app/signals/apps/api/v1/views/signal.py
@@ -23,17 +23,17 @@ from signals.auth.backend import JWTAuthBackend
 
 class PublicSignalViewSet(PublicSignalGenericViewSet):
     def create(self, request):
-        serializer = PublicSignalCreateSerializer(data=request.data, context={'request': request})
+        serializer = PublicSignalCreateSerializer(data=request.data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)
         signal = serializer.save()
 
-        data = PublicSignalSerializerDetail(signal, context={'request': request}).data
+        data = PublicSignalSerializerDetail(signal, context=self.get_serializer_context()).data
         return Response(data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, signal_id):
         signal = Signal.objects.get(signal_id=signal_id)
 
-        data = PublicSignalSerializerDetail(signal, context={'request': request}).data
+        data = PublicSignalSerializerDetail(signal, context=self.get_serializer_context()).data
         return Response(data)
 
 

--- a/api/app/signals/apps/api/v1/views/signal.py
+++ b/api/app/signals/apps/api/v1/views/signal.py
@@ -1,9 +1,8 @@
 from datapunt_api.rest import DatapuntViewSet, HALPagination
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin
 from rest_framework.response import Response
-from rest_framework_extensions.mixins import DetailSerializerMixin
 
 from signals.apps.api import mixins
 from signals.apps.api.generics.filters import FieldMappingOrderingFilter
@@ -22,10 +21,20 @@ from signals.apps.signals.models import History, Signal
 from signals.auth.backend import JWTAuthBackend
 
 
-class PublicSignalViewSet(CreateModelMixin, DetailSerializerMixin, RetrieveModelMixin,
-                          PublicSignalGenericViewSet):
-    serializer_class = PublicSignalCreateSerializer
-    serializer_detail_class = PublicSignalSerializerDetail
+class PublicSignalViewSet(PublicSignalGenericViewSet):
+    def create(self, request):
+        serializer = PublicSignalCreateSerializer(data=request.data, context={'request': request})
+        serializer.is_valid(raise_exception=True)
+        signal = serializer.save()
+
+        data = PublicSignalSerializerDetail(signal, context={'request': request}).data
+        return Response(data, status=status.HTTP_201_CREATED)
+
+    def retrieve(self, request, signal_id):
+        signal = Signal.objects.get(signal_id=signal_id)
+
+        data = PublicSignalSerializerDetail(signal, context={'request': request}).data
+        return Response(data)
 
 
 class PrivateSignalViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, DatapuntViewSet):

--- a/api/app/tests/apps/api/v1/json_schema/get_signals_v1_public_signals_{uuid}.json
+++ b/api/app/tests/apps/api/v1/json_schema/get_signals_v1_public_signals_{uuid}.json
@@ -1,24 +1,14 @@
 {
   "type": "object",
   "properties": {
-    "_links": {
-      "type": "object",
-      "properties": {
-        "self": {
-          "type": "object",
-          "properties": {
-            "href": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
     "_display": {
       "type": "string"
     },
     "signal_id": {
       "type": "string"
+    },
+    "id": {
+      "type": "integer"
     },
     "status": {
       "type": "object",
@@ -28,10 +18,7 @@
         },
         "state_display": {
           "type": "string"
-        },
-        "id": {
-          "type": "number"
-        }
+        }     
       }
     },
     "created_at": {
@@ -51,16 +38,6 @@
       ]
     },
     "incident_date_end": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "operational_date": {
       "anyOf": [
         {
           "type": "string"

--- a/api/app/tests/apps/api/v1/json_schema/post_signals_v1_public_signals.json
+++ b/api/app/tests/apps/api/v1/json_schema/post_signals_v1_public_signals.json
@@ -4,9 +4,6 @@
     "id": {
       "type": "integer"
     },
-    "signal_id": {
-      "type": "string"
-    },
     "source": {
       "type": "string"
     },
@@ -15,43 +12,6 @@
     },
     "text_extra": {
       "type": "string"
-    },
-    "status": {
-      "type": "object",
-      "properties": {
-        "text": {
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "user": {
-          "type": "null"
-        },
-        "state": {
-          "type": "string"
-        },
-        "state_display": {
-          "type": "string"
-        },
-        "extra_properties": {
-          "anyOf": [
-            {
-              "type": "null"
-            },
-            {
-              "type": "object"
-            }
-          ]
-        },
-        "created_at": {
-          "type": "string"
-        }
-      }
     },
     "location": {
       "type": "object",
@@ -157,12 +117,6 @@
     },
     "incident_date_end": {
       "type": "null"
-    },
-    "operational_date": {
-      "type": "null"
-    },
-    "has_attachments": {
-      "type": "boolean"
     },
     "extra_properties": {
       "type": "null"

--- a/api/app/tests/apps/api/v1/request_data/create_initial.json
+++ b/api/app/tests/apps/api/v1/request_data/create_initial.json
@@ -37,5 +37,6 @@
     "operational_date": null,
     "image": null,
     "upload": null,
-    "source": "online"
+    "source": "online",
+    "extra_properties": []
 }

--- a/api/app/tests/apps/api/v1/request_data/create_initial_public.json
+++ b/api/app/tests/apps/api/v1/request_data/create_initial_public.json
@@ -1,0 +1,37 @@
+{
+    "text": "Luidruchtige vergadering",
+    "text_extra": "extra: heel luidruchtig debat",
+    "location": {
+        "geometrie": {
+            "type": "Point",
+            "coordinates": [
+                4.90022563,
+                52.36768424
+            ]
+        },
+        "stadsdeel": "A",
+        "buurt_code": "A04i",
+        "address": {
+            "openbare_ruimte": "Amstel",
+            "huisnummer": 1,
+            "huisletter": "",
+            "huisnummer_toevoeging": "",
+            "postcode": "1011PN",
+            "woonplaats": "Amsterdam"
+        },
+        "extra_properties": {}
+    },
+    "category": {
+        "sub_category": "/signals/v1/public/terms/categories/overig/sub_categories/overig"
+    },
+    "reporter": {
+        "email": "melder@example.com",
+        "phone": "0123456789",
+        "created_at": "2018-06-18T13:30:47.766420Z",
+        "updated_at": "2018-06-18T13:30:47.795622Z"
+    },
+    "incident_date_start": "2018-06-18T13:30:47.604472Z",
+    "incident_date_end": null,
+    "source": "online",
+    "extra_properties": []
+}


### PR DESCRIPTION
Changes to have only one public serialization of a signal (before the HTTP 201 response body had a different serialization than the signal detail get, in the public API).

This may break assumptions the frontend and other API users make.