### PR TITLE
fix/SIG-2486

### DIFF
--- a/api/app/signals/apps/signals/models/signal.py
+++ b/api/app/signals/apps/signals/models/signal.py
@@ -111,7 +111,7 @@ class Signal(CreatedUpdatedModel):
         DO NOT expose sensitive stuff here.
         """
 
-        # Fix for bug SIG-2486 Timezones where not consistently showed
+        # Fix for bug SIG-2486 Timezones were not consistently shown
         created_at = self.created_at
         field_timezone = timezone.get_current_timezone() if settings.USE_TZ else None
         if timezone.is_aware(created_at) and field_timezone:

--- a/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
@@ -1549,6 +1549,22 @@ class TestPrivateSignalViewSet(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(new_signal.reporter.email, None)
         self.assertEqual(new_signal.reporter.phone, None)
 
+    def test_detail_endpoint_SIG_2486(self):
+        """
+        The date in the _display value did showed with the correct timestamp as all other dates
+        """
+        response = self.client.get(self.detail_endpoint.format(pk=self.signal_no_image.id))
+        self.assertEqual(response.status_code, 200)
+
+        # JSONSchema validation
+        data = response.json()
+        self.assertJsonSchema(self.retrieve_signal_schema, data)
+
+        created_at = self.signal_no_image.created_at.astimezone(timezone.get_current_timezone())
+        created_at_with_time_zone_str = created_at.isoformat()
+        self.assertIn(created_at_with_time_zone_str, data['_display'])
+        self.assertEqual(created_at_with_time_zone_str, data['created_at'])
+
 
 class TestPrivateSignalAttachments(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
     list_endpoint = '/signals/v1/private/signals/'

--- a/api/app/tests/apps/signals/test_models.py
+++ b/api/app/tests/apps/signals/test_models.py
@@ -454,12 +454,10 @@ class TestSignalModel(TestCase):
         state = status.state
         signal.refresh_from_db()
 
-        self.assertEqual('{} - {} - {} - {}'.format(
-            signal.id,
-            state,
-            "ABCD",
-            signal.created_at
-        ), signal.__str__())
+        # Fix for bug SIG-2486 Timezones where not consistently showed
+        created_at = signal.created_at.astimezone(timezone.get_current_timezone())
+
+        self.assertEqual(f'{signal.id} - {state} - ABCD - {created_at.isoformat()}', signal.__str__())
 
     @mock.patch("uuid.uuid4")
     def test_uuid_assignment(self, mocked_uuid4):

--- a/api/app/tests/apps/signals/test_models.py
+++ b/api/app/tests/apps/signals/test_models.py
@@ -454,7 +454,7 @@ class TestSignalModel(TestCase):
         state = status.state
         signal.refresh_from_db()
 
-        # Fix for bug SIG-2486 Timezones where not consistently showed
+        # Fix for bug SIG-2486 Timezones were not consistently shown
         created_at = signal.created_at.astimezone(timezone.get_current_timezone())
 
         self.assertEqual(f'{signal.id} - {state} - ABCD - {created_at.isoformat()}', signal.__str__())


### PR DESCRIPTION
Fix for SIG-2486 [BE] tijdzones in de API niet consistent