### PR TITLE
SIG-2533 move marker 20 pixels up so that the tip points to Signal/me…

### DIFF
--- a/api/app/signals/apps/api/templates/api/pdf/print_signal.html
+++ b/api/app/signals/apps/api/templates/api/pdf/print_signal.html
@@ -99,7 +99,7 @@
     <div class="divider">&nbsp;</div>
     <h1>{{ signal.sia_id }}</h1>
     <div style="width: 680px; height: 250px; background-color: lightgray; margin-bottom: 25px; ">
-        <img src="https://map.data.amsterdam.nl/dist/images/svg/marker.svg" alt="marker" tabindex="0" style="position: absolute; left: 320px; top: 220px; width: 40px; height: 40px;">
+        <img src="https://map.data.amsterdam.nl/dist/images/svg/marker.svg" alt="marker" tabindex="0" style="position: absolute; left: 320px; top: 200px; width: 40px; height: 40px;">
         <img src="https://map.data.amsterdam.nl/maps/topografie?request=GetMap&format=image%2Fpng&version=1.1.1&layers=basiskaart&srs=EPSG%3A28992&width=680&height=250&bbox={{ bbox }}" />
     </div>
 


### PR DESCRIPTION
Fix for SIG-2533

The map marker symbol was not centered correctly (the middle of the marker was located at the Signal/notification, not the tip). Moving it 20 px up (half the height of the marker) fixes this.
