### PR TITLE
Run tests using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: amsterdam/postgres11
+        env:
+          POSTGRES_USER: signals
+          POSTGRES_PASSWORD: insecure
+          POSTGRES_DB: signals
+        ports: ['5409:5432']
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache pip modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+
+      - name: Install geospatial libraries # https://docs.djangoproject.com/en/3.0/ref/contrib/gis/install/geolibs/
+        run: sudo apt install binutils libproj-dev gdal-bin
+
+      - name: Setup Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r api/requirements.txt
+
+      - name: Run tests
+        run: |
+          cd api/app
+          tox
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v1
+        with:
+          name: coverage-report
+          path: api/app/htmlcov/

--- a/api/app/tox.ini
+++ b/api/app/tox.ini
@@ -14,7 +14,7 @@ whitelist_externals =
     flake8
     isort
 commands =
-    pytest: pytest -n 4 --cov=signals --cov-report term --no-cov-on-fail {posargs:} --tb=short
+    pytest: pytest -n 4 --cov=signals --cov-report=term --cov-report=html --no-cov-on-fail {posargs:} --tb=short
     flake8: flake8 signals tests
     isort: isort --recursive --diff --check-only signals tests
 


### PR DESCRIPTION
This PR introduces continuous integration using GitHub Actions. This allows pull requests from external contributors to be tested securely.

- The [GitHub Actions](https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions) manual served as template of this setup.
- Pip modules are cached between builds.
- Code coverage report is generated in HTML and uploaded using [artifacts](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts).

This setup is easily extendible for testing against multiple Python versions with the [build matrix feature](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix).

We could optimize this setup further by caching the apt install step, but this could be premature optimization.

Closes Signalen/backend#18