### PR TITLE
V1 public signals list endpoint should return a 404 instead of a 500

### DIFF
--- a/api/app/signals/apps/api/v1/views/signal.py
+++ b/api/app/signals/apps/api/v1/views/signal.py
@@ -1,4 +1,5 @@
 from datapunt_api.rest import DatapuntViewSet, HALPagination
+from django.http import Http404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.decorators import action
@@ -24,6 +25,9 @@ from signals.auth.backend import JWTAuthBackend
 
 
 class PublicSignalViewSet(PublicSignalGenericViewSet):
+    def list(self, *args, **kwargs):
+        raise Http404
+
     def create(self, request):
         serializer = PublicSignalCreateSerializer(data=request.data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)

--- a/api/app/tests/apps/api/v1/test_public_signal_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_public_signal_endpoint.py
@@ -264,3 +264,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         self.assertIn('extra_properties', data)
         self.assertEqual(data['extra_properties'][0], 'Invalid input.')
         self.assertEqual(0, Signal.objects.count())
+
+    def test_get_list(self):
+        response = self.client.get(f'{self.list_endpoint}')
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
V1 public signals list endpoint should return a 404 instead of a 500