### PR TITLE
Removed geometry from areas endpoint response

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -2400,19 +2400,6 @@ components:
           items:
             type: integer
           example: [4.804035, 52.306854, 4.87683, 52.352063]
-        geometry:
-          type: object
-          properties:
-            'type':
-              type: string
-              example: "MultiPolygon"
-            coordinates:
-              type: array
-              items:
-                type: integer
-              minItems: 0
-              maxItems: 2
-              example: [[[[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [0.0, 0.0]]], [[[1.0, 1.0], [1.0, 2.0], [2.0, 2.0], [1.0, 1.0]]]]
 
   securitySchemes:
     OAuth2:

--- a/api/app/signals/apps/api/v1/serializers/area.py
+++ b/api/app/signals/apps/api/v1/serializers/area.py
@@ -30,7 +30,7 @@ class AreaSerializer(HALSerializer):
 
     class Meta:
         model = Area
-        fields = ('name', 'code', 'type', 'bbox', 'geometry', )
+        fields = ('name', 'code', 'type', 'bbox', )
 
     def get_bbox(self, obj):
         if obj.geometry:

--- a/api/app/tests/apps/api/v1/json_schema/get_signals_v1_private_areas.json
+++ b/api/app/tests/apps/api/v1/json_schema/get_signals_v1_private_areas.json
@@ -96,43 +96,13 @@
 							},
 							"minItems": 4,
 							"maxItems": 4
-						},
-						"geometry": {
-							"type": "object",
-							"properties" : {
-								"type": {
-									"type": "string"
-								},
-								"coordinates": {
-									"type": "array",
-									"items": {
-										"type": "array",
-										"items": {
-											"type": "array",
-											"items": {
-												"type": "array",
-												"items": {
-													"type": "number"
-												},
-												"minItems": 2,
-												"maxItems": 2
-											}
-										}
-									}
-								}
-							},
-							"required": [
-								"type",
-								"coordinates"
-							]
 						}
 					},
 					"required": [
 						"name",
 						"code",
 						"type",
-						"bbox",
-						"geometry"
+						"bbox"
 					]
 				}
 			]

--- a/api/app/tests/apps/api/v1/json_schema/get_signals_v1_public_areas.json
+++ b/api/app/tests/apps/api/v1/json_schema/get_signals_v1_public_areas.json
@@ -96,43 +96,13 @@
 							},
 							"minItems": 4,
 							"maxItems": 4
-						},
-						"geometry": {
-							"type": "object",
-							"properties" : {
-								"type": {
-									"type": "string"
-								},
-								"coordinates": {
-									"type": "array",
-									"items": {
-										"type": "array",
-										"items": {
-											"type": "array",
-											"items": {
-												"type": "array",
-												"items": {
-													"type": "number"
-												},
-												"minItems": 2,
-												"maxItems": 2
-											}
-										}
-									}
-								}
-							},
-							"required": [
-								"type",
-								"coordinates"
-							]
 						}
 					},
 					"required": [
 						"name",
 						"code",
 						"type",
-						"bbox",
-						"geometry"
+						"bbox"
 					]
 				}
 			]


### PR DESCRIPTION
The `geometry` field in the areas endpoint response results in a very large dataset. Therefore it is removed. If this data is needed to draw shapes the `/signals/v1/public/areas/geography` or /signals/v1/private/areas/geography` endpoints will provide the geosjon to do so.