### PR TITLE
Make Elasticsearch settings configurable

### DIFF
--- a/api/app/signals/apps/search/config.py
+++ b/api/app/signals/apps/search/config.py
@@ -11,5 +11,5 @@ class SearchConfig(AppConfig):
 
         from elasticsearch_dsl import connections
 
-        host = app_settings.CONNECTION['URL'] or 'localhost'
+        host = app_settings.CONNECTION['HOST'] or 'localhost'
         connections.create_connection(hosts=[host, ])

--- a/api/app/signals/apps/search/settings.py
+++ b/api/app/signals/apps/search/settings.py
@@ -4,7 +4,7 @@ from django.test.signals import setting_changed
 DEFAULTS = dict(
     PAGE_SIZE=100,
     CONNECTION=dict(
-        URL='http://127.0.0.1:9200',
+        HOST='http://127.0.0.1:9200',
         INDEX_NAME='sia_signals',
     ),
 )

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -495,8 +495,8 @@ ML_TOOL_ENDPOINT = os.getenv('SIGNALS_ML_TOOL_ENDPOINT', 'https://api.data.amste
 SEARCH = {
     'PAGE_SIZE': 500,
     'CONNECTION': {
-        'URL': 'elastic-index.service.consul:9200',
-        'INDEX': 'sia_signals',
+        'HOST': os.getenv('ELASTICSEARCH_HOST', 'elastic-index.service.consul:9200'),
+        'INDEX': os.getenv('ELASTICSEARCH_INDEX', 'sia_signals'),
     },
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,8 @@ services:
       - SIGMAX_AUTH_TOKEN
       - SIGMAX_SERVER
       - DWH_MEDIA_ROOT=/dwh_media
+      - ELASTICSEARCH_HOST=elasticsearch:9200
+      - ELASTICSEARCH_INDEX=signals
     volumes:
       - ./api/app:/app
       - ./api/deploy:/deploy


### PR DESCRIPTION
This MR makes the Elasticsearch settings configurable by environment variables.

Fixes https://github.com/Signalen/backend/issues/36.