### PR TITLE
make pdok municipalities configurable

### DIFF
--- a/api/app/signals/apps/api/v1/validation/address/pdok.py
+++ b/api/app/signals/apps/api/v1/validation/address/pdok.py
@@ -7,12 +7,7 @@ from signals.apps.api.v1.validation.address.base import (
     AddressValidationUnavailableException,
     BaseAddressValidation
 )
-
-MUNICIPALITIES = (
-    'Amsterdam',
-    'Amstelveen',
-    'Weesp',
-)
+from signals.settings import DEFAULT_PDOK_MUNICIPALITIES
 
 
 class PDOKAddressValidation(BaseAddressValidation):
@@ -45,7 +40,7 @@ class PDOKAddressValidation(BaseAddressValidation):
             query_dict.update({'fq': f'woonplaatsnaam:{address["woonplaats"]}'})
         if 'postcode' in address and address["postcode"]:
             query_dict.update({'fq': f'postcode:{address["postcode"]}'})
-        query_dict.update({'fq': f'gemeentenaam:{",".join(MUNICIPALITIES)}'})
+        query_dict.update({'fq': f'gemeentenaam:{",".join(DEFAULT_PDOK_MUNICIPALITIES)}'})
 
         straatnaam = address["openbare_ruimte"]
         huisnummer = address["huisnummer"]

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -520,3 +520,8 @@ GRAPHENE = {
     'RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST': True,
     'RELAY_CONNECTION_MAX_LIMIT': 50,
 }
+
+DEFAULT_PDOK_MUNICIPALITIES = os.getenv(
+    'DEFAULT_PDOK_MUNICIPALITIES',
+    'Amsterdam,Amstelveen,Weesp',
+).split(',')


### PR DESCRIPTION
Currently the PDOKAddressValidation.py has hardcoded municipalities values:
```
MUNICIPALITIES = (
    'Amsterdam',
    'Amstelveen',
    'Weesp',
)
```

We need make this configurable for other municipalities