### PR TITLE
Allow configuration of SIGNALS_AUTHZ in development using environment variables

### DIFF
--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -156,7 +156,7 @@ MEDIA_URL = '/signals/media/'
 MEDIA_ROOT = os.path.join(os.path.dirname(os.path.dirname(BASE_DIR)), 'media')
 
 # Object store / Swift
-if os.getenv('SWIFT_ENABLED', False) in [True, 1, '1', 'True', 'true']:
+if os.getenv('SWIFT_ENABLED', 'False') in ['True', 'true', '1']:
     DEFAULT_FILE_STORAGE = 'swift.storage.SwiftStorage'
     SWIFT_USERNAME = os.getenv('SWIFT_USERNAME')
     SWIFT_PASSWORD = os.getenv('SWIFT_PASSWORD')

--- a/api/app/signals/settings/development.py
+++ b/api/app/signals/settings/development.py
@@ -9,7 +9,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 SIGNALS_AUTHZ = {
     'JWKS_URL': os.getenv('JWKS_URL', 'http://dex:5556/keys'),
-    'ALWAYS_OK': os.getenv('ALWAYS_OK', 'false') == 'true',
+    'ALWAYS_OK': os.getenv('ALWAYS_OK', 'False') in ['True', 'true', '1'],
     'USER_ID_FIELD': os.getenv('USER_ID_FIELD', 'email')
 }
 

--- a/api/app/signals/settings/development.py
+++ b/api/app/signals/settings/development.py
@@ -8,9 +8,9 @@ ALLOWED_HOSTS = ['*']
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 SIGNALS_AUTHZ = {
-    'JWKS_URL': "http://dex:5556/keys",
-    'ALWAYS_OK': False,
-    'USER_ID_FIELD': 'email'
+    'JWKS_URL': os.getenv('JWKS_URL', 'http://dex:5556/keys'),
+    'ALWAYS_OK': os.getenv('ALWAYS_OK', 'false') == 'true',
+    'USER_ID_FIELD': os.getenv('USER_ID_FIELD', 'email')
 }
 
 SITE_DOMAIN = 'localhost:8000'


### PR DESCRIPTION
This allows developers to configure their own setup and support for example running Dex locally.