### PR TITLE
Allow user datapunt to create files in /app

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -28,4 +28,4 @@ USER datapunt
 
 RUN SECRET_KEY=$DJANGO_SECRET_KEY python manage.py collectstatic --no-input
 
-CMD uwsgi=
+CMD uwsgi

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,8 +21,11 @@ ARG DJANGO_SECRET_KEY=insecure_docker_build_key
 COPY app /app/
 COPY deploy /deploy/
 
+RUN chgrp datapunt /app
+RUN chmod g+w /app
+
 USER datapunt
 
 RUN SECRET_KEY=$DJANGO_SECRET_KEY python manage.py collectstatic --no-input
 
-CMD uwsgi
+CMD uwsgi=


### PR DESCRIPTION
Celery beat writes `/app/celerybeat.pid` file. Allow this file to be written from user 'datapunt', so that we don't need to start the container as user 'root' for celery beat to work.