### PR TITLE
Fixed handling of 'duplicate' slug names

### DIFF
--- a/api/app/signals/apps/dataset/management/commands/load_categories.py
+++ b/api/app/signals/apps/dataset/management/commands/load_categories.py
@@ -16,14 +16,15 @@ class Command(BaseCommand):
 
     def _get_parent(self, id) -> Category:
         if id in self.slugsdict:
-            return self._get_cat(slug=self.slugsdict[id])
+            return self._get_cat(slug=self.slugsdict[id], parent=None)
         else:
             return None
 
-    def _get_cat(self, slug) -> Category:
+    def _get_cat(self, slug, parent) -> Category:
         try:
-            return Category.objects.get(slug=slug)
-        except Exception:
+            return Category.objects.get(slug=slug, parent=parent)
+        except Exception as e:
+            print("Failed get cat {cat} - {parent}: {err}".format(cat=slug, parent=parent, err=str(e)))
             return None
 
     def add_arguments(self, parser) -> None:
@@ -41,7 +42,7 @@ class Command(BaseCommand):
                 parent_id = fields.pop('parent')
                 if parent_id:
                     fields['parent'] = self._get_parent(parent_id)
-                cat = self._get_cat(fields['slug'])
+                cat = self._get_cat(fields['slug'], fields.get('parent', None))
                 if cat is not None:
                     self.stdout.write(f'Updating: {fields["slug"]}')
                     for attr, value in fields.items():

--- a/api/app/tests/apps/dataset/management/commands/test_load_categories.py
+++ b/api/app/tests/apps/dataset/management/commands/test_load_categories.py
@@ -24,3 +24,51 @@ class TestLoadCategories(TestCase):
 
         renamed = categories.get(slug='test-parent-cat1')
         self.assertEqual(renamed.name, 'test parent cat1 (renamed)')
+
+    def test_load_categories_with_existing_entries(self):
+        main = Category.objects.create(**{
+            "slug": "test-parent-cat1",
+            "name": "test parent cat1",
+            "handling": "REST",
+            "is_active": True
+        })
+
+        # sub cat with same name as parent
+        Category.objects.create(**{
+            "slug": "test-parent-cat1",
+            "name": "test parent cat1",
+            "handling": "REST",
+            "is_active": True,
+            "parent": main
+        })
+
+        main2 = Category.objects.create(**{
+            "slug": "test-parent-cat2",
+            "name": "test parent cat2",
+            "handling": "REST",
+            "is_active": True
+        })
+
+        # sub cat with same name as parent, but different parent
+        Category.objects.create(**{
+            "slug": "test-parent-cat1",
+            "name": "test parent cat1",
+            "handling": "REST",
+            "is_active": True,
+            "parent": main2
+        })
+
+        datafile = os.path.join(THIS_DIR, 'json_data', 'categories.json')
+        datafile_update = os.path.join(THIS_DIR, 'json_data', 'categories-update.json')
+
+        # load 'initial' categories
+        call_command('load_categories', datafile)
+        categories = Category.objects.filter(is_active=True)
+        self.assertEqual(4, len(categories))
+        # update categories, and make one inactive
+        call_command('load_categories', datafile_update)
+        categories = Category.objects.filter(is_active=True)
+        self.assertEqual(3, len(categories))
+
+        renamed = categories.get(slug='test-parent-cat1')
+        self.assertEqual(renamed.name, 'test parent cat1 (renamed)')


### PR DESCRIPTION
When loading categories, we cannot assume that a slug name is unique. It's only unique in combination with its parent. The importer did not take existing 'duplicates' into account when importing.

This PR fixes handling of the slug name. A unit test is added to illustrate the issue.