### PR TITLE
feature/temporary-datadump-sia-ontsluiting

### DIFF
--- a/api/app/signals/apps/reporting/csv/datawarehouse/__init__.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/__init__.py
@@ -11,11 +11,6 @@ from signals.apps.reporting.csv.datawarehouse.tasks import (
     save_csv_file_datawarehouse,
     save_csv_files_datawarehouse
 )
-from signals.apps.reporting.csv.datawarehouse.utils import (
-    map_choices,
-    queryset_to_csv_file,
-    save_csv_files
-)
 
 __all__ = [
     'create_category_assignments_csv',
@@ -27,7 +22,4 @@ __all__ = [
     'create_signals_csv',
     'save_csv_file_datawarehouse',
     'save_csv_files_datawarehouse',
-    'save_csv_files',
-    'queryset_to_csv_file',
-    'map_choices',
 ]

--- a/api/app/signals/apps/reporting/csv/datawarehouse/categories.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/categories.py
@@ -4,7 +4,7 @@ from django.contrib.postgres.aggregates import StringAgg
 from django.db.models import CharField, F, Q, Value
 from django.db.models.functions import Cast, Coalesce
 
-from signals.apps.reporting.csv.datawarehouse.utils import queryset_to_csv_file, reorder_csv
+from signals.apps.reporting.csv.utils import queryset_to_csv_file, reorder_csv
 from signals.apps.signals.models import CategoryAssignment, ServiceLevelObjective
 
 

--- a/api/app/signals/apps/reporting/csv/datawarehouse/kto_feedback.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/kto_feedback.py
@@ -1,11 +1,7 @@
 import os
 
 from signals.apps.feedback.models import Feedback
-from signals.apps.reporting.csv.datawarehouse.utils import (
-    map_choices,
-    queryset_to_csv_file,
-    reorder_csv
-)
+from signals.apps.reporting.csv.utils import map_choices, queryset_to_csv_file, reorder_csv
 
 
 def create_kto_feedback_csv(location: str) -> str:

--- a/api/app/signals/apps/reporting/csv/datawarehouse/locations.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/locations.py
@@ -3,11 +3,7 @@ import os
 from django.db.models import CharField, ExpressionWrapper, FloatField, Func, Value
 from django.db.models.functions import Cast, Coalesce
 
-from signals.apps.reporting.csv.datawarehouse.utils import (
-    map_choices,
-    queryset_to_csv_file,
-    reorder_csv
-)
+from signals.apps.reporting.csv.utils import map_choices, queryset_to_csv_file, reorder_csv
 from signals.apps.signals.models import STADSDELEN, Location
 
 

--- a/api/app/signals/apps/reporting/csv/datawarehouse/reporters.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/reporters.py
@@ -2,11 +2,7 @@ import os
 
 from django.db.models import BooleanField, Case, CharField, Q, Value, When
 
-from signals.apps.reporting.csv.datawarehouse.utils import (
-    map_choices,
-    queryset_to_csv_file,
-    reorder_csv
-)
+from signals.apps.reporting.csv.utils import map_choices, queryset_to_csv_file, reorder_csv
 from signals.apps.signals.models import Reporter
 
 

--- a/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
@@ -7,7 +7,7 @@ import os
 from django.db.models import CharField, F, Max, Value
 from django.db.models.functions import Cast, Coalesce
 
-from signals.apps.reporting.csv.datawarehouse.utils import queryset_to_csv_file, reorder_csv
+from signals.apps.reporting.csv.utils import queryset_to_csv_file, reorder_csv
 from signals.apps.signals.models import Signal
 
 logger = logging.getLogger(__name__)

--- a/api/app/signals/apps/reporting/csv/datawarehouse/statusses.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/statusses.py
@@ -3,11 +3,7 @@ import os
 from django.db.models import CharField, Value
 from django.db.models.functions import Cast, Coalesce
 
-from signals.apps.reporting.csv.datawarehouse.utils import (
-    map_choices,
-    queryset_to_csv_file,
-    reorder_csv
-)
+from signals.apps.reporting.csv.utils import map_choices, queryset_to_csv_file, reorder_csv
 from signals.apps.signals.models import Status
 from signals.apps.signals.workflow import STATUS_CHOICES
 

--- a/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
@@ -10,7 +10,7 @@ from signals.apps.reporting.csv.datawarehouse.locations import create_locations_
 from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_csv
 from signals.apps.reporting.csv.datawarehouse.signals import create_signals_csv
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
-from signals.apps.reporting.csv.datawarehouse.utils import save_csv_files
+from signals.apps.reporting.csv.utils import save_csv_files
 from signals.celery import app
 
 
@@ -29,7 +29,7 @@ def save_csv_file_datawarehouse(func: Callable[[str], str]) -> None:
             pass
 
         # Store the CSV files to the correct location
-        save_csv_files(csv_files)
+        save_csv_files(csv_files=csv_files, using='datawarehouse')
 
 
 @app.task

--- a/api/app/signals/apps/reporting/csv/tdo.py
+++ b/api/app/signals/apps/reporting/csv/tdo.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 from signals.apps.reporting.csv.utils import queryset_to_csv_file, save_csv_files
 from signals.apps.reporting.models import TDOSignal
-from signals.apps.signals.workflow import STATUS_CHOICES
+from signals.apps.signals.workflow import LEEG, STATUS_CHOICES
 from signals.celery import app
 
 
@@ -31,6 +31,7 @@ def create_statuses_csv(location: str) -> str:
     with open(os.path.join(location, 'statuses.csv'), 'w') as csv_file:
         writer = csv.writer(csv_file)
         writer.writerow(['code', 'name'])
+        writer.writerow([LEEG, 'Leeg'])  # Special case, not present in STATUS_CHOICES
         for row in STATUS_CHOICES:
             writer.writerow(row)
     return csv_file.name

--- a/api/app/signals/apps/reporting/csv/tdo.py
+++ b/api/app/signals/apps/reporting/csv/tdo.py
@@ -16,7 +16,8 @@ def create_signals_csv(location: str) -> str:
     :param location: Directory for saving the CSV file
     :returns: Path to CSV file
     """
-    csv_file = queryset_to_csv_file(TDOSignal.objects.all(), os.path.join(location, 'signals.csv'))
+    queryset = TDOSignal.objects.all().order_by('id')
+    csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'signals.csv'))
     return csv_file.name
 
 

--- a/api/app/signals/apps/reporting/csv/tdo.py
+++ b/api/app/signals/apps/reporting/csv/tdo.py
@@ -1,0 +1,35 @@
+import tempfile
+from typing import Callable
+
+from signals.apps.reporting.csv.utils import save_csv_files
+from signals.celery import app
+
+
+def create_signals_csv(location: str) -> str:
+    """
+    Create the CSV file based on the Signals view
+
+    TODO: Add functionality to export the "view" to CSV, for an example look at the datawarehouse/signals.py file
+
+    :param location: Directory for saving the CSV file
+    :returns: Path to CSV file
+    """
+    pass
+
+
+@app.task
+def save_csv_file_tdo(func: Callable[[str], str]) -> None:
+    """
+    Create CSV files for teamdata openbare ruimte and save them on the storage backend.
+
+    :returns:
+    """
+    csv_files = list()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        try:
+            csv_files.append(func(tmp_dir))
+        except EnvironmentError:
+            pass
+
+        # Store the CSV files to the correct location
+        save_csv_files(csv_files=csv_files, using='tdo')

--- a/api/app/signals/apps/reporting/csv/tdo.py
+++ b/api/app/signals/apps/reporting/csv/tdo.py
@@ -1,7 +1,11 @@
+import csv
+import os
 import tempfile
 from typing import Callable
 
-from signals.apps.reporting.csv.utils import save_csv_files
+from signals.apps.reporting.csv.utils import queryset_to_csv_file, save_csv_files
+from signals.apps.reporting.models import TDOSignal
+from signals.apps.signals.workflow import STATUS_CHOICES
 from signals.celery import app
 
 
@@ -9,12 +13,26 @@ def create_signals_csv(location: str) -> str:
     """
     Create the CSV file based on the Signals view
 
-    TODO: Add functionality to export the "view" to CSV, for an example look at the datawarehouse/signals.py file
+    :param location: Directory for saving the CSV file
+    :returns: Path to CSV file
+    """
+    csv_file = queryset_to_csv_file(TDOSignal.objects.all(), os.path.join(location, 'signals.csv'))
+    return csv_file.name
+
+
+def create_statuses_csv(location: str) -> str:
+    """
+    Create the CSV file based on the STATUS_CHOICES from the workflow.py
 
     :param location: Directory for saving the CSV file
     :returns: Path to CSV file
     """
-    pass
+    with open(os.path.join(location, 'statuses.csv'), 'w') as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(['code', 'name'])
+        for row in STATUS_CHOICES:
+            writer.writerow(row)
+    return csv_file.name
 
 
 @app.task

--- a/api/app/signals/apps/reporting/csv/utils.py
+++ b/api/app/signals/apps/reporting/csv/utils.py
@@ -1,6 +1,3 @@
-"""
-Dump CSV of SIA tables matching the old, agreed-upon, format.
-"""
 import csv
 import logging
 import os
@@ -17,15 +14,16 @@ from signals.apps.reporting.utils import _get_storage_backend
 logger = logging.getLogger(__name__)
 
 
-def save_csv_files(csv_files: list) -> None:
+def save_csv_files(csv_files: list, using: str) -> None:
     """
     Writes the CSV files to the configured storage backend
-    This could either be the SwiftStorage (used to store files for the Datawarehouse) or a local FileSystemStorage
+    This could either be the SwiftStorage or a local FileSystemStorage
 
     :param csv_files:
+    :param using:
     :returns None:
     """
-    storage = _get_storage_backend(using='datawarehouse')
+    storage = _get_storage_backend(using=using)
 
     for csv_file_path in csv_files:
         with open(csv_file_path, 'rb') as opened_csv_file:

--- a/api/app/signals/apps/reporting/management/commands/dump_tdo_csv_files.py
+++ b/api/app/signals/apps/reporting/management/commands/dump_tdo_csv_files.py
@@ -5,10 +5,15 @@ from django.conf import settings
 from django.core.management import BaseCommand
 from django.utils import timezone
 
-from signals.apps.reporting.csv.tdo import create_signals_csv, save_csv_file_tdo
+from signals.apps.reporting.csv.tdo import (
+    create_signals_csv,
+    create_statuses_csv,
+    save_csv_file_tdo
+)
 
 REPORT_OPTIONS = {
     'signals': create_signals_csv,
+    'statuses': create_statuses_csv,
 }
 
 

--- a/api/app/signals/apps/reporting/management/commands/dump_tdo_csv_files.py
+++ b/api/app/signals/apps/reporting/management/commands/dump_tdo_csv_files.py
@@ -1,0 +1,48 @@
+import os
+from timeit import default_timer as timer
+
+from django.conf import settings
+from django.core.management import BaseCommand
+from django.utils import timezone
+
+from signals.apps.reporting.csv.tdo import create_signals_csv, save_csv_file_tdo
+
+REPORT_OPTIONS = {
+    'signals': create_signals_csv,
+}
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('--report', type=str,
+                            help=f'Report type to export (if none given all reports will be exported), '
+                                 f'choices are: {", ".join(REPORT_OPTIONS.keys())}')
+
+    def handle(self, *args, **kwargs):
+        start = timer()
+
+        swift_enabled = os.getenv('SWIFT_ENABLED', False) in [True, 1, '1', 'True', 'true']
+        self.stdout.write('Swift storage: '
+                          f'{"Enabled" if swift_enabled else "Disabled (Files will be stored in local file storage"}')
+        if swift_enabled:
+            swift_parameters = settings.SWIFT.get('tdo')
+            self.stdout.write(f'* Swift storage container name: {swift_parameters["container_name"]}')
+        else:
+            now = timezone.now()
+            self.stdout.write(f'* Local File storage directory: {now:%Y}/{now:%m}/{now:%d}/')
+
+        reports = kwargs['report'].split(',') if kwargs['report'] else None
+        if reports is None or set(reports) == set(REPORT_OPTIONS.keys()):
+            reports = REPORT_OPTIONS.keys()
+
+        reports = set(reports)
+        self.stdout.write(f'Export: {", ".join(reports)}')
+        for report in reports:
+            self.stdout.write(f'* Exporting: {report}')
+            func = REPORT_OPTIONS[report]
+            save_csv_file_tdo(func)
+            self.stdout.write('* ---------------------------------')
+
+        stop = timer()
+        self.stdout.write(f'Time: {stop - start:.2f} second(s)')
+        self.stdout.write('Done!')

--- a/api/app/signals/apps/reporting/models/tdo.py
+++ b/api/app/signals/apps/reporting/models/tdo.py
@@ -2,6 +2,12 @@ from django.contrib.gis.db import models
 
 
 class TDOSignal(models.Model):
+    """
+    This model exposes a database view and therefore has the "managed = False" property.
+
+    The view exposes SIA data for teamdata openbare ruimte, as a temporary solution it is also possible to export this
+    data via a management command by CSV to the teamdata openbare ruimte ObjectStore.
+    """
     class Meta:
         managed = False
         db_table = 'signals_ext_tdo'

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -185,6 +185,14 @@ SWIFT = {
         'tenant_id': os.getenv('HORECA_SWIFT_TENANT_ID'),
         'container_name': os.getenv('HORECA_SWIFT_CONTAINER_NAME'),
         'auto_overwrite': os.getenv('HORECA_SWIFT_AUTO_OVERWRITE', True)
+    },
+    'tdo': {
+        'api_username': os.getenv('TDO_SWIFT_USERNAME'),
+        'api_key': os.getenv('TDO_SWIFT_PASSWORD'),
+        'tenant_name': os.getenv('TDO_SWIFT_TENANT_NAME'),
+        'tenant_id': os.getenv('TDO_SWIFT_TENANT_ID'),
+        'container_name': os.getenv('TDO_SWIFT_CONTAINER_NAME'),
+        'auto_overwrite': os.getenv('TDO_SWIFT_AUTO_OVERWRITE', True)
     }
 }
 

--- a/api/app/tests/apps/reporting/test_datawarehouse.py
+++ b/api/app/tests/apps/reporting/test_datawarehouse.py
@@ -13,6 +13,7 @@ from django.test import override_settings, testcases
 from freezegun import freeze_time
 
 from signals.apps.reporting.csv import datawarehouse
+from signals.apps.reporting.utils import _get_storage_backend
 from tests.apps.feedback.factories import FeedbackFactory
 from tests.apps.signals.factories import SignalFactory
 
@@ -28,7 +29,7 @@ class TestDatawarehouse(testcases.TestCase):
         shutil.rmtree(self.file_backend_tmp_dir)
 
     @mock.patch.dict('os.environ', {}, clear=True)
-    @mock.patch('signals.apps.reporting.csv.datawarehouse.utils._get_storage_backend')
+    @mock.patch('signals.apps.reporting.csv.utils._get_storage_backend')
     @freeze_time('2020-09-10T12:00:00+00:00')
     def test_save_csv_files_datawarehouse(self, mocked_get_storage_backend):
         # Mocking the storage backend to local file system with tmp directory.
@@ -83,7 +84,7 @@ class TestDatawarehouse(testcases.TestCase):
         mocked_swift_storage_instance = mock.Mock()
         mocked_swift_storage.return_value = mocked_swift_storage_instance
 
-        result = datawarehouse.utils._get_storage_backend(using='datawarehouse')
+        result = _get_storage_backend(using='datawarehouse')
 
         self.assertEqual(result, mocked_swift_storage_instance)
         mocked_swift_storage.assert_called_once_with(


### PR DESCRIPTION
Added SWIFT settings for the teamdata openbare ruimte objectstore + refactored utils so that they can be used in a more general way in the reporting CSV app + added management command to dump the data + added placeholder function to export the view to CSV