### PR TITLE
feature/SIG-2879

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -217,18 +217,17 @@ paths:
                 value: 'child_signal'
               combination:
                 value: ['parent_signal', 'signal']
-        - name: changes_in_children
+        - name: has_changed_children
           in: query
           description: >-
-            Filters all parent signals...
+            Filters all parent signals that have changes or no changes in children. Accepts true,
+            false or both. When both true and false are given only parent Signals are returned.
           required: false
           schema:
             type: boolean
             example:
               true: true
-              1: 1
               false: false
-              0: 0
 
       responses:
         '200':
@@ -1909,7 +1908,7 @@ components:
           format: date-time
           nullable: true
           example: null
-        has_chidlren:
+        has_children:
           type: boolean
           example: false
 

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -217,6 +217,18 @@ paths:
                 value: 'child_signal'
               combination:
                 value: ['parent_signal', 'signal']
+        - name: changes_in_children
+          in: query
+          description: >-
+            Filters all parent signals...
+          required: false
+          schema:
+            type: boolean
+            example:
+              true: true
+              1: 1
+              false: false
+              0: 0
 
       responses:
         '200':
@@ -1897,6 +1909,9 @@ components:
           format: date-time
           nullable: true
           example: null
+        has_chidlren:
+          type: boolean
+          example: false
 
     V1PrivateSignalListGetGeography:
       description: Geography

--- a/api/app/signals/apps/api/v1/filters/signal.py
+++ b/api/app/signals/apps/api/v1/filters/signal.py
@@ -30,7 +30,6 @@ class SignalFilterSet(FilterSet):
         to_field_name='slug',
         field_name='category_assignment__category__slug',
     )
-    changes_in_children = filters.MultipleChoiceFilter(method='changes_in_children_filter', choices=boolean_choices)
     contact_details = filters.MultipleChoiceFilter(method='contact_details_filter', choices=contact_details_choices)
     created_before = filters.IsoDateTimeFilter(field_name='created_at', lookup_expr='lte')
     directing_department = filters.MultipleChoiceFilter(
@@ -39,6 +38,7 @@ class SignalFilterSet(FilterSet):
     )
     created_after = filters.IsoDateTimeFilter(field_name='created_at', lookup_expr='gte')
     feedback = filters.ChoiceFilter(method='feedback_filter', choices=feedback_choices)
+    has_changed_children = filters.MultipleChoiceFilter(method='has_changed_children_filter', choices=boolean_choices)
     kind = filters.MultipleChoiceFilter(method='kind_filter', choices=kind_choices)  # SIG-2636
     incident_date = filters.DateFilter(field_name='incident_date_start', lookup_expr='date')
     incident_date_before = filters.DateFilter(field_name='incident_date_start', lookup_expr='date__gte')
@@ -218,7 +218,7 @@ class SignalFilterSet(FilterSet):
         return queryset.annotate(type_assignment_id=Max('types__id')).filter(types__id=F('type_assignment_id'),
                                                                              types__name__in=value)
 
-    def changes_in_children_filter(self, queryset, name, value):
+    def has_changed_children_filter(self, queryset, name, value):
         # we have a MultipleChoiceFilter ...
         choices = list(set(map(lambda x: True if x in [True, 'True', 'true', 1] else False, value)))
         q_filter = Q(children__isnull=False)

--- a/api/app/signals/apps/api/v1/filters/utils.py
+++ b/api/app/signals/apps/api/v1/filters/utils.py
@@ -28,6 +28,11 @@ def area_choices():
     return [(c, f'{n} ({t})') for c, t, n in Area.objects.values_list('code', '_type__name', 'name')]
 
 
+boolean_true_choices = [(True, 'True'), ('true', 'true'), ('True', 'True'), (1, '1')]
+boolean_false_choices = [(False, 'False'), ('false', 'false'), ('False', 'False'), (0, '0')]
+boolean_choices = boolean_true_choices + boolean_false_choices
+
+
 def buurt_choices():
     return [(c, f'{n} ({c})') for c, n in Buurt.objects.values_list('vollcode', 'naam')]
 

--- a/api/app/signals/apps/api/v1/serializers/signal.py
+++ b/api/app/signals/apps/api/v1/serializers/signal.py
@@ -304,6 +304,7 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
         write_only=True,
         queryset=Signal.objects.all()
     )
+    has_children = serializers.SerializerMethodField()
 
     attachments = PrivateSignalAttachmentRelatedField(view_name='private-signals-attachments-detail', many=True,
                                                       required=False, read_only=False, write_only=True,
@@ -337,12 +338,14 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
             'directing_departments',
             'attachments',
 
-            'parent'
+            'parent',
+            'has_children',
         )
         read_only_fields = (
             'created_at',
             'updated_at',
             'has_attachments',
+            'has_children',
         )
         extra_kwargs = {
             'source': {'validators': [SignalSourceValidator()]},
@@ -350,6 +353,9 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
 
     def get_has_attachments(self, obj):
         return obj.attachments.exists()
+
+    def get_has_children(self, obj):
+        return obj.children.exists()
 
     def validate(self, attrs):
         errors = {}

--- a/api/app/tests/apps/api/v1/test_filters.py
+++ b/api/app/tests/apps/api/v1/test_filters.py
@@ -905,7 +905,7 @@ class TestParentSignalFilter(SignalsBaseApiTestCase):
         with freeze_time(now):
             SignalFactory(parent=parent_signal)
 
-        filter_params = {'changes_in_children': True}
+        filter_params = {'has_changed_children': True}
         ids = self._request_filter_signals(filter_params)
         self.assertEqual(len(ids), 1)
         self.assertEqual(ids, [parent_signal.id])
@@ -921,7 +921,7 @@ class TestParentSignalFilter(SignalsBaseApiTestCase):
         with freeze_time(now + timedelta(hours=1)):
             parent_signal.save()
 
-        filter_params = {'changes_in_children': 'False'}
+        filter_params = {'has_changed_children': 'False'}
         ids = self._request_filter_signals(filter_params)
         self.assertEqual(len(ids), 1)
         self.assertEqual(ids, [parent_signal.id])
@@ -946,12 +946,12 @@ class TestParentSignalFilter(SignalsBaseApiTestCase):
             for parent_signal in parents_without_changes:
                 parent_signal.save()
 
-        filter_params = {'changes_in_children': True}
+        filter_params = {'has_changed_children': True}
         ids = self._request_filter_signals(filter_params)
         self.assertEqual(len(ids), len(parents_with_changes))
         self.assertEqual(set(ids), set([parent_signal.id for parent_signal in parents_with_changes]))
 
-        filter_params = {'changes_in_children': False}
+        filter_params = {'has_changed_children': False}
         ids = self._request_filter_signals(filter_params)
         self.assertEqual(len(ids), len(parents_without_changes))
         self.assertEqual(set(ids), set([parent_signal.id for parent_signal in parents_without_changes]))
@@ -973,6 +973,6 @@ class TestParentSignalFilter(SignalsBaseApiTestCase):
             for parent_signal in parents_without_changes:
                 parent_signal.save()
 
-        filter_params = {'changes_in_children': ['true', 0]}
+        filter_params = {'has_changed_children': ['true', 0]}
         ids = self._request_filter_signals(filter_params)
         self.assertEqual(len(ids), len(parents_with_changes) + len(parents_without_changes))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   database:
     image: amsterdam/postgres11
-    shm_size: '512m'
+    shm_size: '1024m'
     ports:
       - "5409:5432"
     environment:


### PR DESCRIPTION
- Added filter for SIG-2879 filter parent signals with changes or no changes in children
- Added "has_children" as described in SIG-2945 to the private signals list endpoint 
- Added more memory to the database docker container to facilitate the production database dump