### PR TITLE
Make geographic bounding box configurable, improve error message for …

### DIFF
--- a/api/app/signals/apps/api/generics/mixins.py
+++ b/api/app/signals/apps/api/generics/mixins.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import mixins
 from rest_framework.exceptions import ValidationError as DRFValidationError
@@ -97,14 +98,15 @@ class WriteOnceMixin:
         return extra_kwargs
 
 
-class NearAmsterdamValidatorMixin:
+class WithinBoundingBoxValidatorMixin:
 
     def validate_geometrie(self, value):
-        fail_msg = 'Location coordinates not anywhere near Amsterdam. (in WGS84)'
+        fail_msg = 'The location coordinates (WS84) are not inside the bounding box we are accepting signals for.'
 
-        lat_not_in_adam_area = not 50 < value.coords[1] < 55
-        lon_not_in_adam_area = not 1 < value.coords[0] < 7
+        lat_not_in_bounding_box = not settings.BOUNDING_BOX[1] <= value.coords[1] <= settings.BOUNDING_BOX[3]
+        lon_not_in_bounding_box = not settings.BOUNDING_BOX[0] <= value.coords[0] <= settings.BOUNDING_BOX[2]
 
-        if lon_not_in_adam_area or lat_not_in_adam_area:
+        if lat_not_in_bounding_box or lon_not_in_bounding_box:
             raise DRFValidationError(fail_msg)
+
         return value

--- a/api/app/signals/apps/api/v0/serializers.py
+++ b/api/app/signals/apps/api/v0/serializers.py
@@ -10,7 +10,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 
 from signals.apps.api.app_settings import SIGNALS_API_MAX_UPLOAD_SIZE
-from signals.apps.api.generics.mixins import AddExtrasMixin, NearAmsterdamValidatorMixin
+from signals.apps.api.generics.mixins import AddExtrasMixin, WithinBoundingBoxValidatorMixin
 from signals.apps.api.v0.fields import (
     CategoryLinksField,
     PriorityLinksField,
@@ -88,7 +88,7 @@ class SignalUpdateImageSerializer(serializers.ModelSerializer):
         return instance
 
 
-class _NestedLocationModelSerializer(NearAmsterdamValidatorMixin, serializers.ModelSerializer):
+class _NestedLocationModelSerializer(WithinBoundingBoxValidatorMixin, serializers.ModelSerializer):
     class Meta:
         model = Location
         geo_field = 'geometrie'
@@ -444,7 +444,7 @@ class SignalAuthHALSerializerDetail(HALSerializer):
         return obj.children.values_list('id', flat=True)
 
 
-class LocationHALSerializer(AddExtrasMixin, NearAmsterdamValidatorMixin, HALSerializer):
+class LocationHALSerializer(AddExtrasMixin, WithinBoundingBoxValidatorMixin, HALSerializer):
     _signal = serializers.PrimaryKeyRelatedField(queryset=Signal.objects.all())
 
     class Meta:

--- a/api/app/signals/apps/api/v1/serializers/nested/location.py
+++ b/api/app/signals/apps/api/v1/serializers/nested/location.py
@@ -1,9 +1,9 @@
-from signals.apps.api.generics.mixins import NearAmsterdamValidatorMixin
+from signals.apps.api.generics.mixins import WithinBoundingBoxValidatorMixin
 from signals.apps.api.generics.serializers import SIAModelSerializer
 from signals.apps.signals.models import Location
 
 
-class _NestedLocationModelSerializer(NearAmsterdamValidatorMixin, SIAModelSerializer):
+class _NestedLocationModelSerializer(WithinBoundingBoxValidatorMixin, SIAModelSerializer):
     class Meta:
         model = Location
         geo_field = 'geometrie'

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -29,6 +29,11 @@ SITE_DOMAIN = os.getenv('SITE_DOMAIN', 'api.data.amsterdam.nl')
 
 ORGANIZATION_NAME = os.getenv('ORGANIZATION_NAME', 'Gemeente Amsterdam')
 
+# Accept signals within this geographic bounding box in
+# format: <lon_min>,<lat_min>,<lon_max>,<lat_max> (WS84)
+# default value covers The Netherlands
+BOUNDING_BOX = [float(i) for i in os.getenv('BOUNDING_BOX', '3.3,50.7,7.3,53.6').split(',')]
+
 # Django security settings
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True

--- a/api/app/tests/apps/api/v1/test_serializers.py
+++ b/api/app/tests/apps/api/v1/test_serializers.py
@@ -12,15 +12,15 @@ from signals.apps.api.v0.fields import CategoryLinksField
 from signals.apps.api.v0.serializers import (
     CategoryHALSerializer,
     LocationHALSerializer,
-    NearAmsterdamValidatorMixin
+    WithinBoundingBoxValidatorMixin
 )
 from signals.apps.signals.models import Location
 from tests.apps.signals.factories import SignalFactory
 from tests.apps.users.factories import UserFactory
 from tests.test import SignalsBaseApiTestCase
 
-IN_AMSTERDAM = (4.898466, 52.361585)
-OUTSIDE_AMSTERDAM = tuple(reversed(IN_AMSTERDAM))
+IN_THE_NETHERLANDS = (4.898466, 52.361585)
+OUTSIDE_THE_NETHERLANDS = tuple(reversed(IN_THE_NETHERLANDS))
 
 
 # V0 has been disabled but we still want to test the code, so for the tests we will add the endpoints
@@ -37,14 +37,14 @@ test_urlconf.urlpatterns = [
 ]
 
 
-class TestNearAmsterdamValidatorMixin(TestCase):
+class TestWithinBoundingBoxValidatorMixin(TestCase):
     def test_validate_geometrie(self):
         # note this test bypasses the API
-        correct = Point(IN_AMSTERDAM)
-        wrong = Point(OUTSIDE_AMSTERDAM)
+        correct = Point(IN_THE_NETHERLANDS)
+        wrong = Point(OUTSIDE_THE_NETHERLANDS)
 
         # check that valid data is returned, and wrong data rejected
-        v = NearAmsterdamValidatorMixin()
+        v = WithinBoundingBoxValidatorMixin()
         self.assertEqual(correct, v.validate_geometrie(correct))
 
         with self.assertRaises(serializers.ValidationError):
@@ -67,7 +67,7 @@ class TestLocationSerializer(SignalsBaseApiTestCase):
         """Post een compleet signaal."""
         url = '/signals/signal/'
         payload = self._get_fixture()
-        payload['location']['geometrie']['coordinates'] = OUTSIDE_AMSTERDAM
+        payload['location']['geometrie']['coordinates'] = OUTSIDE_THE_NETHERLANDS
 
         response = self.client.post(url, payload, format='json')
         self.assertEqual(response.status_code, 400)
@@ -75,7 +75,7 @@ class TestLocationSerializer(SignalsBaseApiTestCase):
     def test_correct_lon_lat(self):
         url = '/signals/signal/'
         payload = self._get_fixture()
-        payload['location']['geometrie']['coordinates'] = IN_AMSTERDAM
+        payload['location']['geometrie']['coordinates'] = IN_THE_NETHERLANDS
 
         response = self.client.post(url, payload, format='json')
         self.assertEqual(response.status_code, 201)


### PR DESCRIPTION
- Make geographic bounding box configurable
- Improve error message for signals outside of the bounding box

Test bounding box on [geojson.io](https://geojson.io/) with:

```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [ 3.3, 50.7 ],
            [ 7.3, 50.7 ],
            [ 7.3, 53.6 ],
            [ 3.3, 53.6 ],
            [ 3.3, 50.7 ]
          ]
        ]
      }
    }
  ]
}
```


Closes Signalen/backend#66