### PR TITLE
when retrieving 'overig-overig' also check the parent slug

### DIFF
--- a/api/app/signals/apps/api/v0/views.py
+++ b/api/app/signals/apps/api/v0/views.py
@@ -234,7 +234,11 @@ class MlPredictCategoryView(APIView):
                     )
                     if not translated:
                         # When we cannot translate we return the 'overig-overig' category url
-                        default_category = Category.objects.get(slug='overig', parent__isnull=False)
+                        default_category = Category.objects.get(
+                            slug='overig',
+                            parent__isnull=False,
+                            parent__slug='overig'
+                        )
                         category_url = url_from_category(default_category, request=self.request)
 
                     data[key].append([category_url])


### PR DESCRIPTION
Currently the retrieve of 'overig-overig' sub cat fails when we  have multiple 'overig' under different main category. This small bugfix ensures that the parent slug name should be 'overig' when retrieving 'overig-overig'