### PR TITLE
bugfix: 'duplicate' subcat with different parent handling

### DIFF
--- a/api/app/signals/apps/api/ml_tool/utils.py
+++ b/api/app/signals/apps/api/ml_tool/utils.py
@@ -12,9 +12,13 @@ def get_category_from_prediction(category_url):
         return category_url, False
 
     slug = resolved.kwargs['slug']
-    parent_isnull = False if 'parent_lookup_parent__slug' in resolved.kwargs else True
+    parent_slug = resolved.kwargs.get('parent_lookup_parent__slug', None)
 
-    category = Category.objects.get(slug=slug, parent__isnull=parent_isnull)
+    if not parent_slug:
+        category = Category.objects.get(slug=slug, parent__isnull=True)
+    else:
+        category = Category.objects.get(slug=slug, parent__slug=parent_slug)
+
     if category.is_translated():
         return category.translated_to()
     return category

--- a/api/app/signals/apps/api/v1/filters/question.py
+++ b/api/app/signals/apps/api/v1/filters/question.py
@@ -6,13 +6,13 @@ from signals.apps.signals.models import Category
 
 class QuestionFilterSet(FilterSet):
     main_slug = filters.ModelChoiceFilter(
-        queryset=Category.objects.filter(parent__isnull=True).all(),
+        queryset=Category.objects.filter(is_active=True, parent__isnull=True).all(),
         to_field_name='slug',
         field_name='category__slug',
         label='Hoofd categorie',
     )
     sub_slug = filters.ModelChoiceFilter(
-        queryset=Category.objects.filter(parent__isnull=False).all(),
+        queryset=Category.objects.filter(is_active=True, parent__isnull=False).all(),
         to_field_name='slug',
         field_name='category__parent__slug',
         label='Sub categorie',


### PR DESCRIPTION
fixed 2 issues with on-unique main / sub slug combination
1. get_category_from_prediction() does not handle 'duplicate' subcat (but with different parent) correctly 
2. QuestionFilterSet should filter on active categories only