### PR TITLE
fix how list of "gemeentenaam" is handled in pdok suggest query

### DIFF
--- a/api/app/signals/apps/api/v1/validation/address/pdok.py
+++ b/api/app/signals/apps/api/v1/validation/address/pdok.py
@@ -41,7 +41,7 @@ class PDOKAddressValidation(BaseAddressValidation):
         if 'postcode' in address and address["postcode"]:
             query_dict.update({'fq': f'postcode:{address["postcode"]}'})
 
-        # remove None, '', ' ' strings before formatting
+        # remove '', ' ' strings before formatting
         cleaned_pdok_list = filter(lambda item: item, map(str.strip, DEFAULT_PDOK_MUNICIPALITIES))
         query_dict.update({'fq': f'''gemeentenaam:("{'" "'.join(cleaned_pdok_list)}")'''})
 

--- a/api/app/signals/apps/api/v1/validation/address/pdok.py
+++ b/api/app/signals/apps/api/v1/validation/address/pdok.py
@@ -40,7 +40,10 @@ class PDOKAddressValidation(BaseAddressValidation):
             query_dict.update({'fq': f'woonplaatsnaam:{address["woonplaats"]}'})
         if 'postcode' in address and address["postcode"]:
             query_dict.update({'fq': f'postcode:{address["postcode"]}'})
-        query_dict.update({'fq': f'gemeentenaam:{",".join(DEFAULT_PDOK_MUNICIPALITIES)}'})
+
+        # remove None, '', ' ' strings before formatting
+        cleaned_pdok_list = filter(lambda item: item, map(str.strip, DEFAULT_PDOK_MUNICIPALITIES))
+        query_dict.update({'fq': f'''gemeentenaam:"{'"gemeentenaam:"'.join(cleaned_pdok_list)}"'''})
 
         straatnaam = address["openbare_ruimte"]
         huisnummer = address["huisnummer"]

--- a/api/app/signals/apps/api/v1/validation/address/pdok.py
+++ b/api/app/signals/apps/api/v1/validation/address/pdok.py
@@ -43,7 +43,7 @@ class PDOKAddressValidation(BaseAddressValidation):
 
         # remove None, '', ' ' strings before formatting
         cleaned_pdok_list = filter(lambda item: item, map(str.strip, DEFAULT_PDOK_MUNICIPALITIES))
-        query_dict.update({'fq': f'''gemeentenaam:"{'"gemeentenaam:"'.join(cleaned_pdok_list)}"'''})
+        query_dict.update({'fq': f'''gemeentenaam:("{'" "'.join(cleaned_pdok_list)}")'''})
 
         straatnaam = address["openbare_ruimte"]
         huisnummer = address["huisnummer"]


### PR DESCRIPTION
BE fix for https://github.com/Signalen/backend/issues/73
see FE PR https://github.com/Amsterdam/signals-frontend/pull/1216 for more details

Pdok uses Solr. Any of these should work:
```
gemeentenaam:("den bosch" "boxtel" "altena")
gemeentenaam:("den bosch" OR "boxtel" OR "altena")
gemeentenaam:"den bosch" gemeentenaam:"boxtel" gemeentenaam:"altena"
gemeentenaam:"den bosch" OR gemeentenaam:"boxtel" OR gemeentenaam:"altena"
```

more info: https://stackoverflow.com/questions/14595767/how-to-select-multiple-values-in-solr-via-the-query-string