### PR TITLE
rename 'SIA systeem' to 'Signalen systeem' in history view

### DIFF
--- a/api/app/signals/apps/signals/models/history.py
+++ b/api/app/signals/apps/signals/models/history.py
@@ -55,7 +55,7 @@ class History(models.Model):
     def get_who(self):
         """Generate string to show in UI, missing users are set to default."""
         if self.who is None:
-            return 'SIA systeem'
+            return 'Signalen systeem'
         return self.who
 
     def get_description(self):


### PR DESCRIPTION
There's a hardcoded SIA string in the history view. 
Fixes issue https://github.com/Signalen/backend/issues/71