### PR TITLE
fix/has_parent

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -2045,6 +2045,9 @@ components:
           format: date-time
           nullable: true
           example: null
+        has_parent:
+          type: boolean
+          example: false
         has_children:
           type: boolean
           example: false

--- a/api/app/signals/apps/api/v1/serializers/signal.py
+++ b/api/app/signals/apps/api/v1/serializers/signal.py
@@ -304,6 +304,7 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
         write_only=True,
         queryset=Signal.objects.all()
     )
+    has_parent = serializers.SerializerMethodField()
     has_children = serializers.SerializerMethodField()
 
     attachments = PrivateSignalAttachmentRelatedField(view_name='private-signals-attachments-detail', many=True,
@@ -339,12 +340,14 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
             'attachments',
 
             'parent',
+            'has_parent',
             'has_children',
         )
         read_only_fields = (
             'created_at',
             'updated_at',
             'has_attachments',
+            'has_parent',
             'has_children',
         )
         extra_kwargs = {
@@ -353,6 +356,9 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
 
     def get_has_attachments(self, obj):
         return obj.attachments.exists()
+
+    def get_has_parent(self, obj):
+        return obj.parent_id is not None  # True is a parent_id is set, False if not
 
     def get_has_children(self, obj):
         return obj.children.exists()


### PR DESCRIPTION
Added has_parent (same style as has_children) to the serializer for the Signals list endpoint