### PR TITLE
fixed 2 issues regarding routing

### DIFF
--- a/api/app/signals/apps/api/v1/serializers/expression.py
+++ b/api/app/signals/apps/api/v1/serializers/expression.py
@@ -39,7 +39,7 @@ class ExpressionSerializer(HALSerializer):
     def update(self, instance, validated_data):
         routing_data = validated_data.pop('routing_department', None)
         if routing_data:
-            RoutingExpression.objects.update_routing(instance, routing_data)
+            RoutingExpression.actions.update_routing(instance, routing_data)
             instance.refresh_from_db()
 
         return super(ExpressionSerializer, self).update(instance, validated_data)

--- a/api/app/signals/apps/services/domain/dsl.py
+++ b/api/app/signals/apps/services/domain/dsl.py
@@ -59,7 +59,7 @@ class SignalContext:
         # add additonal question answers id to context
         if signal.extra_properties:
             for prop in signal.extra_properties:
-                if 'id' in prop and 'answer' in prop and not hasattr(signal, prop['id']):
+                if 'id' in prop and 'answer' in prop and prop['id'] not in tmp:
                     tmp[prop['id']] = prop['answer']
 
         return tmp

--- a/api/app/signals/apps/services/domain/dsl.py
+++ b/api/app/signals/apps/services/domain/dsl.py
@@ -71,7 +71,7 @@ class SignalDslService(DslService):
 
     def process_routing_rules(self, signal):
         ctx = self.context_func(signal)
-        rules = RoutingExpression.actions.select_related('_expression', '_department')
+        rules = RoutingExpression.objects.select_related('_expression', '_department')
         for rule in rules.filter(is_active=True, _expression___type__name='routing').order_by('order'):
             if self.evaluate(signal, rule._expression.code, ctx):
                 # assign relation to department

--- a/api/app/signals/apps/services/domain/dsl.py
+++ b/api/app/signals/apps/services/domain/dsl.py
@@ -63,7 +63,7 @@ class SignalDslService(DslService):
 
     def process_routing_rules(self, signal):
         ctx = self.context_func(signal)
-        rules = RoutingExpression.objects.select_related('_expression', '_department')
+        rules = RoutingExpression.actions.select_related('_expression', '_department')
         for rule in rules.filter(is_active=True, _expression___type__name='routing').order_by('order'):
             if self.evaluate(signal, rule._expression.code, ctx):
                 # assign relation to department

--- a/api/app/signals/apps/services/domain/dsl.py
+++ b/api/app/signals/apps/services/domain/dsl.py
@@ -38,14 +38,6 @@ class SignalContext:
             }
         return tmp
 
-    def _get_extra_properties(self, signal: Signal):
-        tmp = {}
-        if signal.extra_properties:
-            for prop in signal.extra_properties:
-                if 'id' in prop and 'answer' in prop:
-                    tmp[prop['id']] = prop['answer']
-        return tmp
-
     @property
     def areas(self):
         if not self._areas:
@@ -55,15 +47,22 @@ class SignalContext:
     def __call__(self, signal: Signal):
 
         t = signal.incident_date_start.strftime("%H:%M:%S")
-        return {
+        tmp = {
             'sub': signal.category_assignment.category.name,
             'main': signal.category_assignment.category.parent.name,
             'location': signal.location.geometrie,
             'stadsdeel': signal.location.stadsdeel,
             'time': time.strptime(t, "%H:%M:%S"),
-            'extra_properties': self._get_extra_properties(signal),
             'areas': self.areas
         }
+
+        # add additonal question answers id to context
+        if signal.extra_properties:
+            for prop in signal.extra_properties:
+                if 'id' in prop and 'answer' in prop and not hasattr(signal, prop['id']):
+                    tmp[prop['id']] = prop['answer']
+
+        return tmp
 
 
 class SignalDslService(DslService):

--- a/api/app/signals/apps/services/domain/dsl.py
+++ b/api/app/signals/apps/services/domain/dsl.py
@@ -38,6 +38,14 @@ class SignalContext:
             }
         return tmp
 
+    def _get_extra_properties(self, signal: Signal):
+        tmp = {}
+        if signal.extra_properties:
+            for prop in signal.extra_properties:
+                if 'id' in prop and 'answer' in prop:
+                    tmp[prop['id']] = prop['answer']
+        return tmp
+
     @property
     def areas(self):
         if not self._areas:
@@ -53,6 +61,7 @@ class SignalContext:
             'location': signal.location.geometrie,
             'stadsdeel': signal.location.stadsdeel,
             'time': time.strptime(t, "%H:%M:%S"),
+            'extra_properties': self._get_extra_properties(signal),
             'areas': self.areas
         }
 

--- a/api/app/signals/apps/signals/managers.py
+++ b/api/app/signals/apps/signals/managers.py
@@ -572,7 +572,7 @@ class SignalManager(models.Manager):
 
         with transaction.atomic():
             locked_signal = Signal.objects.select_for_update(nowait=True).get(pk=signal.pk)  # Lock the Signal
-            departments = self._update_directing_departments_no_transaction(
+            departments = self._update_routing_departments_no_transaction(
                 data=data,
                 signal=locked_signal
             )

--- a/api/app/signals/apps/signals/models/routing_expression.py
+++ b/api/app/signals/apps/signals/models/routing_expression.py
@@ -8,7 +8,7 @@ class RoutingExpressionManager(models.Manager):
         department = data['_department']['id']
         order = data.get('order', None)
         if not hasattr(instance, 'routing_department'):
-            instance.routing_department = RoutingExpression.objects.create(
+            instance.routing_department = RoutingExpression.actions.create(
                 _department=department,
                 _expression=instance,
                 order=order

--- a/api/app/signals/apps/signals/models/routing_expression.py
+++ b/api/app/signals/apps/signals/models/routing_expression.py
@@ -8,7 +8,7 @@ class RoutingExpressionManager(models.Manager):
         department = data['_department']['id']
         order = data.get('order', None)
         if not hasattr(instance, 'routing_department'):
-            instance.routing_department = RoutingExpression.actions.create(
+            instance.routing_department = RoutingExpression.objects.create(
                 _department=department,
                 _expression=instance,
                 order=order
@@ -32,3 +32,4 @@ class RoutingExpression(models.Model):
     is_active = models.BooleanField(default=False)
 
     actions = RoutingExpressionManager()
+    objects = models.Manager()


### PR DESCRIPTION
- modelmanager was assigned to `.actions` instead of `.objects` for RoutingExpression model.
- when updating routing, the directing department relation was used
- make extra questions answers available for dsl. For now we expose extra property id and its value to the context. This is only being done if the id of the extra property is not available as signal attribute (we avoid attributes being overwritten this way)