### PR TITLE
Pin Github actions on Ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     services:
       postgres:


### PR DESCRIPTION
As ubuntu-latest will [soon be replaced](https://github.com/actions/virtual-environments/issues/1816).