### PR TITLE
properly handle complex ui answer structures for custom questions in …

### DIFF
--- a/api/app/signals/apps/services/domain/dsl.py
+++ b/api/app/signals/apps/services/domain/dsl.py
@@ -60,7 +60,17 @@ class SignalContext:
         if signal.extra_properties:
             for prop in signal.extra_properties:
                 if 'id' in prop and 'answer' in prop and prop['id'] not in tmp:
-                    tmp[prop['id']] = prop['answer']
+                    answer = prop['answer']
+                    # UI elements can be a list of dicts with 'label' or 'value' keys
+                    # or a single dict with 'label' or 'value' keys
+                    if type(answer) is list:
+                        tmp[prop['id']] = set(
+                            [x.get('label', x.get('value', None)) for x in answer if type(x) is dict]
+                        )
+                    elif type(answer) is dict:
+                        tmp[prop['id']] = answer.get('label', answer.get('value', None))
+                    else:
+                        tmp[prop['id']] = prop['answer']
 
         return tmp
 

--- a/api/app/tests/apps/signals/test_routing_mechanism.py
+++ b/api/app/tests/apps/signals/test_routing_mechanism.py
@@ -54,7 +54,10 @@ class TestRoutingMechanism(TestCase):
         # simulate apply routing rules
         self.dsl_service.process_routing_rules(signal_inside)
         signal_inside.refresh_from_db()
-        self.assertIsNstort
+        self.assertIsNotNone(signal_inside.routing_assignment)
+        self.assertEqual(len(signal_inside.routing_assignment.departments.all()), 1)
+        routing_dep = signal_inside.routing_assignment.departments.first()
+        self.assertEqual(routing_dep.id, self.department.id)
 
     def test_context_func(self):
         # test signal outside center

--- a/api/app/tests/apps/signals/test_routing_mechanism.py
+++ b/api/app/tests/apps/signals/test_routing_mechanism.py
@@ -55,6 +55,7 @@ class TestRoutingMechanism(TestCase):
         self.dsl_service.process_routing_rules(signal_inside)
         signal_inside.refresh_from_db()
         self.assertIsNstort
+
     def test_context_func(self):
         # test signal outside center
         signal = SignalFactory.create()

--- a/api/app/tests/apps/signals/test_routing_mechanism.py
+++ b/api/app/tests/apps/signals/test_routing_mechanism.py
@@ -1,7 +1,7 @@
 from django.contrib.gis import geos
 from django.test import TestCase
 
-from signals.apps.services.domain.dsl import SignalDslService
+from signals.apps.services.domain.dsl import SignalContext, SignalDslService
 from signals.apps.signals.factories import (
     AreaFactory,
     DepartmentFactory,
@@ -54,7 +54,51 @@ class TestRoutingMechanism(TestCase):
         # simulate apply routing rules
         self.dsl_service.process_routing_rules(signal_inside)
         signal_inside.refresh_from_db()
-        self.assertIsNotNone(signal_inside.routing_assignment)
-        self.assertEqual(len(signal_inside.routing_assignment.departments.all()), 1)
-        routing_dep = signal_inside.routing_assignment.departments.first()
-        self.assertEqual(routing_dep.id, self.department.id)
+        self.assertIsNstort
+    def test_context_func(self):
+        # test signal outside center
+        signal = SignalFactory.create()
+        signal.extra_properties = [
+            {
+                "id": "key1",
+                "answer": {
+                    "id": "2",
+                    "info": "",
+                    "label": "value 1"
+                },
+            },
+            {
+                "id": "key2",
+                "answer": {
+                    "id": "2",
+                    "info": "",
+                    "value": "value 2"
+                },
+            },
+            {
+                "id": "key3_list",
+                "answer": [
+                    {
+                        "id": "2",
+                        "label": "value 3.1"
+                    },
+                    {
+                        "id": "3",
+                        "label": "value 3.2"
+                    }
+                ],
+            },
+            {
+                "id": "key4",
+                "answer": "value 4",
+            }
+        ]
+
+        ctx_func = SignalContext()
+        ctx = ctx_func(signal)
+        self.assertEqual(ctx['key1'], "value 1")
+        self.assertEqual(ctx['key2'], "value 2")
+        self.assertEqual(type(ctx['key3_list']), set)
+        self.assertTrue("value 3.1" in ctx['key3_list'])
+        self.assertTrue("value 3.2" in ctx['key3_list'])
+        self.assertEqual(ctx['key4'], "value 4")


### PR DESCRIPTION
UI stores question answers in different structures. We should be able to map the anwers.
list(dict['label'/'value'])) -> map to Set(['label'/'value'])
dict['label'/'value'] -> 'label'/'value' 
text -> text

```dict['label'/'value']
    "extra_properties": [
        {
            "id": "AFV_keuzemogelijkheden",
            "label": "Vervuiling",
            "answer": {
                "id": "2",
                "info": "",
                "label": "Illegale stort"
            },
            "category_url": "/signals/v1/public/terms/categories/afval-en-vervuiling/sub_categories/vervuiling-openbare-ruimte"
        },
        {
            "id": "AFV_keuzemogelijkheden_list",
            "label": "Vervuiling",
            "answer": [{
                "id": "2",
                "label": "Illegale stort 1"
            }, {
                "id": "3",
                "label": "Illegale stort 2"
            }],
            "category_url": "/signals/v1/public/terms/categories/afval-en-vervuiling/sub_categories/vervuiling-openbare-ruimte"
        },
        {
            "id": "Dader/Veroorzaker",
            "label": "U kunt hier aangeven wie de dader/veroorzaker is",
            "answer": "test amso 3-12: automatische routering naar wijkteam noord?",
            "category_url": "/signals/v1/public/terms/categories/afval-en-vervuiling/sub_categories/vervuiling-openbare-ruimte"
        }
```