### PR TITLE
add graceful handling of compile and runtime exceptions

### DIFF
--- a/api/app/signals/apps/signals/admin.py
+++ b/api/app/signals/apps/signals/admin.py
@@ -1,8 +1,9 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.gis.admin import OSMGeoAdmin
 from django.db import transaction
 from django.db.models import Q
 
+from signals.apps.dsl.ExpressionEvaluator import ExpressionEvaluator
 from signals.apps.signals import workflow
 from signals.apps.signals.models import (
     Area,
@@ -214,6 +215,19 @@ admin.site.register(Source, SourceAdmin)
 class RoutingExpressionAdmin(admin.ModelAdmin):
     list_filter = ['_expression___type__name', '_department__code']
     list_display = ['_expression', '_department', 'is_active']
+
+    def save_model(self, request, obj, form, change):
+        # if is_active is true, try to compile code, deactivate when invalid
+        try:
+            if obj.is_active:
+                expr = form.cleaned_data.get('_expression', None)
+                if expr:
+                    ExpressionEvaluator().compile(expr.code)
+        except Exception as e:
+            obj.is_active = False
+            messages.add_message(request, messages.WARNING, f'Rule deactivated due to error in expression: {str(e)}')
+
+        super(RoutingExpressionAdmin, self).save_model(request, obj, form, change)
 
 
 admin.site.register(RoutingExpression, RoutingExpressionAdmin)

--- a/api/app/tests/apps/signals/test_routing_mechanism.py
+++ b/api/app/tests/apps/signals/test_routing_mechanism.py
@@ -17,7 +17,12 @@ class TestRoutingMechanism(TestCase):
 
     def setUp(self):
         geometry = geos.MultiPolygon([geos.Polygon.from_bbox([4.877157, 52.357204, 4.929686, 52.385239])], srid=4326)
-        self.area = AreaFactory.create(geometry=geometry, name='centrum', code='centrum', _type__code='stadsdeel')
+        self.area = AreaFactory.create(
+            geometry=geometry,
+            name='centrum',
+            code='centrum',
+            _type__name='gebied',
+            _type__code='stadsdeel')
 
         self.exp_routing_type = ExpressionTypeFactory.create(name="routing")
         self.department = DepartmentFactory.create()
@@ -30,7 +35,8 @@ class TestRoutingMechanism(TestCase):
         RoutingExpressionFactory.create(
             _expression=self.location_expr,
             _department=self.department,
-            is_active=True
+            is_active=True,
+            order=2
         )
 
     def test_routing(self):
@@ -54,6 +60,72 @@ class TestRoutingMechanism(TestCase):
         # simulate apply routing rules
         self.dsl_service.process_routing_rules(signal_inside)
         signal_inside.refresh_from_db()
+        self.assertIsNotNone(signal_inside.routing_assignment)
+        self.assertEqual(len(signal_inside.routing_assignment.departments.all()), 1)
+        routing_dep = signal_inside.routing_assignment.departments.first()
+        self.assertEqual(routing_dep.id, self.department.id)
+
+    def test_routing_syntax_error(self):
+        # create expression which will cause error in compilation
+        err_expr = ExpressionFactory.create(
+            _type=self.exp_routing_type,
+            name="error expression",
+            code=f'abc location in areas."{self.area._type.name}"."{self.area.code}"'
+        )
+
+        routing_expr = RoutingExpressionFactory.create(
+            _expression=err_expr,
+            _department=self.department,
+            is_active=True,
+            order=1
+        )
+        # test signal inside center
+        signal_inside = SignalFactory.create(
+            location__geometrie=geos.Point(4.88, 52.36)
+        )
+        self.assertIsNone(signal_inside.routing_assignment)
+        # simulate apply routing rules
+        self.dsl_service.process_routing_rules(signal_inside)
+        signal_inside.refresh_from_db()
+
+        # routing rule will be de-activated due to syntax/compilation errors
+        routing_expr.refresh_from_db()
+        self.assertFalse(routing_expr.is_active)
+
+        # 2nd rule should still work
+        self.assertIsNotNone(signal_inside.routing_assignment)
+        self.assertEqual(len(signal_inside.routing_assignment.departments.all()), 1)
+        routing_dep = signal_inside.routing_assignment.departments.first()
+        self.assertEqual(routing_dep.id, self.department.id)
+
+    def test_routing_runtime_error(self):
+        # create expression which will cause error in compilation
+        err_expr = ExpressionFactory.create(
+            _type=self.exp_routing_type,
+            name="runtime error expressin",
+            code='unknown_abc > 1'
+        )
+
+        routing_expr = RoutingExpressionFactory.create(
+            _expression=err_expr,
+            _department=self.department,
+            is_active=True,
+            order=1
+        )
+        # test signal inside center
+        signal_inside = SignalFactory.create(
+            location__geometrie=geos.Point(4.88, 52.36)
+        )
+        self.assertIsNone(signal_inside.routing_assignment)
+        # simulate apply routing rules
+        self.dsl_service.process_routing_rules(signal_inside)
+        signal_inside.refresh_from_db()
+
+        # runtime errors should not effect is_active status
+        routing_expr.refresh_from_db()
+        self.assertTrue(routing_expr.is_active)
+
+        # 2nd rule should still work
         self.assertIsNotNone(signal_inside.routing_assignment)
         self.assertEqual(len(signal_inside.routing_assignment.departments.all()), 1)
         routing_dep = signal_inside.routing_assignment.departments.first()


### PR DESCRIPTION
## Description

During testing two issues were discovered
- Since we don't have validation in place for the routing (currently done via django admin) compilation errors can occur during evaluation of rules. Exceptions will stop evaluation of other rules
- Runtime exceptions (such as 1/0) should also not stop evaluation of other rules

This PR corrects this behavior by doing the following:
- compilation errors will set rule to in_active and continue flow
- runtime errors will be handled and will not prevent other rules from being executed

Add compilation check to modeladmin(routingexpression). If expression contains syntax errors, rule will be deactivated and user will get a notice. We should do full validation (check for valid identifiers in contex) after this commit. It requires refactor of the `ExpressionContext` validation handling
