### PR TITLE
DRAFT: feature: add optional location, category to public signal endpoint

### DIFF
--- a/api/app/signals/apps/api/v1/serializers/signal.py
+++ b/api/app/signals/apps/api/v1/serializers/signal.py
@@ -470,8 +470,18 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
 
 
 class PublicSignalSerializerDetail(HALSerializer):
+    def __init__(self, *args, **kwargs):
+        super(PublicSignalSerializerDetail, self).__init__(*args, **kwargs)
+
+        if settings.PUBLIC_SIGNAL_HIDE_EXTRA_PROPERTIES:
+            # remove 'location' field if we did not override this
+            self.fields.pop('location')
+            self.fields.pop('category')
+
     status = _NestedPublicStatusModelSerializer(required=False)
     serializer_url_field = PublicSignalLinksField
+    location = _NestedLocationModelSerializer(required=False)
+    category = _NestedCategoryModelSerializer(source='category_assignment', required=False)
     _display = serializers.SerializerMethodField(method_name='get__display')
 
     class Meta:
@@ -485,6 +495,8 @@ class PublicSignalSerializerDetail(HALSerializer):
             'updated_at',
             'incident_date_start',
             'incident_date_end',
+            'location',
+            'category',
         )
 
     def get__display(self, obj):

--- a/api/app/signals/apps/api/v1/views/_base.py
+++ b/api/app/signals/apps/api/v1/views/_base.py
@@ -1,12 +1,13 @@
 """
 Viewset base classes, not to be used directly.
 """
+from rest_framework import mixins
 from rest_framework.viewsets import GenericViewSet
 
 from signals.apps.signals.models import Signal
 
 
-class PublicSignalGenericViewSet(GenericViewSet):
+class PublicSignalGenericViewSet(mixins.ListModelMixin, GenericViewSet):
     lookup_field = 'signal_id'
     lookup_url_kwarg = 'signal_id'
 

--- a/api/app/signals/apps/api/v1/views/signal.py
+++ b/api/app/signals/apps/api/v1/views/signal.py
@@ -1,4 +1,5 @@
 from datapunt_api.rest import DatapuntViewSet, HALPagination
+from django.conf import settings
 from django.http import Http404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
@@ -31,8 +32,10 @@ from signals.auth.backend import JWTAuthBackend
 class PublicSignalViewSet(PublicSignalGenericViewSet):
     serializer_class = PublicSignalSerializerDetail
 
-    def list(self, *args, **kwargs):
-        raise Http404
+    def list(self, request, *args, **kwargs):
+        if settings.PUBLIC_SIGNAL_HIDE_EXTRA_PROPERTIES:
+            raise Http404
+        return super(PublicSignalViewSet, self).list(request, *args, **kwargs)
 
     def create(self, request):
         serializer = PublicSignalCreateSerializer(data=request.data, context=self.get_serializer_context())

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -569,3 +569,6 @@ DEFAULT_SIGNAL_AREA_TYPE = os.getenv('DEFAULT_SIGNAL_AREA_TYPE', 'district')
 # Note: this assumes the configured image is available through the staticfiles
 # app.
 API_PDF_LOGO_STATIC_FILE = os.getenv('API_PDF_LOGO_STATIC_FILE', 'api/logo-gemeente-amsterdam.svg')
+
+# prevent location property from being removed from public signal list endpoint if set
+PUBLIC_SIGNAL_HIDE_EXTRA_PROPERTIES = os.getenv('PUBLIC_SIGNAL_HIDE_EXTRA_PROPERTIES', True) in TRUE_VALUES


### PR DESCRIPTION
We need a public signal endpoint that also returns location and category (to be used in public maps). Currently The public list endpoint don't include these attributes. We can add these extra attributes via a setting. By default the `location` and `category` will be removed from the serializer. When setting the `PUBLIC_SIGNAL_HIDE_EXTRA_PROPERTIES` to FALSE, it will keep these values. Default value is True

## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Documentation has been updated if needed
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts
- [ ] There are no conflicting Django migrations

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 90% (the higher the better)
- [ ] No iSort issues are present in the code
- [ ] No Flake8 issues are present in the code
