### PR TITLE
Also include date in csv-zip-dump filename

### DIFF
--- a/api/app/signals/apps/reporting/csv/utils.py
+++ b/api/app/signals/apps/reporting/csv/utils.py
@@ -24,7 +24,7 @@ def zip_csv_files(files_to_zip: list, using: str) -> None:
     storage = _get_storage_backend(using=using)
     now = timezone.now()
     src_folder = f'{storage.location}/{now:%Y}/{now:%m}/{now:%d}'
-    dst_file = os.path.join(src_folder, f'{now:%H%M%S%Z}')
+    dst_file = os.path.join(src_folder, f'{now:%Y%m%d_%H%M%S%Z}')
 
     with zipfile.ZipFile(f'{dst_file}.zip', 'w') as zipper:
         for file in files_to_zip:

--- a/api/app/tests/apps/reporting/test_datawarehouse.py
+++ b/api/app/tests/apps/reporting/test_datawarehouse.py
@@ -91,7 +91,7 @@ class TestDatawarehouse(testcases.TestCase):
         statuses_csv = path.join(self.file_backend_tmp_dir, '2020/09/10', '120000UTC_statuses.csv')
         sla_csv = path.join(self.file_backend_tmp_dir, '2020/09/10', '120000UTC_sla.csv')
         directing_departments_csv = path.join(self.file_backend_tmp_dir, '2020/09/10', '120000UTC_directing_departments.csv')  # noqa
-        zip_package = path.join(self.file_backend_tmp_dir, '2020/09/10', '120000UTC.zip')
+        zip_package = path.join(self.file_backend_tmp_dir, '2020/09/10', '20200910_120000UTC.zip')
 
         self.assertTrue(path.exists(signals_csv))
         self.assertTrue(path.getsize(signals_csv))


### PR DESCRIPTION
Currently the generated csv zip filename does not include the date in the filename. It's was requested to have the date stamp in the file name.
