### PR TITLE
Change SIA-### references to Signalen-### references in pdf, add base…

### DIFF
--- a/api/app/signals/apps/api/pdf/mixins.py
+++ b/api/app/signals/apps/api/pdf/mixins.py
@@ -10,7 +10,7 @@ class PDFTemplateResponseMixin(TemplateResponseMixin):
 
     def get_pdf_filename(self):
         if not self.pdf_filename:
-            self.pdf_filename = 'SIA-{}.pdf'.format(self.object.pk)
+            self.pdf_filename = 'Signalen-{}.pdf'.format(self.object.pk)
         return self.pdf_filename
 
     def render_to_response(self, context, **response_kwargs):

--- a/api/app/signals/apps/api/templates/api/pdf/print_signal.html
+++ b/api/app/signals/apps/api/templates/api/pdf/print_signal.html
@@ -99,7 +99,7 @@
         </table>
     </div>
 
-    <h1>{{ signal.sia_id }}</h1>
+    <h1>Signalen-{{ signal.id }}</h1>
     <div style="width: 680px; height: 250px; background-color: lightgray; margin-bottom: 25px; position:relative; top:0px; left:0px;">
         {% if img_data_uri %}
         <img src="{{img_data_uri}}" style="position:relative; top:0px; left:0px;"/>
@@ -114,7 +114,7 @@
         {% if signal.is_child %}
         <tr>
             <td>Hoofdmelding</td>
-            <td>: SIA-{{ signal.parent.id }}</td>
+            <td>: Signalen-{{ signal.parent.id }}</td>
         </tr>
         {% endif %}
         <tr>
@@ -127,7 +127,11 @@
         </tr>
         <tr>
             <td>Stadsdeel</td>
+            {% if signal.location.stadsdeel %}
             <td>: {{ signal.location.get_stadsdeel_display }}</td>
+            {% else %}
+            <td>: {{ signal.location.area_code }}</td>
+            {% endif %}
         </tr>
         <tr>
             <td>Adres</td>
@@ -178,7 +182,7 @@
     <h2>Foto's</h2>
     {% if images %}
         {% for image in images %}
-            <p><img src="{{ image.file.url }}" style="width:680px" alt=""></p>
+            <p><img src="{{base_url}}{{ image.file.url }}" style="width:680px" alt=""></p>
         {% endfor %}
         <br>
     {% elif jpg_data_urls %}  {# HOTFIX SIG-1473 #}

--- a/api/app/signals/apps/api/v1/views/pdf.py
+++ b/api/app/signals/apps/api/v1/views/pdf.py
@@ -93,4 +93,5 @@ class GeneratePdfView(SingleObjectMixin, PDFTemplateView):
             images=self.object.attachments.filter(is_image=True),
             user=self.request.user,
             logo_src=logo_src,
+            base_url=f'{self.request.scheme}://{self.request.get_host()}',
         )

--- a/api/app/tests/apps/api/v1/test_pdf.py
+++ b/api/app/tests/apps/api/v1/test_pdf.py
@@ -15,7 +15,7 @@ class TestPDFView(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(response.get('Content-Type'), 'application/pdf')
         self.assertEqual(
             response.get('Content-Disposition'),
-            'attachment;filename="SIA-{}.pdf"'.format(self.signal.pk)
+            'attachment;filename="Signalen-{}.pdf"'.format(self.signal.pk)
         )
 
     def test_get_pdf_signal_does_not_exists(self):


### PR DESCRIPTION
Fixes issues mentioned in: https://github.com/Signalen/backend/issues/105
- Change SIA-### refs to Signalen-### refs in pdf
- Use absolute url to for photos in pdf
- When location.stadsdeel is not set, use location.area_code instead