### PR TITLE
Changed the 'has_changed_children' filter to work correctly

### DIFF
--- a/api/app/signals/apps/api/v1/filters/signal.py
+++ b/api/app/signals/apps/api/v1/filters/signal.py
@@ -233,7 +233,7 @@ class SignalFilterSet(FilterSet):
 
     def has_changed_children_filter(self, queryset, name, value):
         # we have a MultipleChoiceFilter ...
-        choices = list(set(map(lambda x: True if x in settings.TRUE_VALUES else False, value)))
+        choices = set(map(lambda x: True if x in settings.TRUE_VALUES else False, value))
         q_filter = Q(children__isnull=False)
         if len(choices) == 2:
             return queryset.filter(q_filter).distinct()

--- a/api/app/tests/apps/api/v1/test_filters.py
+++ b/api/app/tests/apps/api/v1/test_filters.py
@@ -998,60 +998,60 @@ class TestParentSignalFilter(SignalsBaseApiTestCase):
     def test_retrieve_all_parents_with_changes_in_one_of_the_children(self):
         now = timezone.now()
 
-        parent_signal = SignalFactory.create()
+        parent_signal_to_keep = SignalFactory.create()
         for hour in range(5):
             # Create 4 child signals 1 hour apart
             with freeze_time(now + timedelta(hours=hour)):
-                SignalFactory.create(parent=parent_signal)
+                SignalFactory.create(parent=parent_signal_to_keep)
 
         with freeze_time(now + timedelta(hours=3)):
             # This way we have 1 child signal changed after the last update on the parent signal
-            parent_signal.save()
+            parent_signal_to_keep.save()
 
         # This parent should not show up in the filter
-        parent_signal_not_to_be_filtered = SignalFactory.create()
+        parent_signal_to_reject = SignalFactory.create()
         for hour in range(5):
             # Create 4 child signals 1 hour apart
             with freeze_time(now + timedelta(hours=hour)):
-                SignalFactory.create(parent=parent_signal_not_to_be_filtered)
+                SignalFactory.create(parent=parent_signal_to_reject)
 
         with freeze_time(now + timedelta(hours=6)):
             # This way the parent signal is changed last
-            parent_signal_not_to_be_filtered.save()
+            parent_signal_to_reject.save()
 
         filter_params = {'has_changed_children': True}
         ids = self._request_filter_signals(filter_params)
         self.assertEqual(len(ids), 1)
-        self.assertEqual(ids, [parent_signal.id])
+        self.assertEqual(ids, [parent_signal_to_keep.id])
 
     def test_retrieve_all_parents_with_no_changes_in_children(self):
         now = timezone.now()
 
-        parent_signal = SignalFactory.create()
+        parent_signal_to_keep = SignalFactory.create()
         for hour in range(5):
             # Create 4 child signals 1 hour apart
             with freeze_time(now + timedelta(hours=hour)):
-                SignalFactory.create(parent=parent_signal)
+                SignalFactory.create(parent=parent_signal_to_keep)
 
         with freeze_time(now + timedelta(hours=6)):
             # This way the parent signal is changed last
-            parent_signal.save()
+            parent_signal_to_keep.save()
 
         # This parent should not show up in the filter
-        parent_signal_not_to_be_filtered = SignalFactory.create()
+        parent_signal_to_reject = SignalFactory.create()
         for hour in range(5):
             # Create 4 child signals 1 hour apart
             with freeze_time(now + timedelta(hours=hour)):
-                SignalFactory.create(parent=parent_signal_not_to_be_filtered)
+                SignalFactory.create(parent=parent_signal_to_reject)
 
-        with freeze_time(now + timedelta(hours=4)):
+        with freeze_time(now + timedelta(hours=3)):
             # This way we have 1 child signal changed after the last update on the parent signal
-            parent_signal_not_to_be_filtered.save()
+            parent_signal_to_reject.save()
 
         filter_params = {'has_changed_children': 'False'}
         ids = self._request_filter_signals(filter_params)
         self.assertEqual(len(ids), 1)
-        self.assertEqual(ids, [parent_signal.id])
+        self.assertEqual(ids, [parent_signal_to_keep.id])
 
     def test_retrieve_mixed_signals(self):
         # A bunch of normal signals that should never be retrieved by this filter

--- a/api/app/tests/apps/api/v1/test_filters.py
+++ b/api/app/tests/apps/api/v1/test_filters.py
@@ -18,7 +18,7 @@ from signals.apps.signals.factories import (
     StatusFactory,
     TypeFactory
 )
-from signals.apps.signals.models import Priority, SignalDepartments
+from signals.apps.signals.models import Priority, Signal, SignalDepartments
 from signals.apps.signals.workflow import BEHANDELING, GEMELD, ON_HOLD
 from tests.test import SignalsBaseApiTestCase
 
@@ -1006,7 +1006,7 @@ class TestParentSignalFilter(SignalsBaseApiTestCase):
 
         with freeze_time(now + timedelta(hours=3)):
             # This way we have 1 child signal changed after the last update on the parent signal
-            parent_signal_to_keep.save()
+            Signal.actions.update_status(data={'text': 'test', 'state': 'b'}, signal=parent_signal_to_keep)
 
         # This parent should not show up in the filter
         parent_signal_to_reject = SignalFactory.create()
@@ -1035,7 +1035,7 @@ class TestParentSignalFilter(SignalsBaseApiTestCase):
 
         with freeze_time(now + timedelta(hours=6)):
             # This way the parent signal is changed last
-            parent_signal_to_keep.save()
+            Signal.actions.update_status(data={'text': 'test', 'state': 'b'}, signal=parent_signal_to_keep)
 
         # This parent should not show up in the filter
         parent_signal_to_reject = SignalFactory.create()
@@ -1046,7 +1046,7 @@ class TestParentSignalFilter(SignalsBaseApiTestCase):
 
         with freeze_time(now + timedelta(hours=3)):
             # This way we have 1 child signal changed after the last update on the parent signal
-            parent_signal_to_reject.save()
+            Signal.actions.update_status(data={'text': 'test', 'state': 'b'}, signal=parent_signal_to_reject)
 
         filter_params = {'has_changed_children': 'False'}
         ids = self._request_filter_signals(filter_params)


### PR DESCRIPTION
## Description

Fixed the 'has_changed_children' filter. 

When True is given at least ONE OF the children must have an update_at after the parents updated_at. 
When False is given ALL children's updated_at must be before the parents updated_at.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] ~~Documentation has been updated if needed~~
- [X] ~~Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes~~
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
