### PR TITLE
Do not escape e-mail title and variables that are used for rendering Markdown

### DIFF
--- a/api/app/signals/apps/email_integrations/reporter/mail_actions.py
+++ b/api/app/signals/apps/email_integrations/reporter/mail_actions.py
@@ -249,11 +249,14 @@ class MailActions:
         try:
             email_template = EmailTemplate.objects.get(key=mail_kwargs['key'])
 
-            subject = Template(email_template.title).render(Context(context))
+            # do not escape as subject is not rendered as HTML
+            subject = Template(email_template.title).render(Context(context, autoescape=False))
 
             rendered_context = {
-                'subject': subject,
-                'body': Template(email_template.body).render(Context(context))
+                'subject': Template(email_template.title).render(Context(context)),
+
+                # do not escape HTML as this is handled by Markdown filter
+                'body': Template(email_template.body).render(Context(context, autoescape=False))
             }
 
             html_message = loader.get_template('email/_base.html').render(rendered_context)

--- a/api/app/tests/apps/email_integrations/reporter/test_email_templates.py
+++ b/api/app/tests/apps/email_integrations/reporter/test_email_templates.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.conf import settings
 from django.core import mail
 from django.test import TestCase
 
@@ -10,25 +11,49 @@ from signals.apps.signals.factories import SignalFactory
 
 class TestEmailTemplates(TestCase):
     def setUp(self):
-        def get_email():
-            return f'{uuid.uuid4()}@example.com'
-
         self.email_template = EmailTemplate.objects.create(
             key=EmailTemplate.SIGNAL_CREATED,
             title='Template title {{ signal.id }}',
-            body='# Template title\n Thanks a lot for reporting **{{ signal.id }}**',
+            body='# Template title\n Thanks a lot for reporting **{{ signal.id }}** '
+                 '{{ signal.text }}\n{{ ORGANIZATION_NAME }}',
         )
 
-        self.signal = SignalFactory.create(reporter__email=get_email())
-
     def test_email_template(self):
-        ma = MailActions(mail_rules=SIGNAL_MAIL_RULES)
-        ma.apply(signal_id=self.signal.id)
+        signal = SignalFactory.create(reporter__email=self.get_email())
 
-        self.assertEqual(f'Template title {self.signal.id}', mail.outbox[0].subject)
-        self.assertEqual(f'Template title\n\nThanks a lot for reporting {self.signal.id}\n\n', mail.outbox[0].body)
+        ma = MailActions(mail_rules=SIGNAL_MAIL_RULES)
+        ma.apply(signal_id=signal.id)
+
+        self.assertEqual(f'Template title {signal.id}', mail.outbox[0].subject)
+        self.assertEqual(f'Template title\n\nThanks a lot for reporting {signal.id} {signal.text}\n'
+                         f'{settings.ORGANIZATION_NAME}\n\n', mail.outbox[0].body)
 
         body, mime_type = mail.outbox[0].alternatives[0]
         self.assertEqual(mime_type, 'text/html')
         self.assertIn('<h1>Template title</h1>', body)
-        self.assertIn(f'<p>Thanks a lot for reporting <strong>{self.signal.id}</strong></p>', body)
+        self.assertIn(f'<p>Thanks a lot for reporting <strong>{signal.id}</strong>', body)
+
+    def test_organization_name_contains_quote(self):
+        signal = SignalFactory.create(reporter__email=self.get_email())
+
+        with self.settings(ORGANIZATION_NAME='Gemeente \'s-Hertogenbosch'):
+            ma = MailActions(mail_rules=SIGNAL_MAIL_RULES)
+            ma.apply(signal_id=signal.id)
+
+        self.assertEqual(f'Template title {signal.id}', mail.outbox[0].subject)
+        self.assertEqual(f'Template title\n\nThanks a lot for reporting {signal.id} {signal.text}\n'
+                         f'Gemeente \'s-Hertogenbosch\n\n', mail.outbox[0].body)
+
+    def test_evil_input(self):
+        evil_signal = SignalFactory.create(reporter__email=self.get_email(),
+                                           text='<script>alert("something evil");</script>')
+
+        ma = MailActions(mail_rules=SIGNAL_MAIL_RULES)
+        ma.apply(signal_id=evil_signal.id)
+
+        self.assertEqual(f'Template title {evil_signal.id}', mail.outbox[0].subject)
+        self.assertEqual(f'Template title\n\nThanks a lot for reporting {evil_signal.id} '
+                         f'alert("something evil");\n{settings.ORGANIZATION_NAME}\n\n', mail.outbox[0].body)
+
+    def get_email(self):
+        return f'{uuid.uuid4()}@example.com'


### PR DESCRIPTION
## Description

The e-mail template functionality did not correctly render variables with special characters when rendering the e-mail title and Markdown.

For example when `ORGANIZATION_NAME` was set to `'s-Hertogenbosch`:

- The Django auto-escaping function would render the e-mail template `{{ ORGANIZATION_NAME}}` to Markdown with `&#39;s-Hertogenbosch`.
- The Markdown renderer did not touch the HTML-escaped characters and performed HTML-escaping again. 

The resulting e-mail contained: `&#39;s-Hertogenbosch`

This PR fixes this:

- Double escaping is not performed any more. Escaping HTML is now handled once by the Markdown parser.
- E-mail titles are not escaped any more.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended

Closes Signalen/backend#96