### PR TITLE
Utils GetAccessToken now uses Keycloak

### DIFF
--- a/utils/get_signals.py
+++ b/utils/get_signals.py
@@ -1,82 +1,36 @@
-# utf-8
+import json
 import requests
 import os
-import random
-import string
-from urllib.parse import urlparse, parse_qsl
 
-class GetAccessToken(object):
-    """
-        Get a header authentication item for access token
-        for using the internal API's
-        by logging in as type = 'employee'
 
-        Usage:
-            from accesstoken import AccessToken
-            getToken = AccessToken()
-            accessToken = getToken.getAccessToken()
-            requests.get(url, headers= accessToken)
-    """
-    def getAccessToken(self, email, password, acceptance):
-
-        def randomword(length):
-            letters = string.ascii_lowercase
-            return ''.join(random.choice(letters) for i in range(length))
-
-        state = randomword(10)
-        scopes = ['SIG/ALL']
-        acc_prefix = 'acc.' if acceptance else ''
-        authzUrl = f'https://{acc_prefix}api.data.amsterdam.nl/oauth2/authorize'
-        params = {
-            'idp_id': 'datapunt',
-            'response_type': 'token',
-            'client_id': 'citydata',
-            'scope': ' '.join(scopes),
-            'state': state,
-            'redirect_uri' : f'https://{acc_prefix}data.amsterdam.nl/'
-        }
-
-        response = requests.get(authzUrl, params, allow_redirects=False)
-        if response.status_code == 303:
-            location = response.headers["Location"]
-        else:
-            return {}
-
-        data = {
-            'type':'employee_plus',
-            'email': email,
-            'password': password,
-        }
-
-        response = requests.post(location, data=data, allow_redirects=False)
-        if response.status_code == 303:
-            location = response.headers["Location"]
-        else:
-            return {}
-
-        response = requests.get(location, allow_redirects=False)
-        if response.status_code == 303:
-            returnedUrl = response.headers["Location"]
-        else:
-            return {}
-
-        # Get grantToken from parameter aselect_credentials in session URL
-        parsed = urlparse(returnedUrl)
-        fragment = parse_qsl(parsed.fragment)
-        access_token = fragment[0][1]
-        os.environ["ACCESS_TOKEN"] = access_token
-        return {"Authorization": 'Bearer ' + access_token}
+class GetAccessToken:
+    def getAccessToken(self, client_id, client_secret, acceptance=True):
+        environment = 'acc' if acceptance else 'b'
+        response = requests.post(
+            f'https://iam.amsterdam.nl/auth/realms/datapunt-ad-{environment}/protocol/openid-connect/token',
+            data={
+                'grant_type': 'client_credentials',
+                'client_id': client_id,
+                'client_secret': client_secret,
+            }
+        )
+        if response.status_code == 200:
+            return {
+                'Authorization': f'Bearer {response.json()["access_token"]}',
+            }
 
 
 if __name__ == "__main__":
-    acceptance = True
-    email = os.getenv('SIGNALS_USER', 'signals.admin@example.com')
-    password = os.getenv('SIGNALS_PASSWORD', 'insecure')
-    access_token = GetAccessToken().getAccessToken(email, password, acceptance)
-    print(f'Received new Access Token Header: {access_token}')
+    access_token_header = GetAccessToken().getAccessToken(
+        client_id=os.getenv('SIGNALS_USER', 'signals.admin@example.com'),
+        client_secret=os.getenv('SIGNALS_PASSWORD', 'insecure'),
+    )
 
-    url = "https://acc.api.data.amsterdam.nl/signals/v1/private/signals"
-    response = requests.get(url, headers=access_token)
-    jsonresponse = response.json()
-    print(jsonresponse)
+    if access_token_header:
+        print(f'Received Access Token Header: {access_token_header["Authorization"]}')
 
+        response = requests.get(
+            'https://acc.api.data.amsterdam.nl/signals/v1/private/signals?page_size=5',
+            headers=access_token_header
+        )
+        print(json.dumps(response.json(), indent=4))


### PR DESCRIPTION
## Description

The util scripts now use keycloak to get the access_token, also used as an example for external parties

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
