### PR TITLE
Proposal for additional signal-assigned user relation csv

### DIFF
--- a/api/app/signals/apps/reporting/csv/datawarehouse/__init__.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/__init__.py
@@ -8,7 +8,10 @@ from signals.apps.reporting.csv.datawarehouse.directing_departments import (
 from signals.apps.reporting.csv.datawarehouse.kto_feedback import create_kto_feedback_csv
 from signals.apps.reporting.csv.datawarehouse.locations import create_locations_csv
 from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_csv
-from signals.apps.reporting.csv.datawarehouse.signals import create_signals_csv
+from signals.apps.reporting.csv.datawarehouse.signals import (
+    create_signals_assigned_user_csv,
+    create_signals_csv
+)
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
 from signals.apps.reporting.csv.datawarehouse.tasks import (
     save_and_zip_csv_files_endpoint,
@@ -24,6 +27,7 @@ __all__ = [
     'create_locations_csv',
     'create_reporters_csv',
     'create_statuses_csv',
+    'create_signals_assigned_user_csv',
     'create_signals_csv',
     'save_csv_file_datawarehouse',
     'save_csv_files_datawarehouse',

--- a/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
@@ -61,3 +61,25 @@ def create_signals_csv(location: str) -> str:
     reorder_csv(csv_file.name, ordered_field_names)
 
     return csv_file.name
+
+
+def create_signals_assigned_user_csv(location: str) -> str:
+    """
+    Create the CSV file with all `Signal - assgined user relation` objects.
+
+    :param location: Directory for saving the CSV file
+    :returns: Path to CSV file
+    """
+    queryset = Signal.objects.annotate(
+        image=Value(None, output_field=CharField()),
+    ).values(
+        'id',
+        assigned_to=F('user_assignment__user__email'),
+    ).exclude(user_assignment__user__isnull=True).exclude(user_assignment__user__email__exact='').order_by('created_at')
+
+    csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'signals_assigned_user.csv'))
+
+    ordered_field_names = ['id', 'assigned_to', ]
+    reorder_csv(csv_file.name, ordered_field_names)
+
+    return csv_file.name

--- a/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
@@ -65,7 +65,7 @@ def create_signals_csv(location: str) -> str:
 
 def create_signals_assigned_user_csv(location: str) -> str:
     """
-    Create the CSV file with all `Signal - assgined user relation` objects.
+    Create the CSV file with all `Signal - assigned user relation` objects.
 
     :param location: Directory for saving the CSV file
     :returns: Path to CSV file

--- a/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
@@ -11,7 +11,10 @@ from signals.apps.reporting.csv.datawarehouse.directing_departments import (
 from signals.apps.reporting.csv.datawarehouse.kto_feedback import create_kto_feedback_csv
 from signals.apps.reporting.csv.datawarehouse.locations import create_locations_csv
 from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_csv
-from signals.apps.reporting.csv.datawarehouse.signals import create_signals_csv
+from signals.apps.reporting.csv.datawarehouse.signals import (
+    create_signals_assigned_user_csv,
+    create_signals_csv
+)
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
 from signals.apps.reporting.csv.utils import save_csv_files, zip_csv_files
 from signals.celery import app
@@ -44,6 +47,7 @@ def save_csv_files_datawarehouse(using='datawarehouse'):
     """
     csv_files = list()
     csv_files.extend(save_csv_file_datawarehouse(create_signals_csv, using=using))
+    csv_files.extend(save_csv_file_datawarehouse(create_signals_assigned_user_csv, using=using))
     csv_files.extend(save_csv_file_datawarehouse(create_locations_csv, using=using))
     csv_files.extend(save_csv_file_datawarehouse(create_reporters_csv, using=using))
     csv_files.extend(save_csv_file_datawarehouse(create_category_assignments_csv, using=using))

--- a/api/app/signals/apps/reporting/management/commands/dumpcsv.py
+++ b/api/app/signals/apps/reporting/management/commands/dumpcsv.py
@@ -15,7 +15,10 @@ from signals.apps.reporting.csv.datawarehouse.directing_departments import (
 from signals.apps.reporting.csv.datawarehouse.kto_feedback import create_kto_feedback_csv
 from signals.apps.reporting.csv.datawarehouse.locations import create_locations_csv
 from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_csv
-from signals.apps.reporting.csv.datawarehouse.signals import create_signals_csv
+from signals.apps.reporting.csv.datawarehouse.signals import (
+    create_signals_assigned_user_csv,
+    create_signals_csv
+)
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
 from signals.apps.reporting.csv.datawarehouse.tasks import (
     save_csv_file_datawarehouse,
@@ -25,6 +28,7 @@ from signals.apps.reporting.csv.datawarehouse.tasks import (
 REPORT_OPTIONS = {
     # Option, Func
     'signals': create_signals_csv,
+    'signals_assigned_user': create_signals_assigned_user_csv,
     'locations': create_locations_csv,
     'reporters': create_reporters_csv,
     'category_assignments': create_category_assignments_csv,

--- a/api/app/tests/apps/reporting/management/commands/test_command.py
+++ b/api/app/tests/apps/reporting/management/commands/test_command.py
@@ -16,7 +16,7 @@ class TestCommand(TransactionTestCase):
         self.assertNotEqual(out.getvalue(), '')
         self.assertEqual(err.getvalue(), '')
 
-        self.assertEqual(patched_save_csv_files_datawarehouse.call_count, 8)
+        self.assertEqual(patched_save_csv_files_datawarehouse.call_count, 9)
 
 
 class TestCSVHorecaCommand(TransactionTestCase):


### PR DESCRIPTION
We need to dump the assigned user in the csv. It can be solved by:
1. add additional field at normal signals.csv
2. add additional file containing [signal_id, email]

Since the dump code is executed in celery and no setting is available for assigned_user (it always works in the back-end, but can be configured in the front-end), we cannot conditionally enable this dump (unless we introduce an additional setting in the celery env)

Solution 1 is probably might break consumers of the 'standard' signals.csv.
I choose solution 2 to create a separate file. Would this work?