### PR TITLE
fix bug in history endpoint

### DIFF
--- a/api/app/signals/apps/api/v1/views/signal.py
+++ b/api/app/signals/apps/api/v1/views/signal.py
@@ -24,7 +24,7 @@ from signals.apps.api.v1.serializers import (
     SignalGeoSerializer
 )
 from signals.apps.api.v1.views._base import PublicSignalGenericViewSet
-from signals.apps.signals.models import History, Signal
+from signals.apps.signals.models import Signal
 from signals.auth.backend import JWTAuthBackend
 
 
@@ -136,9 +136,10 @@ class PrivateSignalViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, Dat
                 )
 
     @action(detail=True, url_path=r'history/?$')
-    def history(self, request, pk=None):
+    def history(self, *args, **kwargs):
         """History endpoint filterable by action."""
-        history_entries = History.objects.filter(_signal__id=pk)
+        signal = self.get_object()
+        history_entries = signal.history.all()
         what = self.request.query_params.get('what', None)
         if what:
             history_entries = history_entries.filter(what=what)

--- a/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
@@ -273,8 +273,6 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         # SIA should not show 2 entries because the Signal was split instead of "opgedeeld"
         self.assertEqual(len(data), 0)
 
-    @skip('TODO: This issue should be fixed. It is now possible to see the history of a Signal without the correct '
-          'permissions')
     def test_history_no_permissions(self):
         """
         The sia_read_user does not have a link with any department and also is not configured with the permission
@@ -287,8 +285,6 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         response = self.client.get(self.detail_endpoint.format(pk=self.signal_no_image.id))
         self.assertEqual(response.status_code, 403)
 
-        # TODO: Fix this issue, it is possible now that a user cannot see any details of a Signal BUT CAN access the
-        #       history of that Signal. This should not be possible!
         response = self.client.get(self.history_endpoint.format(pk=self.signal_no_image.id))
         self.assertEqual(response.status_code, 403)
 


### PR DESCRIPTION
## Description

Fixed bug in history that made it possible to view history of Signals that a user cannot access

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
