### PR TITLE
Make JWKS setting secure by default

### DIFF
--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -236,7 +236,7 @@ JWKS_TEST_KEY = """
 """
 
 SIGNALS_AUTHZ = {
-    'JWKS': os.getenv('PUB_JWKS', JWKS_TEST_KEY),
+    'JWKS': os.getenv('PUB_JWKS'),
     'JWKS_URL': os.getenv('JWKS_URL'),
     'USER_ID_FIELDS': os.getenv('USER_ID_FIELDS', 'sub').split(','),
     'ALWAYS_OK': False,

--- a/api/app/signals/settings/development.py
+++ b/api/app/signals/settings/development.py
@@ -8,6 +8,7 @@ ALLOWED_HOSTS = ['*']
 EMAIL_BACKEND = os.getenv('EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend')
 
 SIGNALS_AUTHZ = {
+    'JWKS': JWKS_TEST_KEY,  # noqa
     'JWKS_URL': os.getenv('JWKS_URL', 'http://dex:5556/keys'),
     'ALWAYS_OK': os.getenv('ALWAYS_OK', 'False') in ['True', 'true', '1'],
     'USER_ID_FIELDS': os.getenv('USER_ID_FIELDS', 'email').split(',')


### PR DESCRIPTION
## Description

The application currently implicitly trusts an insecure testing key when the `PUB_JWKS` setting is not set. This could easily lead to insecure behavior when system administrators forget to set `PUB_JWKS`.

This PR fixes this implicit behavior and only loads the JWKS testing key during development and testing.