### PR TITLE
SIG-3499 resize and base64 encode images in PDF

### DIFF
--- a/api/app/signals/apps/signals/factories/__init__.py
+++ b/api/app/signals/apps/signals/factories/__init__.py
@@ -1,5 +1,5 @@
 from .area import AreaFactory, AreaTypeFactory
-from .attachment import ImageAttachmentFactory
+from .attachment import AttachmentFactory, ImageAttachmentFactory
 from .category import CategoryFactory, ParentCategoryFactory
 from .category_assignment import CategoryAssignmentFactory
 from .department import DepartmentFactory
@@ -22,6 +22,7 @@ from .type import TypeFactory
 __all__ = [
     'AreaFactory',
     'AreaTypeFactory',
+    'AttachmentFactory',
     'CategoryAssignmentFactory',
     'CategoryFactory',
     'ImageAttachmentFactory',

--- a/api/app/signals/apps/signals/factories/attachment.py
+++ b/api/app/signals/apps/signals/factories/attachment.py
@@ -1,17 +1,16 @@
 from factory import DjangoModelFactory, Sequence, SubFactory, post_generation
-from factory.django import ImageField
+from factory.django import FileField, ImageField
 
 from signals.apps.signals.models import Attachment
 
 
-class ImageAttachmentFactory(DjangoModelFactory):
-
+class AttachmentFactory(DjangoModelFactory):
     class Meta:
         model = Attachment
 
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory')
     created_by = Sequence(lambda n: 'veelmelder{}@example.com'.format(n))
-    file = ImageField()  # In reality it's a FileField, but we want to force an image
+    file = FileField()
     is_image = True
 
     @post_generation
@@ -19,3 +18,7 @@ class ImageAttachmentFactory(DjangoModelFactory):
         self.signal = self._signal
         self.is_image = True
         self.save()
+
+
+class ImageAttachmentFactory(AttachmentFactory):
+    file = ImageField()  # In reality it's a FileField, but we want to force an image

--- a/api/app/signals/apps/signals/factories/attachment.py
+++ b/api/app/signals/apps/signals/factories/attachment.py
@@ -11,7 +11,6 @@ class AttachmentFactory(DjangoModelFactory):
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory')
     created_by = Sequence(lambda n: 'veelmelder{}@example.com'.format(n))
     file = FileField()
-    is_image = True
 
     @post_generation
     def set_one_to_one_relation(self, create, extracted, **kwargs):
@@ -22,3 +21,4 @@ class AttachmentFactory(DjangoModelFactory):
 
 class ImageAttachmentFactory(AttachmentFactory):
     file = ImageField()  # In reality it's a FileField, but we want to force an image
+    is_image = True

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -561,6 +561,10 @@ DEFAULT_SIGNAL_AREA_TYPE = os.getenv('DEFAULT_SIGNAL_AREA_TYPE', 'district')
 # app.
 API_PDF_LOGO_STATIC_FILE = os.getenv('API_PDF_LOGO_STATIC_FILE', 'api/logo-gemeente-amsterdam.svg')
 
+# Large images are resized to max dimension of `API_PDF_RESIZE_IMAGES_TO`
+# along the largest side, aspect ratio is maintained.
+API_PDF_RESIZE_IMAGES_TO = 800
+
 # Enable public map geo endpoint
 ENABLE_PUBLIC_GEO_SIGNAL_ENDPOINT = os.getenv('ENABLE_PUBLIC_GEO_SIGNAL_ENDPOINT', False) in TRUE_VALUES
 


### PR DESCRIPTION
## Description

This, currently draft, PR changes the PDF rendering to work around a GDK-pixbuf bug that renders some JPGs unusable. We pass images through PIL and resize (if they are large), base64 encode them and include them in the PDF. The attachments are now accessed through the `default_storage`.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
