### PR TITLE
fix/test-email-address-formatting

### DIFF
--- a/api/app/tests/apps/email_integrations/reporter/test_email_templates_address_formating.py
+++ b/api/app/tests/apps/email_integrations/reporter/test_email_templates_address_formating.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.reporter.mail_actions import SIGNAL_MAIL_RULES, MailActions
-from signals.apps.signals.factories import SignalFactoryValidLocation
+from signals.apps.signals.factories import SignalFactory
 from tests.apps.signals.valid_locations import STADHUIS
 
 
@@ -23,7 +23,7 @@ class TestEmailTemplateAddressFormatting(TestCase):
         longitude = valid_location.pop('lon')
         latitude = valid_location.pop('lat')
 
-        signal = SignalFactoryValidLocation.create(
+        signal = SignalFactory.create(
             reporter__email='test@example.com',
             location__geometrie=Point(longitude, latitude),
             location__buurt_code=valid_location.pop('buurt_code'),


### PR DESCRIPTION
## Description

Use SignalFactory instead of the SignalFactoryValidLocation. The SignalFactoryValidLocation uses the ValidLocationFactory which is using post_generation to override the location with a random choice from the VALID_LOCATIONS

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
