### PR TITLE
SIG-2680 Expose setting for maximum allowed size for an attachment

### DIFF
--- a/api/app/signals/apps/api/v1/serializers/attachment.py
+++ b/api/app/signals/apps/api/v1/serializers/attachment.py
@@ -1,8 +1,8 @@
 from datapunt_api.rest import DisplayField, HALSerializer
+from django.conf import settings
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from signals.apps.api.app_settings import SIGNALS_API_MAX_UPLOAD_SIZE
 from signals.apps.api.v1.fields import (
     PrivateSignalAttachmentLinksField,
     PublicSignalAttachmentLinksField
@@ -45,8 +45,8 @@ class SignalAttachmentSerializer(HALSerializer):
         return attachment
 
     def validate_file(self, file):
-        if file.size > SIGNALS_API_MAX_UPLOAD_SIZE:
-            msg = f'Bestand mag maximaal {SIGNALS_API_MAX_UPLOAD_SIZE} bytes groot zijn.'
+        if file.size > settings.API_MAX_UPLOAD_SIZE:
+            msg = f'Bestand mag maximaal {settings.API_MAX_UPLOAD_SIZE} bytes groot zijn.'
             raise ValidationError(msg)
         return file
 

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -565,6 +565,9 @@ API_PDF_LOGO_STATIC_FILE = os.getenv('API_PDF_LOGO_STATIC_FILE', 'api/logo-gemee
 # along the largest side, aspect ratio is maintained.
 API_PDF_RESIZE_IMAGES_TO = 800
 
+# Maximum size for attachments
+API_MAX_UPLOAD_SIZE = os.getenv('API_MAX_UPLOAD_SIZE', 8388608)  # 8MB = 8*1024*1024
+
 # Enable public map geo endpoint
 ENABLE_PUBLIC_GEO_SIGNAL_ENDPOINT = os.getenv('ENABLE_PUBLIC_GEO_SIGNAL_ENDPOINT', False) in TRUE_VALUES
 


### PR DESCRIPTION
## Description

Introduce `API_MAX_UPLOAD_SIZE` in project settings and allow it to be overridden through an environment variable.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
