### PR TITLE
fix/bug-in-AddressFormatter

### DIFF
--- a/api/app/signals/apps/signals/utils/location.py
+++ b/api/app/signals/apps/signals/utils/location.py
@@ -58,31 +58,32 @@ class AddressFormatter:
         """
         Openbare ruimte
         """
-        return self.address['openbare_ruimte'] if 'openbare_ruimte' in self.address else ''
+        return self.address['openbare_ruimte'] if self.address and 'openbare_ruimte' in self.address else ''
 
     def h(self):
         """
         Huisnummer
         """
-        return self.address['huisnummer'] if 'huisnummer' in self.address else ''
+        return self.address['huisnummer'] if self.address and 'huisnummer' in self.address else ''
 
     def l(self):  # noqa E743
         """
         Huisletter
         """
-        return self.address['huisletter'] if 'huisletter' in self.address else ''
+        return self.address['huisletter'] if self.address and 'huisletter' in self.address else ''
 
     def t(self):
         """
         Huisnummer toevoeging  without a hyphen
         """
-        return self.address['huisnummer_toevoeging'] if 'huisnummer_toevoeging' in self.address else ''
+        return self.address['huisnummer_toevoeging'] if self.address and 'huisnummer_toevoeging' in self.address else ''
 
     def T(self):  # noqa E743
         """
         Huisnummer toevoeging with a hyphen
         """
-        if 'huisnummer_toevoeging' in self.address and len(self.address['huisnummer_toevoeging'].strip()) > 0:
+        if self.address and 'huisnummer_toevoeging' in self.address \
+                and len(self.address['huisnummer_toevoeging'].strip()) > 0:
             return f'-{self.address["huisnummer_toevoeging"]}'
         else:
             return ''
@@ -92,20 +93,21 @@ class AddressFormatter:
         Postcode without a space between the digits and the characters
         """
         # Returns a postal code in the following format "1234AA"
-        return self.address['postcode'] if 'postcode' in self.address else ''
+        return self.address['postcode'] if self.address and 'postcode' in self.address else ''
 
     def P(self):  # noqa E743
         """
         Postcode with a space between the digits and the characters
         """
         # Returns a postal code in the following format "1234 AA"
-        return str(re.sub('(^[0-9]+)', r' \1 ', self.address['postcode'])).strip() if 'postcode' in self.address else ''
+        return str(re.sub('(^[0-9]+)', r' \1 ', self.address['postcode'])).strip() \
+            if self.address and 'postcode' in self.address else ''
 
     def W(self):  # noqa E743
         """
         Woonplaats
         """
-        return self.address['woonplaats'] if 'woonplaats' in self.address else ''
+        return self.address['woonplaats'] if self.address and 'woonplaats' in self.address else ''
 
     def format(self, format_str):
         formatted_string = []

--- a/api/app/tests/apps/signals/test_utils.py
+++ b/api/app/tests/apps/signals/test_utils.py
@@ -100,3 +100,8 @@ class TestAddressFormatter(TransactionTestCase):
 
         formatted_address_str = address_formatter.format(format_str='Z')
         self.assertEqual(formatted_address_str, 'Z')
+
+    def test_address_none_type(self):
+        address_formatter = AddressFormatter(address=None)
+        formatted_address_str = address_formatter.format(format_str='O')
+        self.assertEqual(formatted_address_str, '')

--- a/api/app/tests/apps/signals/test_utils.py
+++ b/api/app/tests/apps/signals/test_utils.py
@@ -103,5 +103,27 @@ class TestAddressFormatter(TransactionTestCase):
 
     def test_address_none_type(self):
         address_formatter = AddressFormatter(address=None)
+
         formatted_address_str = address_formatter.format(format_str='O')
+        self.assertEqual(formatted_address_str, '')
+
+        formatted_address_str = address_formatter.format(format_str='h')
+        self.assertEqual(formatted_address_str, '')
+
+        formatted_address_str = address_formatter.format(format_str='l')
+        self.assertEqual(formatted_address_str, '')
+
+        formatted_address_str = address_formatter.format(format_str='t')
+        self.assertEqual(formatted_address_str, '')
+
+        formatted_address_str = address_formatter.format(format_str='T')
+        self.assertEqual(formatted_address_str, '')
+
+        formatted_address_str = address_formatter.format(format_str='p')
+        self.assertEqual(formatted_address_str, '')
+
+        formatted_address_str = address_formatter.format(format_str='P')
+        self.assertEqual(formatted_address_str, '')
+
+        formatted_address_str = address_formatter.format(format_str='W')
         self.assertEqual(formatted_address_str, '')


### PR DESCRIPTION
## Description

Added additional check to the functions in the AddressFormatter to prevent the error "TypeError: argument of type NoneType is not iterable"

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
