### PR TITLE
fix/SIG-3511

### DIFF
--- a/api/app/tests/apps/signals/test_models.py
+++ b/api/app/tests/apps/signals/test_models.py
@@ -676,6 +676,39 @@ class TestAttachmentModel(LiveServerTestCase):
         resp = requests.get(self.live_server_url + attachment.file.url)
         self.assertEqual(200, resp.status_code, "Original file is not reachable")
 
+    def test_is_image_gif(self):
+        attachment = Attachment()
+        attachment.file = self.gif_upload
+        attachment._signal = self.signal
+        attachment.mimetype = "image/gif"
+        attachment.save()
+
+        self.assertTrue(attachment.is_image)
+
+    def test_is_image_doc_provided(self):
+        with open(self.doc_upload_location, "rb") as f:
+            doc_upload = SimpleUploadedFile("file.doc", f.read(), content_type="application/msword")
+
+            attachment = Attachment()
+            attachment.file = doc_upload
+            attachment.mimetype = "application/msword"
+            attachment._signal = self.signal
+            attachment.save()
+
+            self.assertFalse(attachment.is_image)
+
+    def test_is_image_doc_renamed_to_gif(self):
+        with open(self.doc_upload_location, "rb") as f:
+            doc_upload = SimpleUploadedFile("file.gif", f.read(), content_type="application/msword")
+
+            attachment = Attachment()
+            attachment.file = doc_upload
+            attachment.mimetype = "application/msword"
+            attachment._signal = self.signal
+            attachment.save()
+
+            self.assertFalse(attachment.is_image)
+
 
 class TestCategoryTranslation(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

Replaced the use of imghdr with PIL to recognise if a file is an image

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Documentation has been updated if needed
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
