### PR TITLE
feature/SIG-3488

### DIFF
--- a/api/app/signals/apps/api/v1/serializers/signal.py
+++ b/api/app/signals/apps/api/v1/serializers/signal.py
@@ -577,6 +577,8 @@ class AbridgedChildSignalSerializer(HALSerializer):
     status = serializers.SerializerMethodField()
     category = serializers.SerializerMethodField()
 
+    can_view_signal = serializers.SerializerMethodField()
+
     class Meta:
         model = Signal
         fields = (
@@ -585,6 +587,7 @@ class AbridgedChildSignalSerializer(HALSerializer):
             'status',
             'category',
             'updated_at',
+            'can_view_signal'
         )
 
     def get_status(self, obj):
@@ -606,3 +609,6 @@ class AbridgedChildSignalSerializer(HALSerializer):
             'main': obj.category_assignment.category.parent.name,
             'main_slug': obj.category_assignment.category.parent.slug,
         }
+
+    def get_can_view_signal(self, obj):
+        return Signal.objects.filter(pk=obj.pk).filter_for_user(self.context['request'].user).exists()


### PR DESCRIPTION
## Description

SIG-3488 Added a flag to the children endpoint response that indicates if a signal can be read by the current user

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
