### PR TITLE
feature/SIG-3545

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -812,7 +812,7 @@ paths:
       - OAuth2:
         - SIG/ALL
 
-  /signals/v1/private/signals/promoted/parent:
+  /signals/v1/private/signals/promoted:
     get:
       description: >-
         Signals that became a Parent are listed here.
@@ -820,7 +820,7 @@ paths:
       parameters:
         - name: after
           in: query
-          description: Timestamp after which dropped signals are to found.
+          description: Timestamp after which promoted signals are to be found.
           schema:
             type: string
       responses:

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -812,6 +812,24 @@ paths:
       - OAuth2:
         - SIG/ALL
 
+  /signals/v1/private/signals/promoted/parent:
+    get:
+      description: >-
+        Signals that became a Parent are listed here.
+        **URL may be changed**
+      parameters:
+        - name: after
+          in: query
+          description: Timestamp after which dropped signals are to found.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of Signal ID's.
+      security:
+        - OAuth2:
+            - SIG/ALL
+
   /signals/v1/private/categories/:
     get:
       description: List of all categories available in the system

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -812,7 +812,7 @@ paths:
       - OAuth2:
         - SIG/ALL
 
-  /signals/v1/private/signals/promoted:
+  /signals/v1/private/signals/promoted/parent:
     get:
       description: >-
         Signals that became a Parent are listed here.

--- a/api/app/signals/apps/api/v1/filters/__init__.py
+++ b/api/app/signals/apps/api/v1/filters/__init__.py
@@ -1,7 +1,11 @@
 from signals.apps.api.v1.filters.area import AreaFilterSet
 from signals.apps.api.v1.filters.department import DepartmentFilterSet
 from signals.apps.api.v1.filters.question import QuestionFilterSet
-from signals.apps.api.v1.filters.signal import SignalCategoryRemovedAfterFilterSet, SignalFilterSet
+from signals.apps.api.v1.filters.signal import (
+    SignalCategoryRemovedAfterFilterSet,
+    SignalFilterSet,
+    SignalPromotedToParentFilter
+)
 from signals.apps.api.v1.filters.utils import (
     _get_child_category_queryset,
     _get_parent_category_queryset,
@@ -27,6 +31,7 @@ __all__ = [
     'QuestionFilterSet',
     'SignalCategoryRemovedAfterFilterSet',
     'SignalFilterSet',
+    'SignalPromotedToParentFilter',
 
     # Util functions
     'area_code_choices',

--- a/api/app/signals/apps/api/v1/urls.py
+++ b/api/app/signals/apps/api/v1/urls.py
@@ -99,7 +99,7 @@ urlpatterns = [
         re_path(r'signals/category/removed/?$', SignalCategoryRemovedAfterViewSet.as_view({'get': 'list'}),
                 name='signal-category-changed-since'),
 
-        re_path(r'signals/promoted/?$', SignalPromotedToParentViewSet.as_view({'get': 'list'}),
+        re_path(r'signals/promoted/parent/?$', SignalPromotedToParentViewSet.as_view({'get': 'list'}),
                 name='signal-became-parent-since'),
 
         # Search

--- a/api/app/signals/apps/api/v1/urls.py
+++ b/api/app/signals/apps/api/v1/urls.py
@@ -20,6 +20,7 @@ from signals.apps.api.v1.views import (  # MLPredictCategoryView,  # V1 disabled
     PublicSignalListViewSet,
     PublicSignalViewSet,
     SignalCategoryRemovedAfterViewSet,
+    SignalPromotedToParentViewSet,
     StatusMessageTemplatesViewSet,
     StoredSignalFilterViewSet
 )
@@ -97,6 +98,9 @@ urlpatterns = [
         re_path(r'signals/(?P<pk>\d+)/pdf/?$', GeneratePdfView.as_view(), name='signal-pdf-download'),
         re_path(r'signals/category/removed/?$', SignalCategoryRemovedAfterViewSet.as_view({'get': 'list'}),
                 name='signal-category-changed-since'),
+
+        re_path(r'signals/promoted/parent/?$', SignalPromotedToParentViewSet.as_view({'get': 'list'}),
+                name='signal-became-parent-since'),
 
         # Search
         re_path('search/?$', SearchView.as_view({'get': 'list'}), name='elastic-search'),

--- a/api/app/signals/apps/api/v1/urls.py
+++ b/api/app/signals/apps/api/v1/urls.py
@@ -99,7 +99,7 @@ urlpatterns = [
         re_path(r'signals/category/removed/?$', SignalCategoryRemovedAfterViewSet.as_view({'get': 'list'}),
                 name='signal-category-changed-since'),
 
-        re_path(r'signals/promoted/parent/?$', SignalPromotedToParentViewSet.as_view({'get': 'list'}),
+        re_path(r'signals/promoted/?$', SignalPromotedToParentViewSet.as_view({'get': 'list'}),
                 name='signal-became-parent-since'),
 
         # Search

--- a/api/app/signals/apps/api/v1/views/__init__.py
+++ b/api/app/signals/apps/api/v1/views/__init__.py
@@ -19,7 +19,8 @@ from signals.apps.api.v1.views.questions import PublicQuestionViewSet
 from signals.apps.api.v1.views.signal import (
     PrivateSignalViewSet,
     PublicSignalListViewSet,
-    PublicSignalViewSet
+    PublicSignalViewSet,
+    SignalPromotedToParentViewSet
 )
 from signals.apps.api.v1.views.source import PrivateSourcesViewSet
 from signals.apps.api.v1.views.status_message_template import StatusMessageTemplatesViewSet
@@ -32,6 +33,7 @@ __all__ = (
     'PublicSignalListViewSet',
     'PrivateSignalViewSet',
     'SignalCategoryRemovedAfterViewSet',
+    'SignalPromotedToParentViewSet',
     'PrivateCategoryViewSet',
     'PrivateCsvViewSet',
     'PublicQuestionViewSet',

--- a/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
@@ -1164,7 +1164,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
             self.assertEqual(data['count'], 0)
 
     def test_signal_promoted_to_parent(self):
-        response = self.client.get(f'{self.list_endpoint}promoted/', format='json')
+        response = self.client.get(f'{self.list_endpoint}promoted/parent/', format='json')
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -1175,7 +1175,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         signal = SignalFactory.create()
         SignalFactory.create(parent=signal)
 
-        response = self.client.get(f'{self.list_endpoint}promoted/', format='json')
+        response = self.client.get(f'{self.list_endpoint}promoted/parent/', format='json')
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -1198,7 +1198,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         with freeze_time(timezone.now() - timedelta(hours=6)):
             SignalFactory.create(parent=signal)
 
-        response = self.client.get(f'{self.list_endpoint}promoted/',
+        response = self.client.get(f'{self.list_endpoint}promoted/parent/',
                                    data={'after': after.isoformat()},
                                    format='json')
         self.assertEqual(response.status_code, 200)
@@ -1215,7 +1215,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
             signal = SignalFactory.create()
 
         after = timezone.now() - timedelta(hours=12)
-        response = self.client.get(f'{self.list_endpoint}promoted/',
+        response = self.client.get(f'{self.list_endpoint}promoted/parent/',
                                    data={'after': after.isoformat()},
                                    format='json')
         self.assertEqual(response.status_code, 200)
@@ -1226,7 +1226,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         with freeze_time(timezone.now() - timedelta(hours=6)):
             SignalFactory.create(parent=signal)
 
-        response = self.client.get(f'{self.list_endpoint}promoted/',
+        response = self.client.get(f'{self.list_endpoint}promoted/parent/',
                                    data={'after': after.isoformat()},
                                    format='json')
         self.assertEqual(response.status_code, 200)

--- a/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
@@ -1164,7 +1164,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
             self.assertEqual(data['count'], 0)
 
     def test_signal_promoted_to_parent(self):
-        response = self.client.get(f'{self.list_endpoint}promoted/parent/', format='json')
+        response = self.client.get(f'{self.list_endpoint}promoted/', format='json')
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -1175,7 +1175,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         signal = SignalFactory.create()
         SignalFactory.create(parent=signal)
 
-        response = self.client.get(f'{self.list_endpoint}promoted/parent/', format='json')
+        response = self.client.get(f'{self.list_endpoint}promoted/', format='json')
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
@@ -1198,7 +1198,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         with freeze_time(timezone.now() - timedelta(hours=6)):
             SignalFactory.create(parent=signal)
 
-        response = self.client.get(f'{self.list_endpoint}promoted/parent/',
+        response = self.client.get(f'{self.list_endpoint}promoted/',
                                    data={'after': after.isoformat()},
                                    format='json')
         self.assertEqual(response.status_code, 200)
@@ -1215,7 +1215,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
             signal = SignalFactory.create()
 
         after = timezone.now() - timedelta(hours=12)
-        response = self.client.get(f'{self.list_endpoint}promoted/parent/',
+        response = self.client.get(f'{self.list_endpoint}promoted/',
                                    data={'after': after.isoformat()},
                                    format='json')
         self.assertEqual(response.status_code, 200)
@@ -1226,7 +1226,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         with freeze_time(timezone.now() - timedelta(hours=6)):
             SignalFactory.create(parent=signal)
 
-        response = self.client.get(f'{self.list_endpoint}promoted/parent/',
+        response = self.client.get(f'{self.list_endpoint}promoted/',
                                    data={'after': after.isoformat()},
                                    format='json')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Description

Added endpoint that gives the ID's of Signals that became a parent (filtered after a certain date). Only ID's of Signals that a user can access are returned

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Documentation has been updated if needed
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
