### PR TITLE
feature/SIG-3491

### DIFF
--- a/api/app/signals/apps/signals/migrations/0133_new_subcategories.py
+++ b/api/app/signals/apps/signals/migrations/0133_new_subcategories.py
@@ -1,0 +1,78 @@
+"""
+Category changes SIG-3491
+
+New subcategories for 'Onderhoud fietspad' and 'Put / Riool kapot'
+"""
+from django.db import migrations
+
+# SIG-3491
+NEW_CATEGORIES = {
+    'wegen-verkeer-straatmeubilair': {
+        'onderhoud-fietspad': {
+            'name': 'Onderhoud fietspad',
+            'description': 'Verzakkingen in/van fietspad, missende tegels, wortelopdruk in het fietspad, scheuren in '
+                           'fietspad',
+            'handling': 'A3DEC',
+            'handling_message':
+                'Wij handelen uw melding binnen een week af. '
+                'Als u een mailadres hebt opgegeven, zullen we u op de hoogte houden.',
+            'departments': ['STW'],
+            'slo': '5W',
+        },
+        'put-riool-kapot': {
+            'name': 'Put / Riool kapot',
+            'description': 'Meldingen die betrekking hebben op een kapotte kolk en riolering.',
+            'handling': 'A3DEC',
+            'handling_message':
+                'Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt '
+                'afgehandeld.  Als u een mailadres hebt opgegeven, zullen we u op de hoogte houden.',
+            'departments': ['STW'],
+            'slo': '5W',
+        }
+    }
+}
+
+
+def _new_categories(apps, schema_editor):
+    Category = apps.get_model('signals', 'Category')
+    Department = apps.get_model('signals', 'Department')
+    ServiceLevelObjective = apps.get_model('signals', 'ServiceLevelObjective')
+
+    for main_category_slug, data in NEW_CATEGORIES.items():
+        try:
+            main_category = Category.objects.get(slug=main_category_slug, parent__isnull=True)
+
+            for category_slug, category_data in data.items():
+                category = Category.objects.create(name=category_slug, parent=main_category)  # noqa Using the slug as name to ensure the slug is correctly created
+
+                category.name = category_data['name']
+                category.description = category_data['description']
+                category.handling = category_data['handling']
+                category.handling_message = category_data['handling_message']
+
+                responsible_deps = Department.objects.filter(code__in=category_data['departments'])
+                category.departments.add(*responsible_deps, through_defaults={'is_responsible': True, 'can_view': True})
+                # all departments have visibility on these categories, hence:
+                can_view_deps = Department.objects.exclude(code__in=category_data['departments'])
+                category.departments.add(*can_view_deps, through_defaults={'is_responsible': False, 'can_view': True})
+
+                n_days = int(category_data['slo'][:-1])
+                use_calendar_days = True if category_data['slo'][-1] == 'K' else False
+
+                ServiceLevelObjective.objects.create(category=category, n_days=n_days,
+                                                     use_calendar_days=use_calendar_days)
+
+                category.save()
+        except Category.DoesNotExist:
+            # don't fail if category does not exists
+            pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('signals', '0132_signaluser_HISTORY'),
+    ]
+
+    operations = [
+        migrations.RunPython(_new_categories, None),  # No reverse possible
+    ]

--- a/api/app/tests/apps/api/v1/test_private_category_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_private_category_endpoint.py
@@ -90,8 +90,8 @@ class TestPrivateCategoryEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         data = response.json()
-        self.assertEqual(data['count'], 167)
-        self.assertEqual(len(data['results']), 167)
+        self.assertEqual(data['count'], 169)
+        self.assertEqual(len(data['results']), 169)
 
     def test_get_parent_category(self):
         self.client.force_authenticate(user=self.sia_read_write_user)


### PR DESCRIPTION
## Description

SIG-3491 added 2 new sub categories "Onderhoud fietspad" and "Put / Riool kapot"

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
