### PR TITLE
Add DataDog Tracing package

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -16,6 +16,7 @@ coreschema==0.0.4
 coverage==5.0.3
 cryptography==3.3.2
 cssselect2==0.2.2
+ddtrace==0.46.0
 debtcollector==2.0.0
 defusedxml==0.6.0
 distlib==0.3.1

--- a/api/requirements/req-base.txt
+++ b/api/requirements/req-base.txt
@@ -37,6 +37,9 @@ Celery
 # Sentry
 raven
 
+# DataDog Tracing
+ddtrace
+
 # PDF
 lxml
 WeasyPrint

--- a/docs/topics/application-design.md
+++ b/docs/topics/application-design.md
@@ -175,6 +175,10 @@ SIA uses Sentry to track application errors. SIA HTTP traffic is logged in the
 general Datapunt logging as well, because SIA is running on Datapunt
 infrastructure.
 
+Also DataDog can also be used to track application errors. To enable [ddtrace]
+(https://ddtrace.readthedocs.io/) configure the environment variable
+`DD_AGENT_HOST` to the DataDog agent and override the run command:
 
-
-
+```bash
+ddtrace-run uwsgi ...
+```

--- a/docs/topics/application-design.md
+++ b/docs/topics/application-design.md
@@ -180,5 +180,5 @@ Also DataDog can also be used to track application errors. To enable [ddtrace]
 `DD_AGENT_HOST` to the DataDog agent and override the run command:
 
 ```bash
-ddtrace-run uwsgi ...
+ddtrace-run uwsgi --enable-threads ...
 ```


### PR DESCRIPTION
## Description

This PR adds the [ddtrace](https://ddtrace.readthedocs.io/en/stable/) package that enables us to use [DataDog Tracing](https://docs.datadoghq.com/tracing/python/). The package can be enabled by overriding the startup command of the container:

```bash
ddtrace-run uwsgi ...
```

## Checklist

- [x] Documentation has been updated if needed

Closes Signalen/backend#122