### PR TITLE
The "view_user" permission is now mandatory to view information on the "/v1/private/users/" endpoint

### DIFF
--- a/api/app/signals/apps/api/generics/permissions.py
+++ b/api/app/signals/apps/api/generics/permissions.py
@@ -123,12 +123,12 @@ class SignalViewObjectPermission(DjangoModelPermissions):
         if request.user.is_superuser or request.user.has_perm('signals.sia_can_view_all_categories'):  # noqa
             return True
 
-        read_permisson = (
+        read_permission = (
             self.permission_service.has_permission_via_category(request.user, obj) or
             self.permission_service.has_permission_via_routing(request.user, obj)
         )
 
-        return read_permisson and request.user.has_perm('signals.sia_read')
+        return read_permission and request.user.has_perm('signals.sia_read')
 
 
 class SIAReportPermissions(SIABasePermission):
@@ -136,4 +136,16 @@ class SIAReportPermissions(SIABasePermission):
         'GET': ['signals.sia_read', 'signals.sia_signal_report'],
         'OPTIONS': [],
         'HEAD': []
+    }
+
+
+class SIAUserPermissions(SIABasePermission):
+    perms_map = {
+        'GET': ['signals.sia_read', 'auth.view_user'],
+        'OPTIONS': [],
+        'HEAD': [],
+        'POST': ['signals.sia_write', 'auth.add_user'],
+        'PUT': ['signals.sia_write', 'auth.change_user'],
+        'PATCH': ['signals.sia_write', 'auth.change_user'],
+        'DELETE': ['signals.sia_write', 'auth.delete_user'],
     }

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -1263,7 +1263,6 @@ paths:
       - OAuth2:
           - SIG/ALL
 
-
   /signals/v1/private/areas/geography/:
     get:
       description: Retrieve a list of areas in the database. Experimental, the content of the response can still be changed
@@ -1472,6 +1471,33 @@ paths:
                 $ref: '#/components/schemas/V1SourceList'
         '404':
           description: Not Found.
+
+  /signals/v1/private/autocomplete/usernames/:
+    get:
+      description: Retrieve list of usernames filtered on username.
+      parameters:
+        - name: "username"
+          in: query
+          description: Filter by username, allows partial matches (must be at least 3 characters long)
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: List of usernames.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/privateUsernameListResponse'
+        '400':
+           description: Filter username not provided or filter username too short.
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Not authorized to access this endpoint.
+      security:
+        - OAuth2:
+            - SIG/ALL
 
 components:
   schemas:
@@ -2915,6 +2941,49 @@ components:
             $ref: '#/components/schemas/privateNestedPermissionResponse'
         profile:
            $ref: '#/components/schemas/privateNestedProfileResponse'
+
+    privateUsernameListResponse:
+      description: JSON serialization of paginated list of SIA users.
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              type: object
+              properties:
+                href:
+                  type: string
+                  description: URI of current page
+            next:
+              type: object
+              properties:
+                href:
+                  type: string
+                  description: URI of the next page in SIA users list (null) if not available
+            previous:
+              type: object
+              properties:
+                href:
+                  type: string
+                  description: URI of the previous page in SIA users list (null) if not available
+        count:
+          type: integer
+          description: Total count of results for the request
+        results:
+          type: array
+          description: A list of categories, paginated
+          items:
+            $ref: '#/components/schemas/privateNestedUsernameResponse'
+
+    privateNestedUsernameResponse:
+      description: JSON serialization of a SIA username.
+      type: object
+      properties:
+        username:
+          description: Username
+          type: string
+          format: email
 
     V1PrivateSignalchildrenGet:
       description: >-

--- a/api/app/signals/apps/api/v1/urls.py
+++ b/api/app/signals/apps/api/v1/urls.py
@@ -29,6 +29,7 @@ from signals.apps.api.v1.views import (
 from signals.apps.feedback.views import FeedbackViewSet, StandardAnswerViewSet
 from signals.apps.search.views import SearchView
 from signals.apps.users.v1.views import (
+    AutocompleteUsernameListView,
     LoggedInUserView,
     PermissionViewSet,
     RoleViewSet,
@@ -110,5 +111,9 @@ urlpatterns = [
         # Search
         re_path('search/?$', SearchView.as_view({'get': 'list'}), name='elastic-search'),
 
+        # Used for autocompletion
+        path('autocomplete/', include([
+            re_path('usernames/?$', AutocompleteUsernameListView.as_view(), name='autocomplete-usernames'),
+        ])),
     ])),
 ]

--- a/api/app/signals/apps/api/v1/urls.py
+++ b/api/app/signals/apps/api/v1/urls.py
@@ -28,7 +28,12 @@ from signals.apps.api.v1.views import (
 )
 from signals.apps.feedback.views import FeedbackViewSet, StandardAnswerViewSet
 from signals.apps.search.views import SearchView
-from signals.apps.users.v1.views import PermissionViewSet, RoleViewSet, UserViewSet
+from signals.apps.users.v1.views import (
+    LoggedInUserView,
+    PermissionViewSet,
+    RoleViewSet,
+    UserViewSet
+)
 
 # Public API
 public_router = SignalsRouterVersion1()
@@ -84,7 +89,7 @@ urlpatterns = [
     # Private additions
     path('v1/private/', include([
         # Returns the details of the currently logged in user
-        re_path('me/?$', UserViewSet.as_view({'get': 'me'}), name='auth-me'),
+        re_path('me/?$', LoggedInUserView.as_view(), name='auth-me'),
 
         # Get/Replace the status message templates per category
         re_path(r'terms/categories/(?P<slug>[-\w]+)/status-message-templates/?$',

--- a/api/app/signals/apps/users/v1/filters.py
+++ b/api/app/signals/apps/users/v1/filters.py
@@ -38,3 +38,11 @@ class UserFilterSet(FilterSet):
             'username': {'apply': Lower}  # Will apply the Lower function when ordering
         }
     )
+
+
+class UserNameListFilterSet(FilterSet):
+    username = filters.CharFilter(lookup_expr='icontains', min_length=3)
+    is_active = filters.BooleanFilter(field_name='is_active')
+    profile_department_code = filters.ModelMultipleChoiceFilter(queryset=_get_department_queryset(),
+                                                                to_field_name='code',
+                                                                field_name='profile__departments__code')

--- a/api/app/signals/apps/users/v1/serializers/__init__.py
+++ b/api/app/signals/apps/users/v1/serializers/__init__.py
@@ -3,7 +3,11 @@
 from signals.apps.users.v1.serializers.permission import PermissionSerializer
 from signals.apps.users.v1.serializers.profile import ProfileDetailSerializer, ProfileListSerializer
 from signals.apps.users.v1.serializers.role import RoleSerializer
-from signals.apps.users.v1.serializers.user import UserDetailHALSerializer, UserListHALSerializer
+from signals.apps.users.v1.serializers.user import (
+    UserDetailHALSerializer,
+    UserListHALSerializer,
+    UserNameListSerializer
+)
 
 __all__ = [
     'PermissionSerializer',
@@ -12,4 +16,5 @@ __all__ = [
     'RoleSerializer',
     'UserDetailHALSerializer',
     'UserListHALSerializer',
+    'UserNameListSerializer',
 ]

--- a/api/app/signals/apps/users/v1/serializers/user.py
+++ b/api/app/signals/apps/users/v1/serializers/user.py
@@ -177,3 +177,9 @@ class PrivateUserHistoryHalSerializer(serializers.ModelSerializer):
 
     def get_description(self, log):
         return None
+
+
+class UserNameListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('username', )

--- a/api/app/signals/apps/users/v1/views/__init__.py
+++ b/api/app/signals/apps/users/v1/views/__init__.py
@@ -2,10 +2,11 @@
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
 from signals.apps.users.v1.views.permission import PermissionViewSet
 from signals.apps.users.v1.views.role import RoleViewSet
-from signals.apps.users.v1.views.user import UserViewSet
+from signals.apps.users.v1.views.user import LoggedInUserView, UserViewSet
 
 __all__ = [
     'PermissionViewSet',
     'RoleViewSet',
     'UserViewSet',
+    'LoggedInUserView',
 ]

--- a/api/app/signals/apps/users/v1/views/__init__.py
+++ b/api/app/signals/apps/users/v1/views/__init__.py
@@ -2,11 +2,16 @@
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
 from signals.apps.users.v1.views.permission import PermissionViewSet
 from signals.apps.users.v1.views.role import RoleViewSet
-from signals.apps.users.v1.views.user import LoggedInUserView, UserViewSet
+from signals.apps.users.v1.views.user import (
+    AutocompleteUsernameListView,
+    LoggedInUserView,
+    UserViewSet
+)
 
 __all__ = [
     'PermissionViewSet',
     'RoleViewSet',
     'UserViewSet',
     'LoggedInUserView',
+    'AutocompleteUsernameListView',
 ]


### PR DESCRIPTION
## Description

The "view_user" and "sia_read" permissions are now mandatory to view users + refactored the "v1/private/me" endpoint to be in its own view + added tests

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
