### PR TITLE
SIG-3605 reimport of stadsdeel (wijk or buurt) data no longer fails

### DIFF
--- a/api/app/signals/apps/dataset/sources/gebieden.py
+++ b/api/app/signals/apps/dataset/sources/gebieden.py
@@ -105,6 +105,8 @@ class APIGebiedenLoader(AreaLoader):
         requests_session = self._get_session()
 
         with transaction.atomic():
+            Area.objects.filter(_type=self.area_type).delete()
+
             for detail_url in self._iterate_urls(requests_session, self.list_endpoint):
                 self._load_area_detail(requests_session, detail_url)
 


### PR DESCRIPTION
## Description

Reimporting stadsdeel, wijk or buurt data resulted in a database constraint being violated, that is now fixed. Behavior matches the other geo datasets that SIA uses.
