### PR TITLE
fixes assertion error on public map endpoint and filter out undesired status

### DIFF
--- a/api/app/signals/apps/api/v1/serializers/__init__.py
+++ b/api/app/signals/apps/api/v1/serializers/__init__.py
@@ -15,6 +15,7 @@ from signals.apps.api.v1.serializers.departments import (
     PrivateDepartmentSerializerDetail,
     PrivateDepartmentSerializerList
 )
+from signals.apps.api.v1.serializers.empty import PublicEmptySerializer
 from signals.apps.api.v1.serializers.expression import ExpressionContextSerializer
 from signals.apps.api.v1.serializers.question import PublicQuestionSerializerDetail
 from signals.apps.api.v1.serializers.signal import (
@@ -54,5 +55,6 @@ __all__ = [
     'PrivateCategorySerializer',
     'PublicQuestionSerializerDetail',
     'AbridgedChildSignalSerializer',
-    'ExpressionContextSerializer'
+    'ExpressionContextSerializer',
+    'PublicEmptySerializer'
 ]

--- a/api/app/signals/apps/api/v1/serializers/empty.py
+++ b/api/app/signals/apps/api/v1/serializers/empty.py
@@ -1,0 +1,5 @@
+from rest_framework import serializers
+
+
+class PublicEmptySerializer(serializers.Serializer):
+    pass

--- a/api/app/signals/apps/api/v1/views/signal.py
+++ b/api/app/signals/apps/api/v1/views/signal.py
@@ -24,6 +24,7 @@ from signals.apps.api.v1.serializers import (
     HistoryHalSerializer,
     PrivateSignalSerializerDetail,
     PrivateSignalSerializerList,
+    PublicEmptySerializer,
     PublicSignalCreateSerializer,
     PublicSignalSerializerDetail,
     SignalGeoSerializer,
@@ -59,6 +60,8 @@ class PublicSignalViewSet(PublicSignalGenericViewSet):
 
 
 class PublicSignalListViewSet(PublicSignalGenericViewSet):
+    serializer_class = PublicEmptySerializer
+
     # django-drf has too much overhead with these kinds of 'fast' request.
     # When implemented using django-drf, retrieving a large number of elements cost around 4s (profiled)
     # Using pgsql ability to generate geojson, the request time reduces to 30ms (> 130x speedup!)
@@ -93,7 +96,7 @@ class PublicSignalListViewSet(PublicSignalGenericViewSet):
             where
                 s.location_id = l.id
                 and s.status_id = status.id
-                and status.state not in ('{workflow.AFGEHANDELD}', '{workflow.AFGEHANDELD_EXTERN}')
+                and status.state not in ('{workflow.AFGEHANDELD}', '{workflow.AFGEHANDELD_EXTERN}', '{workflow.GEANNULEERD}', '{workflow.VERZOEK_TOT_HEROPENEN}') # noqa
             order by s.id desc
             limit 4000 offset 0
         ) as features

--- a/api/app/signals/apps/api/v1/views/signal.py
+++ b/api/app/signals/apps/api/v1/views/signal.py
@@ -96,11 +96,11 @@ class PublicSignalListViewSet(PublicSignalGenericViewSet):
             where
                 s.location_id = l.id
                 and s.status_id = status.id
-                and status.state not in ('{workflow.AFGEHANDELD}', '{workflow.AFGEHANDELD_EXTERN}', '{workflow.GEANNULEERD}', '{workflow.VERZOEK_TOT_HEROPENEN}') # noqa
+                and status.state not in ('{workflow.AFGEHANDELD}', '{workflow.AFGEHANDELD_EXTERN}', '{workflow.GEANNULEERD}', '{workflow.VERZOEK_TOT_HEROPENEN}')
             order by s.id desc
             limit 4000 offset 0
         ) as features
-        """
+        """ # noqa
 
         cursor = connection.cursor()
         try:


### PR DESCRIPTION
1) The public map endpoint bypasses DRF for serialization. But we are using bits of it. When accessing the endpoint via a browser an assertion error is shown. In order to solve this, an empty serializer has been added.

2) It's also undesirable to include the status VERZOEK_TOT_HEROPENEN and GEANNULEERD on the map

This PR addresses both issues