### PR TITLE
load_areas: check existing type using code only

### DIFF
--- a/api/app/signals/apps/dataset/sources/cbs.py
+++ b/api/app/signals/apps/dataset/sources/cbs.py
@@ -40,9 +40,8 @@ class CBSBoundariesLoader(ShapeBoundariesLoader):
         assert type_string in self.PROVIDES
 
         self.area_type, _ = AreaType.objects.get_or_create(
-            name=type_string,
             code=type_string,
-            description=f'{type_string} from CBS "Wijk- en buurtkaart" data.',
+            defaults={'name': type_string, 'description': f'{type_string} from CBS "Wijk- en buurtkaart" data.'}
         )
 
         dataset_info = self.DATASET_INFO[type_string]

--- a/api/app/signals/apps/dataset/sources/shape.py
+++ b/api/app/signals/apps/dataset/sources/shape.py
@@ -27,8 +27,7 @@ class ShapeBoundariesLoader(AreaLoader):
 
         self.area_type, _ = AreaType.objects.get_or_create(
             name=options['type'],
-            code=options['type'],
-            description=f"{options['type']} data",
+            defaults={'code': options['type'], 'description': f"{options['type']} data"}
         )
         self.directory = directory  # Data downloaded / processed here. Caller is responsible to clean-up directory.
         self.DATASET_URL = options['url']

--- a/api/app/signals/apps/dataset/sources/shape.py
+++ b/api/app/signals/apps/dataset/sources/shape.py
@@ -26,8 +26,8 @@ class ShapeBoundariesLoader(AreaLoader):
         assert type_string in self.PROVIDES
 
         self.area_type, _ = AreaType.objects.get_or_create(
-            name=options['type'],
-            defaults={'code': options['type'], 'description': f"{options['type']} data"}
+            code=options['type'],
+            defaults={'name': options['type'], 'description': f"{options['type']} data"}
         )
         self.directory = directory  # Data downloaded / processed here. Caller is responsible to clean-up directory.
         self.DATASET_URL = options['url']


### PR DESCRIPTION
When loading areas via manage.py load_areas, a get_or_create is used with all properties. When for example a description was changed, this would cause an error during import. We should get_or_create on code field only and supply the rest as defaults.