### PR TITLE
Bug/sig 3555 handling message wrong in signal history

### DIFF
--- a/api/app/signals/apps/signals/migrations/0136_categoryassignment_stored_handling_message_and_HISTORY.py
+++ b/api/app/signals/apps/signals/migrations/0136_categoryassignment_stored_handling_message_and_HISTORY.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+from django.db import migrations, models
+
+history_view = """
+DROP VIEW IF EXISTS "signals_history_view";
+CREATE VIEW "signals_history_view" AS
+    SELECT
+        CAST("identifier" AS varchar(255)),
+        _signal_id,
+        CAST("when" AS timestamptz),
+        CAST("what" AS varchar(255)),
+        CAST("who" AS varchar(255)),
+        CAST("extra" AS varchar(255)),
+        CAST("description" AS varchar(3000))  /* Most extreme case; the Note model's text field. */
+    FROM (
+        SELECT
+            CONCAT('UPDATE_STATUS_', CAST("s"."id" AS VARCHAR(255))) AS "identifier",
+            "s"."_signal_id" AS "_signal_id",
+            "s"."created_at" AS "when",
+            'UPDATE_STATUS' As "what",
+            "s"."user" AS "who",
+            "s"."state" AS "extra",
+            "s"."text" AS "description"
+        FROM
+            "public"."signals_status" AS "s"
+        UNION SELECT
+            CONCAT('UPDATE_PRIORITY_', CAST("p"."id" AS VARCHAR(255))) AS "identifier",
+            "p"."_signal_id" AS "_signal_id",
+            "p"."created_at" AS "when",
+            'UPDATE_PRIORITY' AS "what",
+            "p"."created_by" AS "who",
+            "p"."priority" AS "extra",
+            null AS "description"
+        FROM
+            "public"."signals_priority" AS "p"
+        UNION SELECT
+            CONCAT('UPDATE_SLA_', CAST("ca"."id" AS VARCHAR(255))) AS "identifier",
+            "ca"."_signal_id" AS "_signal_id",
+            "ca"."created_at" AS "when",
+            'UPDATE_SLA' AS "what",
+            NULL AS "who",
+            NULL AS "extra",
+            "ca"."stored_handling_message" AS "description"
+        FROM
+            "public"."signals_categoryassignment" AS "ca"
+        WHERE
+            "ca"."id" = (
+                SELECT MIN("sca1"."id")
+                FROM "public"."signals_categoryassignment" AS "sca1"
+                WHERE "sca1"."_signal_id" = "ca"."_signal_id"
+            )
+        UNION SELECT
+            CONCAT('UPDATE_CATEGORY_ASSIGNMENT_', CAST("ca"."id" AS VARCHAR(255))) AS "identifier",
+            "ca"."_signal_id" AS "_signal_id",
+            "ca"."created_at" AS "when",
+            'UPDATE_CATEGORY_ASSIGNMENT' AS "what",
+            "created_by" AS "who",
+            "sc"."name" AS "extra",
+            "ca"."text" AS "description"
+        FROM
+            "public"."signals_categoryassignment" AS "ca",
+            "public"."signals_category" AS "sc"
+        WHERE
+            "ca"."category_id" = "sc"."id"
+        UNION SELECT
+            CONCAT('CREATE_NOTE_', CAST("n"."id" AS VARCHAR(255))) AS "identifier",
+            "n"."_signal_id" as "_signal_id",
+            "n"."created_at" as "when",
+            'CREATE_NOTE' as "what",
+            "n"."created_by" as "who",
+            'Notitie toegevoegd' AS "extra",
+            "n"."text" AS "description"
+        FROM
+            "public"."signals_note" AS "n"
+        UNION SELECT
+            CONCAT('UPDATE_LOCATION_', CAST("l"."id" AS VARCHAR(255))) AS "identifier",
+            "l"."_signal_id" AS "_signal_id",
+            "l"."created_at" AS "when",
+            'UPDATE_LOCATION' AS "what",
+            "created_by" AS "who",
+            'Locatie gewijzigd' AS "extra",
+            null AS "description"
+        FROM
+            "public"."signals_location" AS "l"
+        UNION SELECT
+            /* token is not numerical id, inconsistent */
+            CONCAT('RECEIVE_FEEDBACK_', "f"."token") AS "identifier",
+            "f"."_signal_id" AS "_signal_id",
+            "f".submitted_at AS "when",
+            'RECEIVE_FEEDBACK' AS "what",
+            null AS "who",
+            'Feedback ontvangen' AS "extra",
+            null AS "description"
+        FROM
+            "public"."feedback_feedback" AS "f"
+        WHERE
+            "f"."submitted_at" IS NOT null
+         UNION SELECT
+            CONCAT('UPDATE_TYPE_ASSIGNMENT_', "st"."id") AS "identifier",
+            "st"."_signal_id" AS "_signal_id",
+            "st"."created_at" AS "when",
+            'UPDATE_TYPE_ASSIGNMENT' AS "what",
+            "st"."created_by" AS "who",
+            "st"."name" AS "extra",
+            null AS "description"
+        FROM
+            "public"."signals_type" AS "st"
+        UNION SELECT
+            CASE
+                WHEN "dd"."relation_type" = 'routing' THEN CONCAT('UPDATE_ROUTING_ASSIGNMENT_', CAST("dd"."id" AS VARCHAR(255)))
+                WHEN "dd"."relation_type" = 'directing' THEN CONCAT('UPDATE_DIRECTING_DEPARTMENTS_ASSIGNMENT_', CAST("dd"."id" AS VARCHAR(255)))
+                ELSE 'UNKNOWN'
+            END as "identifier",
+            "dd"."_signal_id" AS "_signal_id",
+            "dd"."created_at" AS "when",
+            CASE
+                WHEN "dd"."relation_type" = 'routing' THEN 'UPDATE_ROUTING_ASSIGNMENT'
+                WHEN "dd"."relation_type" = 'directing' THEN 'UPDATE_DIRECTING_DEPARTMENTS_ASSIGNMENT'
+                ELSE 'UNKNOWN'
+            END as "what",
+            "created_by" AS "who",
+            array_to_string(array(
+                SELECT "sd"."code"
+                FROM "signals_department" AS "sd"
+                JOIN "signals_signaldepartments_departments" AS "ssd" ON "sd"."id" = "ssd"."department_id"
+                WHERE "ssd"."signaldepartments_id" = "dd"."id"
+                ORDER BY "sd"."code"
+                ), ', ') AS "extra",
+               null AS "description"
+        FROM
+            "public"."signals_signaldepartments" AS "dd"
+        UNION SELECT
+            CONCAT('UPDATE_USER_ASSIGNMENT_', CAST("us"."id" AS VARCHAR(255))) AS "identifier",
+            "us"."_signal_id" AS "_signal_id",
+            "us"."created_at" AS "when",
+            'UPDATE_USER_ASSIGNMENT' AS "what",
+            "created_by" AS "who",
+            CAST("user"."email" AS VARCHAR(255)) AS "extra",
+            null AS "description"
+        FROM
+            "public"."signals_signaluser" AS "us", "public"."auth_user" AS "user"
+        WHERE
+            "us"."user_id" = "user"."id" 
+        UNION SELECT
+            CONCAT('CHILD_SIGNAL_CREATED_', "cs"."id") AS "identifier",
+            "cs"."parent_id" AS "_signal_id",
+            "cs"."created_at" AS "when",
+            'CHILD_SIGNAL_CREATED' AS "what",
+            null AS "who",
+            CAST("cs"."id" AS varchar) AS "extra",
+            '_signal_id contains the parent Signal ID, extra contains the child Signal ID' AS "description"
+        FROM signals_signal AS "cs"
+        INNER JOIN signals_signal AS "ps" ON "ps"."id" = "cs"."parent_id"
+        INNER JOIN signals_status AS "pss" ON "pss"."id" = "ps"."status_id" AND "pss"."state" != 's'
+
+    ) AS "subselect"
+    ORDER BY
+        "when"
+    DESC;
+""" # noqa
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0135_delete_categorytranslation'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='categoryassignment',
+            name='stored_handling_message',
+            field=models.TextField(null=True),
+        ),
+        migrations.RunSQL(history_view),
+    ]

--- a/api/app/signals/apps/signals/models/category_assignment.py
+++ b/api/app/signals/apps/signals/models/category_assignment.py
@@ -32,6 +32,12 @@ class CategoryAssignment(CreatedUpdatedModel):
     deadline = models.DateTimeField(null=True)
     deadline_factor_3 = models.DateTimeField(null=True)
 
+    # SIG-3555 store handling message as it was at the moment the category
+    # was assigned. Before we had problems with history "changing" when the
+    # handling message for a category was updated (because it was queried from
+    # the category table each time the history is shown).
+    stored_handling_message = models.CharField(null=True)
+
     def __str__(self):
         """String representation."""
         return '{sub} - {signal}'.format(sub=self.category, signal=self._signal)
@@ -43,4 +49,5 @@ class CategoryAssignment(CreatedUpdatedModel):
         # Note: this may be moved to the API layer of SIA/Signalen.
         self.deadline, self.deadline_factor_3 = DeadlineCalculationService.from_signal_and_category(
             self._signal, self.category)
+        self.stored_handling_message = self.category.handling_message  # SIG-3555
         super().save(*args, **kwargs)

--- a/api/app/signals/apps/signals/models/category_assignment.py
+++ b/api/app/signals/apps/signals/models/category_assignment.py
@@ -36,7 +36,7 @@ class CategoryAssignment(CreatedUpdatedModel):
     # was assigned. Before we had problems with history "changing" when the
     # handling message for a category was updated (because it was queried from
     # the category table each time the history is shown).
-    stored_handling_message = models.CharField(null=True)
+    stored_handling_message = models.TextField(null=True)
 
     def __str__(self):
         """String representation."""

--- a/api/app/signals/apps/signals/models/history.py
+++ b/api/app/signals/apps/signals/models/history.py
@@ -7,6 +7,8 @@ from signals.apps.signals.models.location import _get_description_of_update_loca
 from signals.apps.signals.models.type import _history_translated_action
 from signals.apps.signals.workflow import STATUS_CHOICES
 
+EMPTY_HANDLING_MESSAGE_PLACEHOLDER_MESSAGE = 'Service belofte onbekend.'
+
 
 class History(models.Model):
     identifier = models.CharField(primary_key=True, max_length=255)
@@ -74,6 +76,10 @@ class History(models.Model):
             return _get_description_of_receive_feedback(feedback_id)
         elif self.what == 'CHILD_SIGNAL_CREATED':
             return f'Melding {self.extra}'
+        elif self.what == 'UPDATE_SLA':
+            if self.description is None:
+                return EMPTY_HANDLING_MESSAGE_PLACEHOLDER_MESSAGE
+            return self.description
         else:
             return self.description
 

--- a/api/app/tests/apps/api/v1/test_history_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_history_endpoint.py
@@ -10,8 +10,13 @@ from freezegun import freeze_time
 from signals.apps.feedback.factories import FeedbackFactory
 from signals.apps.feedback.models import Feedback
 from signals.apps.signals import workflow
-from signals.apps.signals.factories import SignalFactory, SignalFactoryValidLocation
+from signals.apps.signals.factories import (
+    CategoryFactory,
+    SignalFactory,
+    SignalFactoryValidLocation
+)
 from signals.apps.signals.models import Category, History, Signal
+from signals.apps.signals.models.category_assignment import CategoryAssignment
 from tests.test import SIAReadUserMixin, SIAReadWriteUserMixin, SignalsBaseApiTestCase
 
 THIS_DIR = os.path.dirname(__file__)
@@ -177,6 +182,50 @@ class TestHistoryAction(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         sla_description_in_history = [entry['description'] for entry in data if entry['action'] == 'Servicebelofte:']
         self.assertEqual(self.signal.category_assignments.all().order_by('created_at')[0].category.handling_message,
                          sla_description_in_history[0])
+
+    def test_handling_message_in_history_is_constant(self):
+        # SIG-3555 because history is not tracked for the Category model and its
+        # handling_message. Changing the handling_message will also change the
+        # history of every Signal that has that Category associated with.
+        # This test demonstrates the problem.
+        message_1 = 'MESSAGE 1'
+        message_2 = 'MESSAGE 2'
+
+        cat1 = CategoryFactory.create(name='cat1', handling_message=message_1)
+        cat2 = CategoryFactory.create(name='cat2')
+        signal = SignalFactoryValidLocation(category_assignment__category=cat1)
+
+        self.sia_read_write_user.user_permissions.add(Permission.objects.get(codename='sia_can_view_all_categories'))
+        self.client.force_authenticate(user=self.sia_read_write_user)
+
+        # Retrieve signal history before changing the Category handling message.
+        response = self.client.get(f'/signals/v1/private/signals/{signal.id}/history' + '?what=UPDATE_SLA')
+        self.assertEqual(response.status_code, 200)
+
+        response_json = response.json()
+        self.assertEqual(len(response_json), 1)
+        self.assertEqual(response_json[0]['description'], message_1)
+
+        # Change handling message on category
+        cat1.handling_message = message_2
+        cat1.save()
+        cat1.refresh_from_db()
+
+        # Assign different category and then the same again, check handling messages.
+        Signal.actions.update_category_assignment({'category': cat2}, signal)
+        signal.refresh_from_db()
+        Signal.actions.update_category_assignment({'category': cat1}, signal)
+        response = self.client.get(f'/signals/v1/private/signals/{signal.id}/history' + '?what=UPDATE_SLA')
+        self.assertEqual(response.status_code, 200)
+
+        response_json = response.json()
+        self.assertEqual(len(response_json), 1)
+        self.assertEqual(response_json[0]['description'], message_1)
+
+        # check that the correct handling messages are stored:
+        category_assignments = list(CategoryAssignment.objects.filter(_signal_id=signal.id).order_by('id'))
+        self.assertEqual(category_assignments[0].stored_handling_message, message_1)
+        self.assertEqual(category_assignments[2].stored_handling_message, message_2)
 
     def test_history_no_permissions(self):
         """


### PR DESCRIPTION
## Description

Make sure handling message is correctly shown in Signal history.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
