### PR TITLE
SIG-3610 Clean-up Attachment model, removed unused resize code

### DIFF
--- a/api/app/signals/apps/signals/models/attachment.py
+++ b/api/app/signals/apps/signals/models/attachment.py
@@ -3,9 +3,6 @@
 import logging
 
 from django.contrib.gis.db import models
-from imagekit import ImageSpec
-from imagekit.cachefiles import ImageCacheFile
-from imagekit.processors import ResizeToFit
 from PIL import Image, ImageFile, UnidentifiedImageError
 
 from signals.apps.signals.models.mixins import CreatedUpdatedModel
@@ -41,34 +38,6 @@ class Attachment(CreatedUpdatedModel):
             models.Index(fields=['is_image']),
             models.Index(fields=['_signal', 'is_image']),
         ]
-
-    class NotAnImageException(Exception):
-        pass
-
-    class CroppedImage(ImageSpec):
-        processors = [ResizeToFit(800, 800), ]
-        format = 'JPEG'
-        options = {'quality': 80}
-
-    @property
-    def image_crop(self):
-        return self._crop_image()
-
-    def _crop_image(self):
-        if not self.is_image:
-            raise Attachment.NotAnImageException("Attachment is not an image. Use is_image to check"
-                                                 " if attachment is an image before asking for the "
-                                                 "cropped version.")
-
-        generator = Attachment.CroppedImage(source=self.file)
-        cache_file = ImageCacheFile(generator)
-
-        try:
-            cache_file.generate()
-        except FileNotFoundError as e:
-            logger.warn("File not found when generating cache file: " + str(e))
-
-        return cache_file
 
     def _check_if_file_is_image(self):
         try:

--- a/api/app/tests/apps/api/v1/test_public_signal_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_public_signal_endpoint.py
@@ -216,7 +216,6 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
 
         attachment = Attachment.objects.last()
         self.assertEqual("image/gif", attachment.mimetype)
-        self.assertIsInstance(attachment.image_crop.url, str)
         self.assertIsNone(attachment.created_by)
 
     def test_add_attachment_nonimagetype(self):


### PR DESCRIPTION
## Description

SIG-3610 Clean-up Attachment model, removed unused resize code

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
