### PR TITLE
Load_categories incorrectly determines slug while importing

### DIFF
--- a/api/app/signals/apps/dataset/management/commands/load_categories.py
+++ b/api/app/signals/apps/dataset/management/commands/load_categories.py
@@ -3,6 +3,7 @@
 import json
 
 from django.core.management import BaseCommand
+from django.utils.text import slugify
 
 from signals.apps.signals.models import Category
 
@@ -44,11 +45,11 @@ class Command(BaseCommand):
                 parent_id = fields.pop('parent')
                 if parent_id:
                     fields['parent'] = self._get_parent(parent_id)
-                cat = self._get_cat(fields['slug'], fields.get('parent', None))
+                cat = self._get_cat(slugify(fields['name']), fields.get('parent', None))
                 if cat is not None:
                     self.stdout.write(f'Updating: {fields["slug"]}')
                     for attr, value in fields.items():
-                        if hasattr(cat, attr):
+                        if attr != 'slug' and hasattr(cat, attr):
                             setattr(cat, attr, value)
                     cat.save()
                 else:

--- a/api/app/signals/apps/dataset/management/commands/load_categories.py
+++ b/api/app/signals/apps/dataset/management/commands/load_categories.py
@@ -33,6 +33,11 @@ class Command(BaseCommand):
     def add_arguments(self, parser) -> None:
         parser.add_argument('data_file', type=str)
 
+    # load_categories will create new slug if the Name property changes. The load_categories command
+    # is not intended to be used for renaming categories. It's intended for loading new catagories
+    # and make un-used categories inactive. Typically this is used during training/debug sessions
+    # and / or adding new categories. It will however re-use the slug if the Name -> Slug
+    # transformation remains the same.
     def handle(self, *args, **options) -> None:
         self.processed_cats = set()
         with open(options['data_file']) as f:

--- a/api/app/tests/apps/dataset/management/commands/json_data/categories-update.json
+++ b/api/app/tests/apps/dataset/management/commands/json_data/categories-update.json
@@ -5,11 +5,11 @@
         "fields": {
             "parent": null,
             "slug": "test-parent-cat1",
-            "name": "test parent cat1 (renamed)",
+            "name": "test parent cat1",
             "handling": "REST",
             "handling_message": null,
             "is_active": true,
-            "description": null
+            "description": "renamed"
         }
     },
     {

--- a/api/app/tests/apps/dataset/management/commands/test_load_categories.py
+++ b/api/app/tests/apps/dataset/management/commands/test_load_categories.py
@@ -25,7 +25,7 @@ class TestLoadCategories(TestCase):
         self.assertEqual(3, len(categories))
 
         renamed = categories.get(slug='test-parent-cat1')
-        self.assertEqual(renamed.name, 'test parent cat1 (renamed)')
+        self.assertEqual(renamed.description, 'renamed')
 
     def test_load_categories_with_existing_entries(self):
         main = Category.objects.create(**{
@@ -73,4 +73,4 @@ class TestLoadCategories(TestCase):
         self.assertEqual(3, len(categories))
 
         renamed = categories.get(slug='test-parent-cat1')
-        self.assertEqual(renamed.name, 'test parent cat1 (renamed)')
+        self.assertEqual(renamed.description, 'renamed')


### PR DESCRIPTION
Category.slug field is defined as: `slug = AutoSlugField(populate_from=['name', ], blank=False, overwrite=False, editable=False)`
The load_categories command tries to load the slug directly. The slug field is generally ignored, and the description (`Name`) field is used. We should therefore supply slugified `Name` as slug. Also prevent updating the `slug` field, since this is not permitted (even if its the same value)