### PR TITLE
Document dependency maturity (issue #123)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@
 * [Glossary](topics/glossary.md)
 * [Technical roadmap](topics/technical-roadmap.md)
 * [Dummy data for local development or testing](topics/dummy-data.md)
+* [Open Source dependencies](topics/dependencies.md)

--- a/docs/topics/dependencies.md
+++ b/docs/topics/dependencies.md
@@ -1,0 +1,23 @@
+# Open Source dependencies
+
+Signalen would not be possible without a number of other Open Source dependencies.
+
+The backend is written in [Python](https://www.python.org/) utilizing the [Django framework](https://www.djangoproject.com/).
+The Django framework is a stable, supported, and actively maintained.
+While Django pulls in some <= 1.0 libraries (e.g.: sqlparse),
+if there is an issue with these, the Django community can be trusted to address it.
+
+A full list of dependencies of the backend can be generated with `pipdeptree`.
+The majority of other dependices are stable.
+Some exceptions include:
+
+| library | mitigation | notes |
+|---------|------------|-------|
+| jwcrypto | codebase is active, developers can work with upstream |needs documenting (token valadation and user authentication code)|
+| [pygelf](https://pypi.org/project/pygelf/) | developers could maintain if needed | is still used in datapunt? |
+| drf-amsterdam | Signalen developers maintain this | |
+| [entrypoints](https://pypi.org/project/entrypoints/) | developers could maintain |(maybe not even needed) |
+| [freezegun](https://pypi.org/project/freezegun/) | developers could maintain | will be updated to 1.x soon; used by tests |
+| wheel | not-needed | This library is the reference implementation of the Python wheel packaging standard, as defined in PEP 427.
+| xmlunittest | can work with upstream if needed | only used by tests |
+

--- a/docs/topics/dependencies.md
+++ b/docs/topics/dependencies.md
@@ -18,6 +18,6 @@ Some exceptions include:
 | drf-amsterdam | Signalen developers maintain this | |
 | [entrypoints](https://pypi.org/project/entrypoints/) | developers could maintain |(maybe not even needed) |
 | [freezegun](https://pypi.org/project/freezegun/) | developers could maintain | will be updated to 1.x soon; used by tests |
-| wheel | not-needed | This library is the reference implementation of the Python wheel packaging standard, as defined in PEP 427.
+| wheel | mitigation not-needed | This library is the reference implementation of the Python wheel packaging standard, as defined in PEP 427.
 | xmlunittest | can work with upstream if needed | only used by tests |
 

--- a/docs/topics/dependencies.md
+++ b/docs/topics/dependencies.md
@@ -14,10 +14,10 @@ Some exceptions include:
 | library | mitigation | notes |
 |---------|------------|-------|
 | jwcrypto | codebase is active, developers can work with upstream |needs documenting (token valadation and user authentication code)|
-| [pygelf](https://pypi.org/project/pygelf/) | developers could maintain if needed | is still used in datapunt? |
+| [pygelf](https://pypi.org/project/pygelf/) | developers could maintain if needed | or pygelf and its configuration could be dropped as it is not essential  |
 | drf-amsterdam | Signalen developers maintain this | |
 | [entrypoints](https://pypi.org/project/entrypoints/) | developers could maintain |(maybe not even needed) |
-| [freezegun](https://pypi.org/project/freezegun/) | developers could maintain | will be updated to 1.x soon; used by tests |
+| [freezegun](https://pypi.org/project/freezegun/) | developers could maintain | will be updated to 1.x soon; used by tests to control the clock |
 | wheel | mitigation not-needed | This library is the reference implementation of the Python wheel packaging standard, as defined in PEP 427.
 | xmlunittest | can work with upstream if needed | only used by tests |
 

--- a/docs/topics/signalen-and-standard-for-public-code.md
+++ b/docs/topics/signalen-and-standard-for-public-code.md
@@ -189,6 +189,6 @@ You MAY include sections in your style guide on understandable English. |  |
 Requirement | meets | links and notes
 -----|-----|-----
 A codebase MUST be versioned. | yes | Semantic versioning and tagged as such. Backend is currently starting to publish tags again.
-A codebase that is ready to use MUST only depend on other codebases that are also ready to use. |  | Probably, but dependency double-check would be good.
+A codebase that is ready to use MUST only depend on other codebases that are also ready to use. | yes | [Open Source dependencies](./dependencies.md)
 A codebase that is not yet ready to use MUST have one of these labels: prototype - to test the look and feel, and to internally prove the concept of the technical possibilities, alpha - to do guided tests with a limited set of users, beta - to open up testing to a larger section of the general public, for example to test if the codebase works at scale, pre-release version - code that is ready to be released but hasn’t received formal approval yet. | N/A |
 A codebase SHOULD contain a log of changes from version to version, for example in the CHANGELOG. | some | There is no changelog, but there are release notes for [backend](https://github.com/Amsterdam/signals/releases) and [frontend](https://github.com/Amsterdam/signals-frontend/releases).


### PR DESCRIPTION
## Description

Initial documentation of dependency maturity. Most are mature or indirect dependencies of Django which is mature.

See: https://github.com/Signalen/backend/issues/123

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] Documentation has been updated if needed
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts

(removed checklist items which do not apply to documentation)