### PR TITLE
Make sure feedback functionality works on development as well

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       - DB_NAME=signals
       - DB_PASSWORD=insecure
       - DJANGO_SETTINGS_MODULE=signals.settings.development
+      - FRONTEND_URL=http://localhost:3001
       - SWIFT_ENABLED=False
       - SIGMAX_AUTH_TOKEN
       - SIGMAX_SERVER


### PR DESCRIPTION
## Description

Feedback functionality does not work "out of the box" on development due to missing environment configuration.

Closes Signalen/backend#141