### PR TITLE
add export of routing department relation

### DIFF
--- a/api/app/signals/apps/reporting/csv/datawarehouse/__init__.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/__init__.py
@@ -12,7 +12,8 @@ from signals.apps.reporting.csv.datawarehouse.locations import create_locations_
 from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_csv
 from signals.apps.reporting.csv.datawarehouse.signals import (
     create_signals_assigned_user_csv,
-    create_signals_csv
+    create_signals_csv,
+    create_signals_routing_departments_csv
 )
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
 from signals.apps.reporting.csv.datawarehouse.tasks import (
@@ -30,6 +31,7 @@ __all__ = [
     'create_reporters_csv',
     'create_statuses_csv',
     'create_signals_assigned_user_csv',
+    'create_signals_routing_departments_csv',
     'create_signals_csv',
     'save_csv_file_datawarehouse',
     'save_csv_files_datawarehouse',

--- a/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
@@ -15,7 +15,8 @@ from signals.apps.reporting.csv.datawarehouse.locations import create_locations_
 from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_csv
 from signals.apps.reporting.csv.datawarehouse.signals import (
     create_signals_assigned_user_csv,
-    create_signals_csv
+    create_signals_csv,
+    create_signals_routing_departments_csv
 )
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
 from signals.apps.reporting.csv.utils import save_csv_files, zip_csv_files
@@ -56,6 +57,7 @@ def save_csv_files_datawarehouse(using='datawarehouse'):
     csv_files.extend(save_csv_file_datawarehouse(create_statuses_csv, using=using))
     csv_files.extend(save_csv_file_datawarehouse(create_category_sla_csv, using=using))
     csv_files.extend(save_csv_file_datawarehouse(create_directing_departments_csv, using=using))
+    csv_files.extend(save_csv_file_datawarehouse(create_signals_routing_departments_csv, using=using))
 
     try:
         csv_files.extend(save_csv_file_datawarehouse(create_kto_feedback_csv, using=using))

--- a/api/app/signals/apps/reporting/management/commands/dumpcsv.py
+++ b/api/app/signals/apps/reporting/management/commands/dumpcsv.py
@@ -19,7 +19,8 @@ from signals.apps.reporting.csv.datawarehouse.locations import create_locations_
 from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_csv
 from signals.apps.reporting.csv.datawarehouse.signals import (
     create_signals_assigned_user_csv,
-    create_signals_csv
+    create_signals_csv,
+    create_signals_routing_departments_csv
 )
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
 from signals.apps.reporting.csv.datawarehouse.tasks import (
@@ -38,6 +39,7 @@ REPORT_OPTIONS = {
     'category_sla': create_category_sla_csv,
     'feedback': create_kto_feedback_csv,
     'directing_departments': create_directing_departments_csv,
+    'routing_departments': create_signals_routing_departments_csv,
 }
 
 

--- a/api/app/tests/apps/reporting/management/commands/test_command.py
+++ b/api/app/tests/apps/reporting/management/commands/test_command.py
@@ -18,7 +18,7 @@ class TestCommand(TransactionTestCase):
         self.assertNotEqual(out.getvalue(), '')
         self.assertEqual(err.getvalue(), '')
 
-        self.assertEqual(patched_save_csv_files_datawarehouse.call_count, 9)
+        self.assertEqual(patched_save_csv_files_datawarehouse.call_count, 10)
 
 
 class TestCSVHorecaCommand(TransactionTestCase):


### PR DESCRIPTION
Similar to directing departments, we need an export of the routing department relation.
It's a copy of the directing_department export except for the relation type. 
A separate file was chosen to avoid format changes.