### PR TITLE
Allow null value in choice area_code filter

### DIFF
--- a/api/app/signals/apps/api/filters/signal.py
+++ b/api/app/signals/apps/api/filters/signal.py
@@ -79,10 +79,6 @@ class SignalFilterSet(FilterSet):
         self.form.cleaned_data.pop('category_slug', None)
         self.form.cleaned_data.pop('maincategory_slug', None)
 
-        if not self.form.cleaned_data.get('area_code', None) or not self.form.cleaned_data.get('area_type_code', None):
-            self.form.cleaned_data.pop('area_code', None)
-            self.form.cleaned_data.pop('area_type_code', None)
-
     def filter_queryset(self, queryset):
         """
         Add custom category filtering to the filter_queryset

--- a/api/app/signals/apps/api/filters/utils.py
+++ b/api/app/signals/apps/api/filters/utils.py
@@ -29,7 +29,9 @@ def area_type_choices():
 
 
 def area_choices():
-    return [(c, f'{n} ({t})') for c, t, n in Area.objects.values_list('code', '_type__name', 'name')]
+    return [
+        ('null', 'null'),
+    ] + [(c, f'{n} ({t})') for c, t, n in Area.objects.values_list('code', '_type__name', 'name')]
 
 
 boolean_true_choices = [(True, 'True'), ('true', 'true'), ('True', 'True'), (1, '1')]

--- a/api/app/tests/apps/api/test_filters.py
+++ b/api/app/tests/apps/api/test_filters.py
@@ -969,18 +969,22 @@ class TestAreaFilter(SignalsBaseApiTestCase):
             location__area_code=self.area.code,
             location__area_type_code=self.area._type.code,
         )
+        # no area code, but with geo location
         SignalFactory.create(location__geometrie=self.pt_out_center)
 
     def test_filter_areas(self):
         # all
         result_ids = self._request_filter_signals({})
         self.assertEqual(2, len(result_ids))
-        # filter on type_code or area code
+        # only non-assigned
+        result_ids = self._request_filter_signals({'area_code': 'null'})
+        self.assertEqual(1, len(result_ids))
+        # filter on type_code
         result_ids = self._request_filter_signals({'area_type_code': 'district'})
-        self.assertEqual(2, len(result_ids))
+        self.assertEqual(1, len(result_ids))
         # filter on type_code or area code
         result_ids = self._request_filter_signals({'area_code': self.area.code})
-        self.assertEqual(2, len(result_ids))
+        self.assertEqual(1, len(result_ids))
         # filter on both
         result_ids = self._request_filter_signals({'area_type_code': 'district', 'area_code': self.area.code})
         self.assertEqual(1, len(result_ids))


### PR DESCRIPTION
The area code filter is defined as a multiple choice filter. The lookup choice list was missing the 'null' value which makes it impossible to filter for 'not-assigned'