### PR TITLE
SIG-3642 Calculate deadlines for open signals/complaints that have none.

### DIFF
--- a/api/app/signals/apps/signals/management/commands/calculate_deadlines.py
+++ b/api/app/signals/apps/signals/management/commands/calculate_deadlines.py
@@ -11,13 +11,12 @@ signals/complaints that are open that have no deadline. Each of these is
 re-assigned to its category, triggering the deadline calculation and solving
 the problem with the punctuality filter.
 """
-
 from django.core.management import BaseCommand
 
 from signals.apps.signals import workflow
 from signals.apps.signals.models import CategoryAssignment, Signal
 
-HISTORY_MESSAGE = 'Afhandel-deadline uitgerekend.'
+HISTORY_MESSAGE = 'Afhandeltermijn uitgerekend.'
 
 
 class Command(BaseCommand):

--- a/api/app/signals/apps/signals/management/commands/calculate_deadlines.py
+++ b/api/app/signals/apps/signals/management/commands/calculate_deadlines.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+"""
+This management command calculates deadlines for signals/complaints that have
+no deadline. We need this to fix a problem where existing old open
+signals/complaints do not show up in the punctuality filter using the
+`late` of `late_factor_3` options.
+
+Deadlines are calculated when a category is assigned. This command goes through
+signals/complaints that are open that have no deadline. Each of these is
+re-assigned to its category, triggering the deadline calculation and solving
+the problem with the punctuality filter.
+"""
+
+from django.core.management import BaseCommand
+
+from signals.apps.signals import workflow
+from signals.apps.signals.models import CategoryAssignment, Signal
+
+HISTORY_MESSAGE = 'Afhandel-deadline uitgerekend.'
+
+
+class Command(BaseCommand):
+    def _set_deadlines(self):
+        # We only update the open complaints, as those are the ones that have to
+        # be worked on and solved (and thus need to show up in the `punctuality`
+        # filter).
+        no_deadlines = Signal.objects.filter(category_assignment__deadline__isnull=True).exclude(
+            status__state__in=[workflow.GESPLITST, workflow.AFGEHANDELD, workflow.GEANNULEERD]
+        )
+
+        for signal in no_deadlines.iterator(chunk_size=1000):
+            category = signal.category_assignment.category
+
+            # We have to bypass the "Actions" manager here, because it will
+            # reject an update to and from the same category.
+            data = {'text': HISTORY_MESSAGE, 'category': category}
+            category_assignment = CategoryAssignment.objects.create(**data, _signal_id=signal.id)
+            signal.category_assignment = category_assignment
+            signal.save()
+
+    def handle(self, *args, **options):
+        self.stdout.write('Find open Signals without deadlines ...')
+        self.stdout.write('... re-assign category (triggering deadline calculation).')
+
+        self._set_deadlines()
+
+        no_deadlines = Signal.objects.filter(category_assignment__deadline__isnull=True).exclude(
+            status__state__in=[workflow.GESPLITST, workflow.AFGEHANDELD, workflow.GEANNULEERD]
+        )
+        self.stdout.write(f'Number of signals without deadlines {no_deadlines.count()}')
+        self.stdout.write('Done')

--- a/api/app/tests/apps/signals/management/commands/test_calculate_deadlines.py
+++ b/api/app/tests/apps/signals/management/commands/test_calculate_deadlines.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+import datetime
+from io import StringIO
+
+from django.core.management import call_command
+from freezegun import freeze_time
+from rest_framework.test import APITestCase
+
+from signals.apps.signals import workflow
+from signals.apps.signals.factories import (
+    CategoryFactory,
+    ServiceLevelObjectiveFactory,
+    SignalFactory
+)
+from signals.apps.signals.management.commands.calculate_deadlines import HISTORY_MESSAGE, Command
+from signals.apps.signals.models import Signal
+from tests.test import SuperUserMixin
+
+
+class TestCalculateDeadlines(APITestCase, SuperUserMixin):
+    NOW = datetime.datetime(2021, 3, 22, 12, 0, 0)  # A monday
+    history_endpoint = '/signals/v1/private/signals/{pk}/history'
+
+    def setUp(self):
+        # We use a category without no deadlines to create signals/complaints that
+        # will have deadline set to None.
+        test_cat = CategoryFactory.create(name='testcategory')
+
+        with freeze_time(self.NOW - datetime.timedelta(days=4*7)):
+            self.signal_late_open = SignalFactory.create(
+                status__state=workflow.GEMELD, category_assignment__category=test_cat)
+            self.signal_late_closed = SignalFactory.create(
+                status__state=workflow.AFGEHANDELD, category_assignment__category=test_cat)
+
+        # We now set a Service Level Objective for the category, so that we can
+        # create some signals/complaints with a deadline set to some value other
+        # than None.
+        ServiceLevelObjectiveFactory.create(
+            category=test_cat,
+            n_days=5,
+            use_calendar_days=False,
+        )
+
+        with freeze_time(self.NOW - datetime.timedelta(hours=1)):
+            self.signal_punctual_open = SignalFactory.create(
+                status__state=workflow.GEMELD, category_assignment__category=test_cat)
+            self.signal_punctual_closed = SignalFactory.create(
+                status__state=workflow.AFGEHANDELD, category_assignment__category=test_cat)
+
+    def test_handle(self):
+        """
+        Test that the calculate_deadlines command updates the open complaints without deadline.
+        """
+        self.assertEqual(Signal.objects.count(), 4)
+        no_deadlines = Signal.objects.filter(category_assignment__deadline__isnull=True)
+        self.assertEqual(no_deadlines.count(), 2)
+
+        buffer = StringIO()
+        call_command('calculate_deadlines', stdout=buffer)
+
+        # all open complaints should now have a deadline, the closed one should not
+        no_deadlines = Signal.objects.filter(category_assignment__deadline__isnull=True)
+        self.assertEqual(no_deadlines.count(), 1)
+        self.assertEqual(no_deadlines[0].id, self.signal_late_closed.id)
+        self.assertEqual(no_deadlines[0].status.state, workflow.AFGEHANDELD)
+
+        output = buffer.getvalue()
+        self.assertIn('Number of signals without deadlines 0', output)
+
+    def test__set_deadlines(self):
+        """
+        Test that the calculate_deadlines command updates the open complaints without deadline.
+        """
+        self.assertEqual(Signal.objects.count(), 4)
+        no_deadlines = Signal.objects.filter(category_assignment__deadline__isnull=True)
+        self.assertEqual(no_deadlines.count(), 2)
+
+        Command()._set_deadlines()
+
+        # all open complaints should now have a deadline, the closed one should not
+        no_deadlines = Signal.objects.filter(category_assignment__deadline__isnull=True)
+        self.assertEqual(no_deadlines.count(), 1)
+        self.assertEqual(no_deadlines[0].id, self.signal_late_closed.id)
+        self.assertEqual(no_deadlines[0].status.state, workflow.AFGEHANDELD)
+
+    def test__history_message(self):
+        """
+        Test that the history of the updated complaint contains the correct message.
+        """
+        self.assertEqual(Signal.objects.count(), 4)
+        no_deadlines = Signal.objects.filter(category_assignment__deadline__isnull=True)
+        self.assertEqual(no_deadlines.count(), 2)
+
+        # find the signal/complaint ID that should be updated
+        signal_id = self.signal_late_open.id
+
+        buffer = StringIO()
+        call_command('calculate_deadlines', stdout=buffer)
+
+        # all open complaints should now have a deadline, the closed one should not
+        no_deadlines = Signal.objects.filter(category_assignment__deadline__isnull=True)
+        self.assertEqual(no_deadlines.count(), 1)
+
+        # check that the updated signal/complaint has to category assignments in
+        # its history and that the most recent one contains the correct message
+        self.client.force_authenticate(user=self.superuser)
+        url = self.history_endpoint.format(pk=signal_id)
+        data = {'what': 'UPDATE_CATEGORY_ASSIGNMENT'}
+
+        response = self.client.get(url, data=data)
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertEqual(len(response_json), 2)
+        self.assertEqual(response_json[0]['description'], HISTORY_MESSAGE)


### PR DESCRIPTION
## Description

The deadlines for handling complaints are only calculated upon a new category assignment. This means that the SIA Amsterdam dataset contains many complaints that have no deadlines (and are still open). This PR adds a management command to calculate deadlines for any open signals/complaints that have no deadline.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
