### PR TITLE
Validate file extension of uploaded attachments, only accept image extensions

### DIFF
--- a/api/app/signals/apps/api/v1/serializers/attachment.py
+++ b/api/app/signals/apps/api/v1/serializers/attachment.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
+import os
+
 from datapunt_api.rest import DisplayField, HALSerializer
 from django.conf import settings
 from rest_framework import serializers
@@ -50,6 +52,12 @@ class SignalAttachmentSerializer(HALSerializer):
         if file.size > settings.API_MAX_UPLOAD_SIZE:
             msg = f'Bestand mag maximaal {settings.API_MAX_UPLOAD_SIZE} bytes groot zijn.'
             raise ValidationError(msg)
+
+        _, ext = os.path.splitext(file.name)
+        if ext.lower() not in ['.gif', '.jpg', '.jpeg', '.png']:
+            msg = 'Bestandsextensie is niet toegestaan. Geldige extensies zijn: .gif, .jpg, .jpeg en .png.'
+            raise ValidationError(msg)
+
         return file
 
 

--- a/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_private_signal_endpoint.py
@@ -1618,7 +1618,7 @@ class TestPrivateSignalAttachments(SIAReadWriteUserMixin, SignalsBaseApiTestCase
         self.assertIsInstance(self.signal.attachments.first(), Attachment)
         self.assertIsInstance(self.signal.attachments.filter(is_image=True).first(), Attachment)
 
-    def test_attachment_upload(self):
+    def test_attachment_upload_extension_not_allowed(self):
         endpoint = self.attachment_endpoint.format(self.signal.id)
         doc_upload = os.path.join(SIGNALS_TEST_DIR, 'sia-ontwerp-testfile.doc')
 
@@ -1627,10 +1627,7 @@ class TestPrivateSignalAttachments(SIAReadWriteUserMixin, SignalsBaseApiTestCase
 
             response = self.client.post(endpoint, data)
 
-        self.assertEqual(response.status_code, 201)
-        self.assertIsInstance(self.signal.attachments.first(), Attachment)
-        self.assertIsNone(self.signal.attachments.filter(is_image=True).first())
-        self.assertEqual(self.sia_read_write_user.email, self.signal.attachments.first().created_by)
+        self.assertEqual(response.status_code, 400)
 
     def test_create_has_attachments_false(self):
         response = self.client.post(self.list_endpoint, self.create_initial_data, format='json')

--- a/api/app/tests/apps/api/v1/test_public_signal_endpoint.py
+++ b/api/app/tests/apps/api/v1/test_public_signal_endpoint.py
@@ -218,7 +218,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         self.assertEqual("image/gif", attachment.mimetype)
         self.assertIsNone(attachment.created_by)
 
-    def test_add_attachment_nonimagetype(self):
+    def test_add_attachment_extension_not_allowed(self):
         signal = SignalFactory.create()
 
         doc_upload = os.path.join(SIGNALS_TEST_DIR, 'sia-ontwerp-testfile.doc')
@@ -227,11 +227,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
 
             response = self.client.post(self.attachment_endpoint.format(uuid=signal.uuid), data)
 
-        self.assertEqual(201, response.status_code)
-        self.assertJsonSchema(self.create_attachment_schema, response.json())
-
-        attachment = Attachment.objects.last()
-        self.assertEqual("application/msword", attachment.mimetype)
+        self.assertEqual(response.status_code, 400)
 
     def test_cannot_access_attachments(self):
         # SIA must not publicly expose attachments


### PR DESCRIPTION
## Description

This PR adds validation of file extensions for uploaded attachments. We accept .gif, .jpg, .jpeg and .png.

## Discuss

- The code contains some traces of handling non-image attachment uploads. What do we do with them? I suggest to keep them in as we are going to work on this in Signalen/backend#54.

## Todo

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
