### PR TITLE
Update checklist that Signalen is reused by more parties

### DIFF
--- a/docs/topics/signalen-and-standard-for-public-code.md
+++ b/docs/topics/signalen-and-standard-for-public-code.md
@@ -31,9 +31,9 @@ Continuous integration tests SHOULD validate that the source code and the policy
 
 Requirement | meets | links and notes
 -----|-----|-----
-The codebase MUST be developed to be reusable in different contexts. | almost | VNG is specifically tasked with this.
-The codebase MUST be independent from any secret, undisclosed, proprietary or non-open licensed code or services for execution and understanding. | yes? | Lacks public dataset for easily running the machine learning model.
-The codebase SHOULD be in use by multiple parties. | almost |
+The codebase MUST be developed to be reusable in different contexts. | yes |
+The codebase MUST be independent from any secret, undisclosed, proprietary or non-open licensed code or services for execution and understanding. | yes |
+The codebase SHOULD be in use by multiple parties. | yes |
 The roadmap SHOULD be influenced by the needs of multiple parties. | yes |
 Configuration SHOULD be used to make code adapt to context specific needs. | yes |
 Codebases SHOULD include a publiccode.yml metadata description so that they’re easily discoverable. | no | Created [backend#64](https://github.com/Signalen/backend/issues/64).


### PR DESCRIPTION
## Description

Updated the Standard for Public Code so that it reflects the actual reuse by 's-Hertogenbosch. Fixes #773

Can we get verified that `any secret, undisclosed, proprietary or non-open licensed code or services for execution and understanding.` was not a problem for the implementation? Perhaps @CBuiVNG can weigh in on that?

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 90% (the higher the better)
- [ ] No iSort issues are present in the code
- [ ] No Flake8 issues are present in the code
