### PR TITLE
Chore update Django to version 2.2.20

### DIFF
--- a/api/app/signals/__init__.py
+++ b/api/app/signals/__init__.py
@@ -18,11 +18,10 @@ __all__ = ['celery_app', 'VERSION', 'API_VERSIONS', ]
 # `/signals/v1/...` will always have major API version number `1`.
 
 # Application version (Major, minor, patch)
-VERSION = (0, 15, 0)
+VERSION = (0, 21, 3)
 
 # API versions (Major, minor, patch)
 API_VERSIONS = {
-    'v0': (0, 8, 0),
     'v1': (1, 12, 0),
 }
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -20,7 +20,7 @@ ddtrace==0.46.0
 debtcollector==2.0.0
 defusedxml==0.6.0
 distlib==0.3.1
-Django==2.2.18
+Django==2.2.20
 django-appconf==1.0.3
 django-celery-beat==1.6.0
 django-celery-email==3.0.0


### PR DESCRIPTION
## Description

Maintenance, update Django to version 2.2.20. Bump internal SIA version to 0.21.3.

