### PR TITLE
Chore/fix versioning scheme

### DIFF
--- a/api/app/signals/__init__.py
+++ b/api/app/signals/__init__.py
@@ -19,21 +19,20 @@ datastructures.EmptyResultSet = EmptyResultSet
 
 # Versioning
 # ==========
-#
-# We are tracking multiple versions. First we've the application version which increments by every
-# release. Based on the changes in the new release there is a major, minor or patch version bump.
-#
-# Besides that we've API versioning which are seperated versioning numbers for the given API. The
-# major versioning number of the API is fixed related to the given API. e.g. API Version 1 with url
-# `/signals/v1/...` will always have major API version number `1`.
+# SIA / Signalen follows the semantic versioning standard. Previously we had
+# separate version numbers for the V0 (now defunct) and V1 versions of the API.
+# We now no longer separately version these, as their releases were always
+# tied to the backend. For backwards compatibility, and to not break external
+# systems that rely on SIA / Signalen we still expose all the separate version
+# numbers, but they are now all the same.
+
 
 # Application version (Major, minor, patch)
-VERSION = (0, 21, 4)
+VERSION = (2, 0, 0)
 
-# API versions (Major, minor, patch)
 API_VERSIONS = {
-    'v0': (0, 8, 0),
-    'v1': (1, 12, 0),
+    'v0': VERSION,
+    'v1': VERSION,
 }
 
 __version__ = get_version(VERSION)

--- a/api/app/signals/apps/api/generics/routers.py
+++ b/api/app/signals/apps/api/generics/routers.py
@@ -3,7 +3,7 @@
 from django.urls import reverse
 from rest_framework import routers
 
-from signals import API_VERSIONS
+from signals import API_VERSIONS, VERSION
 from signals.utils.version import get_version
 
 
@@ -20,8 +20,11 @@ class BaseSignalsAPIRootView(routers.APIRootView):
                 }
             },
             'version': get_version(API_VERSIONS['v1']),
-            'status': 'in development',
+            'status': 'in production',
         }
+        response.data.update({
+            'version': get_version(VERSION),
+        })
         return response
 
     def get_view_name(self):


### PR DESCRIPTION
## Description

SIA tracked three version numbers:
* backend overall
* V0 API (defunct)
* V1 API

These were never released separately. This PR is a proposal to only track the overall SIA version number, and do that following the semantic versioning rules. (One piece of software, one release, one version number.)

The version is bumped all the way to 2.0 because we want to be sure not to break software that checks for minimum versions in the V1 API. That API is already on version 1.something.something, by moving to 2.0 we have a higher version number for the new release. We think this is reasonable and avoids having to speak to all external users about the API version checks they might have.
