### PR TITLE
fix/django-debug-toolbar-bump-3.2.1

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -31,7 +31,7 @@ django-celery-beat==2.2.0
 django-celery-email==3.0.0
 django-celery-results==2.0.1
 django-cors-headers==3.7.0
-django-debug-toolbar==3.2
+django-debug-toolbar==3.2.1
 django-extensions==3.1.2
 django-filter==2.4.0
 django-imagekit==4.0.2


### PR DESCRIPTION
## Description

Update django-debug-toolbar to version 3.2.1 see CVE-2021-30459 for more information

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts