### PR TITLE
Bugfix/sig 3649 timezone problem deadlines

### DIFF
--- a/api/app/signals/apps/services/domain/deadlines.py
+++ b/api/app/signals/apps/services/domain/deadlines.py
@@ -24,9 +24,10 @@ class DeadlineCalculationService:
         # received during the weekend, work will only start on Monday. The
         # deadline calculation needs to take this into account.
         weekday = created_at.date().weekday()
+        tzinfo = created_at.tzinfo
 
         if weekday > 4:
-            return datetime.combine(created_at.date(), time(0, 0, 0)) + timedelta(days=7-weekday)
+            return datetime.combine(created_at.date(), time(0, 0, 0), tzinfo=tzinfo) + timedelta(days=7-weekday)
         return created_at
 
     @staticmethod

--- a/api/app/tests/apps/services/domain/test_deadlines.py
+++ b/api/app/tests/apps/services/domain/test_deadlines.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 from django.test import TestCase
+from django.utils import timezone
 from django.utils.timezone import get_default_timezone
 from freezegun import freeze_time
 
@@ -67,11 +68,18 @@ FULL_TEST_CASES = [
 ]
 
 
+def is_aware(d):
+    """Datetime object `d` is timezone aware."""
+    return d.tzinfo is not None and d.tzinfo.utcoffset(d) is not None
+
+
 class TestDeadlineCalculationService(TestCase):
     def test_get_start(self):
         """
         Test start of work period for ServiceLevelObjectives in working days.
         """
+        tzinfo = timezone.get_default_timezone()
+
         TEST_CASES = [
             (datetime(2021, 2, 15, 12, 0, 0), datetime(2021, 2, 15, 12, 0, 0)),  # Monday 12:00 -> Monday 12:00
             (datetime(2021, 2, 16, 12, 0, 0), datetime(2021, 2, 16, 12, 0, 0)),  # Tuesday 12:00 -> Tuesday 12:00
@@ -79,13 +87,23 @@ class TestDeadlineCalculationService(TestCase):
             (datetime(2021, 2, 21, 12, 0, 0), datetime(2021, 2, 22, 0, 0, 0)),  # Sunday 12:00 -> Monday 00:00
         ]
         for created_at, start in TEST_CASES:
+            # Make sure we run these tests using "aware" datetime objects.
+            created_at = created_at.replace(tzinfo=tzinfo)
+            start = start.replace(tzinfo=tzinfo)
+            self.assertTrue(is_aware(created_at))
+            self.assertTrue(is_aware(start))
+
+            # Perform actual test.
             calculated_start = DeadlineCalculationService.get_start(created_at)
             self.assertEqual(calculated_start, start)
+            self.assertTrue(is_aware(calculated_start))  # check that timezone information is retained
 
     def test_get_end(self):
         """
         Test end of work period for ServiceLevelObjectives in working days.
         """
+        tzinfo = timezone.get_default_timezone()
+
         # We do not test weekends here (get_end is only called with weekdays)
         TEST_CASES = [
             # Columns below: created_at, n_days, factor, deadline
@@ -94,8 +112,16 @@ class TestDeadlineCalculationService(TestCase):
             (datetime(2021, 2, 22, 0, 0, 0), 1, 1, datetime(2021, 2, 23, 0, 0, 0)),  # Monday 00:00 -> Tuesday 00:00
         ]
         for start, n_days, factor, end in TEST_CASES:
+            # Make sure we run these tests using "aware" datetime objects.
+            start = start.replace(tzinfo=tzinfo)
+            end = end.replace(tzinfo=tzinfo)
+            self.assertTrue(is_aware(start))
+            self.assertTrue(is_aware(end))
+
+            # Perform actual test.
             calculated_end = DeadlineCalculationService.get_end(start, n_days, factor)
             self.assertEqual(calculated_end, end)
+            self.assertTrue(is_aware(calculated_end))
 
     def test_get_deadline(self):
         """
@@ -105,11 +131,21 @@ class TestDeadlineCalculationService(TestCase):
         - this tests both ServiceLevelObjectives given in calendar days and
           those given in working days.
         """
+        tzinfo = timezone.get_default_timezone()
+
         # Go through testcases check that we get the correct answers.
         for created_at, n_days, use_calendar_days, factor, deadline in FULL_TEST_CASES:
+            # Make sure we run these tests using "aware" datetime objects.
+            created_at = created_at.replace(tzinfo=tzinfo)
+            deadline = deadline.replace(tzinfo=tzinfo)
+            self.assertTrue(is_aware(created_at))
+            self.assertTrue(is_aware(deadline))
+
+            # Perform actual test.
             calculated_deadline = DeadlineCalculationService.get_deadline(
                 created_at, n_days, use_calendar_days, factor)
             self.assertEqual(calculated_deadline, deadline)
+            self.assertTrue(is_aware(calculated_deadline))
 
     def test_from_signal_and_category(self):
         """
@@ -129,6 +165,8 @@ class TestDeadlineCalculationService(TestCase):
         deadline, deadline_factor_3 = DeadlineCalculationService.from_signal_and_category(signal, cat)
         self.assertEqual(deadline, true_deadline)
         self.assertEqual(deadline_factor_3, true_deadline_factor_3)
+        self.assertTrue(is_aware(deadline))
+        self.assertTrue(is_aware(deadline_factor_3))
 
     def test_category_assignment_model(self):
         """
@@ -148,3 +186,5 @@ class TestDeadlineCalculationService(TestCase):
         self.assertEqual(cas._signal.created_at, start)
         self.assertEqual(cas.deadline, true_deadline)
         self.assertEqual(cas.deadline_factor_3, true_deadline_factor_3)
+        self.assertTrue(is_aware(cas.deadline))
+        self.assertTrue(is_aware(cas.deadline_factor_3))

--- a/api/app/tests/apps/services/domain/test_deadlines.py
+++ b/api/app/tests/apps/services/domain/test_deadlines.py
@@ -15,6 +15,8 @@ from signals.apps.signals.factories import (
     SignalFactory
 )
 
+# Note these testcases contain naive datetimes, but they are converted to
+# timezone aware datetimes in the tests below (see TestDeadlineCalculationService).
 FULL_TEST_CASES = [
     # Columns below: created_at, n_days, use_calendar_days, factor, deadline
     # One working day throughout week


### PR DESCRIPTION
## Description

Deadline calculations in SIA/Signalen did not properly propagate timezone information when calculating deadlines for complaints received during a weekend and whose service level agreement is given in working days.

This PR fixes that, and adapts the tests to prevent the problem from reoccuring.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
