### PR TITLE
Bugfix/sig 3745 no child signals in reporter context

### DIFF
--- a/api/app/signals/apps/api/serializers/signal_context.py
+++ b/api/app/signals/apps/api/serializers/signal_context.py
@@ -82,10 +82,13 @@ class SignalContextSerializer(HALSerializer):
 
         reporter_email = obj.reporter.email
 
-        signals_for_reporter_count = Signal.objects.filter_reporter(email=reporter_email).count()
+        signals_for_reporter_count = Signal.objects.filter_reporter(
+            email=reporter_email
+        ).filter(parent__isnull=True).count()
         open_signals_for_reporter_count = Signal.objects.filter_reporter(email=reporter_email).exclude(
             status__state__in=[workflow.GEANNULEERD, workflow.AFGEHANDELD, workflow.GESPLITST]
-        ).count()
+        ).filter(parent__isnull=True).count()
+        # Not filtering parent__isnull=True, as feedback is not requested for child signals.
         satisfied_count = Signal.objects.reporter_feedback_satisfied_count(email=reporter_email)
         not_satisfied_count = Signal.objects.reporter_feedback_not_satisfied_count(email=reporter_email)
 

--- a/api/app/signals/apps/api/views/signal_context.py
+++ b/api/app/signals/apps/api/views/signal_context.py
@@ -53,6 +53,8 @@ class SignalContextViewSet(mixins.RetrieveModelMixin, GenericViewSet):
             ).prefetch_related(
                 'feedback',
                 'category_assignment__category__departments'
+            ).filter(
+                parent__isnull=True
             ).filter_reporter(
                 email=signal.reporter.email
             ).order_by('-created_at')

--- a/api/app/tests/apps/api/test_signal_context_view.py
+++ b/api/app/tests/apps/api/test_signal_context_view.py
@@ -62,6 +62,9 @@ class TestSignalContextView(SuperUserMixin, APITestCase):
         self.anonymous_signals = [SignalFactory.create(reporter__email=None, status__state=workflow.BEHANDELING),
                                   SignalFactory.create(reporter__email='', status__state=workflow.BEHANDELING)]
         self.reporter_2_signals = SignalFactory.create_batch(size=5, reporter__email=self.reporter_2_email)
+        # Child signals ("deelmeldingen") should not show up in the reporter context, as they are used internally.
+        self.child_signals = SignalFactory.create_batch(
+            2, reporter__email=self.reporter_1_email, parent=self.reporter_1_signals.first())
 
     def test_get_signal_context(self):
         self.client.force_authenticate(user=self.superuser)


### PR DESCRIPTION
## Description

Because the child signal entries were not made by the reporter, they should not show up in the reporter context endpoint.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
