### PR TITLE
SIG-3662 Add note field to category, expose it in API.

### DIFF
--- a/api/app/signals/apps/api/serializers/category.py
+++ b/api/app/signals/apps/api/serializers/category.py
@@ -104,6 +104,7 @@ class PrivateCategorySerializer(HALSerializer):
             'sla',
             'new_sla',
             'departments',
+            'note',
         )
         read_only_fields = (
             'slug',

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -1611,6 +1611,7 @@ components:
         - QUE
         - COM
         - MAI
+      example: 'SIG'
 
     _NestedLocationRequestData:
       description: JSON Data
@@ -1713,10 +1714,10 @@ components:
         text:
           type: string
         state:
-          type: string
           $ref: '#/components/schemas/StatusStateChoices'
         target_api:
           type: string
+          nullable: true
           enum:
             - sigmax
             - null
@@ -1732,7 +1733,6 @@ components:
           nullable: true
           example: null
         state:
-          type: string
           $ref: '#/components/schemas/StatusStateChoices'
         target_api:
           type: string
@@ -1843,7 +1843,6 @@ components:
       type: object
       properties:
         priority:
-          type: string
           $ref: '#/components/schemas/PriorityPriorityChoices'
 
     _NestedPriorityResponseData:
@@ -1851,7 +1850,6 @@ components:
       type: object
       properties:
         priority:
-          type: string
           $ref: '#/components/schemas/PriorityPriorityChoices'
         created_by:
           type: string
@@ -1885,7 +1883,6 @@ components:
       type: object
       properties:
         code:
-          type: string
           $ref: '#/components/schemas/TypeCodeChoices'
 
     _NestedTypeResponseData:
@@ -1893,9 +1890,7 @@ components:
       type: object
       properties:
         code:
-          type: string
           $ref: '#/components/schemas/TypeCodeChoices'
-          example: 'SIG'
         created_at:
           type: string
           format: date-time
@@ -2537,6 +2532,10 @@ components:
                   identified by the `category_id` (true) or not (false).
                   Defaults to false.
                 type: boolean
+        note:
+          type: string
+          nullable: true
+          description: Note field, used internally.
 
     privateCategoryListResponse:
       description: JSON data describing the category response
@@ -2570,7 +2569,6 @@ components:
           type: array
           description: A list of categories, paginated
           items:
-            type: object
             $ref: '#/components/schemas/privateCategoryResponse'
 
     privateCategoryPatch:
@@ -2632,7 +2630,6 @@ components:
           type: array
           description: A list of categories, paginated
           items:
-            type: object
             $ref: '#/components/schemas/privateDepartmentResponse'
 
     privateDepartmentResponse:

--- a/api/app/signals/apps/signals/migrations/0140_category_note.py
+++ b/api/app/signals/apps/signals/migrations/0140_category_note.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2021 Gemeente Amsterdam
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0139_json_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='category',
+            name='note',
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/api/app/signals/apps/signals/models/category.py
+++ b/api/app/signals/apps/signals/models/category.py
@@ -97,7 +97,9 @@ class Category(models.Model):
                                        through='signals.CategoryQuestion',
                                        through_fields=('category', 'question'))
 
-    logger = ChangeLogger(track_fields=('name', 'description', 'is_active', 'slo', 'handling_message', ))
+    note = models.TextField(blank=True, null=True)
+
+    logger = ChangeLogger(track_fields=('name', 'description', 'is_active', 'slo', 'handling_message'))
 
     objects = CategoryManager()
 

--- a/api/app/tests/apps/api/test_private_category_endpoint.py
+++ b/api/app/tests/apps/api/test_private_category_endpoint.py
@@ -84,6 +84,8 @@ class TestPrivateCategoryEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase)
         else:
             self.assertEqual(0, len(data['departments']))
 
+        self.assertIn('note', data)
+
     def test_list_categories(self):
         self.client.force_authenticate(user=self.sia_read_write_user)
 
@@ -167,6 +169,7 @@ class TestPrivateCategoryEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase)
                 'use_calendar_days': True
             },
             'handling_message': 'Patched handling message',
+            'note': 'Very important note!',
         }
 
         response = self.client.patch(url, data=data, format='json')
@@ -213,6 +216,9 @@ class TestPrivateCategoryEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase)
         self.client.force_authenticate(user=self.sia_read_write_user)
 
         url = f'/signals/v1/private/categories/{self.parent_category.pk}'
+
+        response = self.client.patch(url, data={'note': 'This is a note'})  # must not show up in category history
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.client.patch(url, data={'name': 'Patched name'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/app/tests/apps/api/test_private_category_endpoint.py
+++ b/api/app/tests/apps/api/test_private_category_endpoint.py
@@ -85,6 +85,7 @@ class TestPrivateCategoryEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase)
             self.assertEqual(0, len(data['departments']))
 
         self.assertIn('note', data)
+        self.assertEqual(data['note'], category.note)
 
     def test_list_categories(self):
         self.client.force_authenticate(user=self.sia_read_write_user)


### PR DESCRIPTION
## Description

Add a note field to category model, expose it in API. Note this field's history is not tracked.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
