### PR TITLE
SIG-3761 add additional trigger categories to automatic child creation

### DIFF
--- a/api/app/signals/apps/services/domain/auto_create_children.py
+++ b/api/app/signals/apps/services/domain/auto_create_children.py
@@ -20,12 +20,16 @@ class AutoCreateChildrenService:
         - The feature flag "AUTOMATICALLY_CREATE_CHILD_SIGNALS_PER_CONTAINER" is enabled
         - A signal is not a parent or a child signal
         - A signal has the status "GEMELD" ("m")
-        - A signal belongs to the sub category "container-is-vol", "container-voor-papier-is-vol", "container-voor-plastic-afval-is-vol" or "container-glas-vol"
+        - A signal belongs to the sub category "container-is-vol", "container-voor-papier-is-vol",
+          "container-voor-plastic-afval-is-vol", "container-glas-vol", "container-glas-kapot",
+          "container-is-kapot", "container-voor-papier-is-stuk", or "container-voor-plastic-afval-is-kapot".
         - A signal must contain at least 2 or more containers but not more than the value of the setting SIGNAL_MAX_NUMBER_OF_CHILDREN
         
         For now this is only used to create child signals when multiple containers are selected.
     """  # noqa
 
+    # These are the default categories used to create child Signals based on the
+    # type of refuse.
     _type_2_category_slug = {
         'rest': 'container-is-vol',
         'papier': 'container-voor-papier-is-vol',
@@ -33,6 +37,15 @@ class AutoCreateChildrenService:
         'glas': 'container-glas-vol',
         'default': 'container-is-vol',
     }
+
+    # These are the categories that trigger the creation of child Signals, child
+    # signals will be mapped to the categories listed in _type_2_category_slug.
+    _trigger_types = set(_type_2_category_slug.values()).union(set([
+        'container-glas-kapot',
+        'container-is-kapot',
+        'container-voor-papier-is-stuk',
+        'container-voor-plastic-afval-is-kapot',
+    ]))
 
     @staticmethod
     def _get_container_location(id_number, default=None):
@@ -97,7 +110,9 @@ class AutoCreateChildrenService:
         """
         - A signal is not a parent or a child signal
         - A signal has the status "GEMELD" ("m")
-        - A signal belongs to the sub category "container-is-vol", "container-voor-papier-is-vol", "container-voor-plastic-afval-is-vol" or "container-glas-vol"
+        - A signal belongs to the sub category "container-is-vol", "container-voor-papier-is-vol",
+          "container-voor-plastic-afval-is-vol", "container-glas-vol", "container-glas-kapot",
+          "container-is-kapot", "container-voor-papier-is-stuk", or "container-voor-plastic-afval-is-kapot".
         - A signal must contain at least 2 or more containers but not more than the value of the setting SIGNAL_MAX_NUMBER_OF_CHILDREN
         
         For now this is only used to create child signals when multiple containers are selected.
@@ -106,7 +121,7 @@ class AutoCreateChildrenService:
             return False
 
         category_slug = signal.category_assignment.category.slug
-        if category_slug not in set(AutoCreateChildrenService._type_2_category_slug.values()):
+        if category_slug not in AutoCreateChildrenService._trigger_types:
             return False
 
         selected_containers = len(AutoCreateChildrenService._container_data(signal))


### PR DESCRIPTION
## Description

The feature that creates child signals automatically for complaints about garbage containers needs more triggering categories. Specifically the broken container categories should also trigger child signal creation. Note that all child signals are created in the full container categories[1].

[1] We cannot differentiate between a broken or a full paper container in a complaint classified as full paper container. The map select functionality for containers does not provide enough information to make the distinction. Business made the decision to classify these automatically created child signals as complaints about full containers.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
