### PR TITLE
Attachments are now copied to the automatically created children

### DIFF
--- a/api/app/signals/apps/services/domain/auto_create_children.py
+++ b/api/app/signals/apps/services/domain/auto_create_children.py
@@ -165,7 +165,12 @@ class AutoCreateChildrenService:
         }
 
         # Create the child signal using the actions manager
-        Signal.actions.create_initial(signal_data, location_data, status_data, category_data, {})
+        child_signal = Signal.actions.create_initial(signal_data, location_data, status_data, category_data, {})
+
+        # Copy attachments to the child signal
+        attachment_qs = signal.attachments.filter(is_image=True)
+        if attachment_qs.exists():
+            Signal.actions.copy_attachments(data=attachment_qs.all(), signal=child_signal)
 
     @staticmethod
     def run(signal_id):


### PR DESCRIPTION
## Description

Attachments are now copied to the automatically created children

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
