### PR TITLE
Added support for dataware house zip file rotation

### DIFF
--- a/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
@@ -19,7 +19,7 @@ from signals.apps.reporting.csv.datawarehouse.signals import (
     create_signals_routing_departments_csv
 )
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
-from signals.apps.reporting.csv.utils import save_csv_files, zip_csv_files
+from signals.apps.reporting.csv.utils import rotate_zip_files, save_csv_files, zip_csv_files
 from signals.celery import app
 
 
@@ -77,7 +77,7 @@ def zip_csv_files_endpoint(files: list):
 
 
 @app.task
-def save_and_zip_csv_files_endpoint():
+def save_and_zip_csv_files_endpoint(max_csv_amount: int = 30):
     """
     Create zip file of generated csv files
 
@@ -85,3 +85,4 @@ def save_and_zip_csv_files_endpoint():
     """
     created_files = save_csv_files_datawarehouse(using=None)
     zip_csv_files(files_to_zip=created_files, using='datawarehouse')
+    rotate_zip_files(using='datawarehouse', max_csv_amount=max_csv_amount)

--- a/api/app/tests/apps/reporting/test_datawarehouse.py
+++ b/api/app/tests/apps/reporting/test_datawarehouse.py
@@ -5,7 +5,6 @@ import json
 import os
 import shutil
 import tempfile
-import time
 from datetime import datetime
 from glob import glob
 from os import path
@@ -123,11 +122,11 @@ class TestDatawarehouse(testcases.TestCase):
         # Creating a few objects in the database.
         for i in range(3):
             SignalFactory.create()
-        datawarehouse.save_and_zip_csv_files_endpoint(max_csv_amount=1)
-        # we need to wait for 1 sec in order to ensure that we will get an different resulting zip file name
-        # else it will generate the same file twice
-        time.sleep(1)
-        datawarehouse.save_and_zip_csv_files_endpoint(max_csv_amount=1)
+        # force certain output name
+        with freeze_time('2020-09-10T14:00:00+00:00'):
+            datawarehouse.save_and_zip_csv_files_endpoint(max_csv_amount=1)
+        with freeze_time('2020-09-10T15:00:00+00:00'):
+            datawarehouse.save_and_zip_csv_files_endpoint(max_csv_amount=1)
         now = timezone.now()
         src_folder = f'{self.file_backend_tmp_dir}/{now:%Y}/{now:%m}/{now:%d}'
         list_of_files = glob(f'{src_folder}/*.zip', recursive=True)

--- a/api/app/tests/apps/reporting/test_datawarehouse.py
+++ b/api/app/tests/apps/reporting/test_datawarehouse.py
@@ -13,7 +13,6 @@ from unittest import mock
 import pytz
 from django.core.files.storage import FileSystemStorage
 from django.test import override_settings, testcases
-from django.utils import timezone
 from freezegun import freeze_time
 
 from signals.apps.feedback.factories import FeedbackFactory
@@ -127,10 +126,11 @@ class TestDatawarehouse(testcases.TestCase):
             datawarehouse.save_and_zip_csv_files_endpoint(max_csv_amount=1)
         with freeze_time('2020-09-10T15:00:00+00:00'):
             datawarehouse.save_and_zip_csv_files_endpoint(max_csv_amount=1)
-        now = timezone.now()
-        src_folder = f'{self.file_backend_tmp_dir}/{now:%Y}/{now:%m}/{now:%d}'
+
+        src_folder = f'{self.file_backend_tmp_dir}/2020/09/10'
         list_of_files = glob(f'{src_folder}/*.zip', recursive=True)
         self.assertEqual(1, len(list_of_files))
+        self.assertTrue(list_of_files[0].endswith('20200910_150000UTC.zip'))
 
     @override_settings(
         SWIFT={

--- a/api/app/tests/apps/reporting/test_datawarehouse.py
+++ b/api/app/tests/apps/reporting/test_datawarehouse.py
@@ -5,6 +5,7 @@ import json
 import os
 import shutil
 import tempfile
+import time
 from datetime import datetime
 from glob import glob
 from os import path
@@ -122,8 +123,11 @@ class TestDatawarehouse(testcases.TestCase):
         # Creating a few objects in the database.
         for i in range(3):
             SignalFactory.create()
-        datawarehouse.save_and_zip_csv_files_endpoint.delay(1)
-        datawarehouse.save_and_zip_csv_files_endpoint.delay(1)
+        datawarehouse.save_and_zip_csv_files_endpoint(max_csv_amount=1)
+        # we need to wait for 1 sec in order to ensure that we will get an different resulting zip file name
+        # else it will generate the same file twice
+        time.sleep(1)
+        datawarehouse.save_and_zip_csv_files_endpoint(max_csv_amount=1)
         now = timezone.now()
         src_folder = f'{self.file_backend_tmp_dir}/{now:%Y}/{now:%m}/{now:%d}'
         list_of_files = glob(f'{src_folder}/*.zip', recursive=True)


### PR DESCRIPTION
## Description
We would to rotate the amount of zip files when generating them for the csv end point.
The default is set to 30 files, and can be overridden by a setting in django admin (celery task)
