### PR TITLE
Added FRONTEND_URL setting in favour of the FEEDBACK_ENV_FE_MAPPING

### DIFF
--- a/api/app/signals/apps/feedback/utils.py
+++ b/api/app/signals/apps/feedback/utils.py
@@ -17,6 +17,13 @@ class NoFrontendAppConfigured(Exception):
 
 def get_fe_application_location():
     """Get location of frontend SIA application."""
+
+    # Temporary workaround, will be removed if feedback is moved to the Questionnaires app
+    fe_url = settings.FE_URL
+    if fe_url:
+        return fe_url
+
+    # If there is no fe_url set fallback to the "old" way of determining the FE url
     env_fe_mapping = copy.deepcopy(getattr(
         settings,
         'FEEDBACK_ENV_FE_MAPPING',

--- a/api/app/signals/apps/feedback/utils.py
+++ b/api/app/signals/apps/feedback/utils.py
@@ -19,11 +19,11 @@ def get_fe_application_location():
     """Get location of frontend SIA application."""
 
     # Temporary workaround, will be removed if feedback is moved to the Questionnaires app
-    fe_url = settings.FE_URL
-    if fe_url:
-        return fe_url
+    frontend_url = settings.FRONTEND_URL
+    if frontend_url:
+        return frontend_url
 
-    # If there is no fe_url set fallback to the "old" way of determining the FE url
+    # If there is no FRONTEND_URL set fallback to the "old" way of determining the frontend url
     env_fe_mapping = copy.deepcopy(getattr(
         settings,
         'FEEDBACK_ENV_FE_MAPPING',

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -468,12 +468,15 @@ SIGMAX_SEND_FAIL_TIMEOUT_MINUTES = os.getenv('SIGMAX_SEND_FAIL_TIMEOUT_MINUTES',
 # Child settings
 SIGNAL_MAX_NUMBER_OF_CHILDREN = 10
 
-# SIG-1017
+# SIG-1017, replaced by setting the correct FE_URL setting when deploying
 FEEDBACK_ENV_FE_MAPPING = {
     'LOCAL': 'http://dummy_link',
     'ACCEPTANCE': os.getenv('FEEDBACK_ENV_FE_MAPPING', 'https://acc.meldingen.amsterdam.nl'),
     'PRODUCTION': os.getenv('FEEDBACK_ENV_FE_MAPPING', 'https://meldingen.amsterdam.nl'),
 }
+
+# The URL of the Frontend, to replace the FEEDBACK_ENV_FE_MAPPING setting
+FE_URL = os.getenv('FE_URL', None)
 
 ML_TOOL_ENDPOINT = os.getenv('SIGNALS_ML_TOOL_ENDPOINT', 'https://api.data.amsterdam.nl/signals_mltool')  # noqa
 

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -468,7 +468,7 @@ SIGMAX_SEND_FAIL_TIMEOUT_MINUTES = os.getenv('SIGMAX_SEND_FAIL_TIMEOUT_MINUTES',
 # Child settings
 SIGNAL_MAX_NUMBER_OF_CHILDREN = 10
 
-# SIG-1017, replaced by setting the correct FE_URL setting when deploying
+# SIG-1017, replaced by setting the correct FRONTEND_URL setting when deploying
 FEEDBACK_ENV_FE_MAPPING = {
     'LOCAL': 'http://dummy_link',
     'ACCEPTANCE': os.getenv('FEEDBACK_ENV_FE_MAPPING', 'https://acc.meldingen.amsterdam.nl'),
@@ -476,7 +476,7 @@ FEEDBACK_ENV_FE_MAPPING = {
 }
 
 # The URL of the Frontend, to replace the FEEDBACK_ENV_FE_MAPPING setting
-FE_URL = os.getenv('FE_URL', None)
+FRONTEND_URL = os.getenv('FRONTEND_URL', None)
 
 ML_TOOL_ENDPOINT = os.getenv('SIGNALS_ML_TOOL_ENDPOINT', 'https://api.data.amsterdam.nl/signals_mltool')  # noqa
 

--- a/api/app/signals/settings/development.py
+++ b/api/app/signals/settings/development.py
@@ -29,6 +29,8 @@ TEST_LOGIN = os.getenv('TEST_LOGIN', 'signals.admin@example.com')
 
 # ML_TOOL_ENDPOINT = 'https://acc.api.data.amsterdam.nl/signals_mltool'
 
+FE_URL = os.getenv('FE_URL', 'https://acc.meldingen.amsterdam.nl')
+
 try:
     from signals.settings.local import *  # noqa
 except ImportError:

--- a/api/app/signals/settings/development.py
+++ b/api/app/signals/settings/development.py
@@ -29,7 +29,7 @@ TEST_LOGIN = os.getenv('TEST_LOGIN', 'signals.admin@example.com')
 
 # ML_TOOL_ENDPOINT = 'https://acc.api.data.amsterdam.nl/signals_mltool'
 
-FRONTEND_URL = os.getenv('FRONTEND_URL', 'https://acc.meldingen.amsterdam.nl')
+FRONTEND_URL = os.getenv('FRONTEND_URL', 'http://dummy_link')
 
 try:
     from signals.settings.local import *  # noqa

--- a/api/app/signals/settings/development.py
+++ b/api/app/signals/settings/development.py
@@ -29,7 +29,7 @@ TEST_LOGIN = os.getenv('TEST_LOGIN', 'signals.admin@example.com')
 
 # ML_TOOL_ENDPOINT = 'https://acc.api.data.amsterdam.nl/signals_mltool'
 
-FE_URL = os.getenv('FE_URL', 'https://acc.meldingen.amsterdam.nl')
+FRONTEND_URL = os.getenv('FRONTEND_URL', 'https://acc.meldingen.amsterdam.nl')
 
 try:
     from signals.settings.local import *  # noqa

--- a/api/app/signals/settings/testing.py
+++ b/api/app/signals/settings/testing.py
@@ -19,3 +19,5 @@ SIGNALS_AUTHZ = {
 
 FEATURE_FLAGS['API_SEARCH_ENABLED'] = False  # noqa F405
 FEATURE_FLAGS['SEARCH_BUILD_INDEX'] = False  # noqa F405
+
+FE_URL = 'http://dummy_link'

--- a/api/app/signals/settings/testing.py
+++ b/api/app/signals/settings/testing.py
@@ -20,4 +20,4 @@ SIGNALS_AUTHZ = {
 FEATURE_FLAGS['API_SEARCH_ENABLED'] = False  # noqa F405
 FEATURE_FLAGS['SEARCH_BUILD_INDEX'] = False  # noqa F405
 
-FE_URL = 'http://dummy_link'
+FRONTEND_URL = 'http://dummy_link'

--- a/api/app/tests/apps/email_integrations/test_mail.py
+++ b/api/app/tests/apps/email_integrations/test_mail.py
@@ -325,8 +325,8 @@ class TestMailRuleConditions(BaseTestMailCase):
         # we want a history entry when a email was sent
         self.assertEqual(Note.objects.count(), 1)
 
-    @override_settings(FE_URL=None)
-    def test_links_in_different_environments_fe_url_not_set(self):
+    @override_settings(FRONTEND_URL=None)
+    def test_links_in_different_environments_frontend_url_not_set(self):
         """Test that generated feedback links contain the correct host."""
         # Prepare signal with status change to `AFGEHANDELD`.
         StatusFactory.create(_signal=self.signal, state=workflow.BEHANDELING)
@@ -355,7 +355,7 @@ class TestMailRuleConditions(BaseTestMailCase):
         # we want a history entry when a email was sent
         self.assertEqual(Note.objects.count(), len(env_fe_mapping))
 
-    def test_links_in_different_environments_fe_url_set(self):
+    def test_links_in_different_environments_frontend_url_set(self):
         """Test that generated feedback links contain the correct host."""
         # Prepare signal with status change to `AFGEHANDELD`.
         StatusFactory.create(_signal=self.signal, state=workflow.BEHANDELING)
@@ -363,20 +363,21 @@ class TestMailRuleConditions(BaseTestMailCase):
         self.signal.status = status
         self.signal.save()
 
-        test_fe_urls = ['https://acc.meldingen.amsterdam.nl', 'https://meldingen.amsterdam.nl', 'https://random.net', ]
-        for test_fe_url in test_fe_urls:
-            with override_settings(FE_URL=test_fe_url):
+        test_frontend_urls = ['https://acc.meldingen.amsterdam.nl', 'https://meldingen.amsterdam.nl',
+                              'https://random.net', ]
+        for test_frontend_url in test_frontend_urls:
+            with override_settings(FRONTEND_URL=test_frontend_url):
                 mail.outbox = []
                 ma = MailActions(mail_rules=SIGNAL_MAIL_RULES)
                 ma.apply(signal_id=self.signal.id)
 
                 self.assertEqual(len(mail.outbox), 1)
                 message = mail.outbox[0]
-                self.assertIn(test_fe_url, message.body)
-                self.assertIn(test_fe_url, message.alternatives[0][0])
+                self.assertIn(test_frontend_url, message.body)
+                self.assertIn(test_frontend_url, message.alternatives[0][0])
 
         # we want a history entry when a email was sent
-        self.assertEqual(Note.objects.count(), len(test_fe_urls))
+        self.assertEqual(Note.objects.count(), len(test_frontend_urls))
 
     def test_links_environment_env_var_not_set(self):
         """Deals with the case where nothing is overridden and `environment` not set."""

--- a/api/app/tests/apps/email_integrations/test_mail.py
+++ b/api/app/tests/apps/email_integrations/test_mail.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.core import mail
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from freezegun import freeze_time
 
 from signals.apps.email_integrations.mail_actions import MailActions
@@ -325,7 +325,8 @@ class TestMailRuleConditions(BaseTestMailCase):
         # we want a history entry when a email was sent
         self.assertEqual(Note.objects.count(), 1)
 
-    def test_links_in_different_environments(self):
+    @override_settings(FE_URL=None)
+    def test_links_in_different_environments_fe_url_not_set(self):
         """Test that generated feedback links contain the correct host."""
         # Prepare signal with status change to `AFGEHANDELD`.
         StatusFactory.create(_signal=self.signal, state=workflow.BEHANDELING)
@@ -353,6 +354,29 @@ class TestMailRuleConditions(BaseTestMailCase):
 
         # we want a history entry when a email was sent
         self.assertEqual(Note.objects.count(), len(env_fe_mapping))
+
+    def test_links_in_different_environments_fe_url_set(self):
+        """Test that generated feedback links contain the correct host."""
+        # Prepare signal with status change to `AFGEHANDELD`.
+        StatusFactory.create(_signal=self.signal, state=workflow.BEHANDELING)
+        status = StatusFactory.create(_signal=self.signal, state=workflow.AFGEHANDELD)
+        self.signal.status = status
+        self.signal.save()
+
+        test_fe_urls = ['https://acc.meldingen.amsterdam.nl', 'https://meldingen.amsterdam.nl', 'https://random.net', ]
+        for test_fe_url in test_fe_urls:
+            with override_settings(FE_URL=test_fe_url):
+                mail.outbox = []
+                ma = MailActions(mail_rules=SIGNAL_MAIL_RULES)
+                ma.apply(signal_id=self.signal.id)
+
+                self.assertEqual(len(mail.outbox), 1)
+                message = mail.outbox[0]
+                self.assertIn(test_fe_url, message.body)
+                self.assertIn(test_fe_url, message.alternatives[0][0])
+
+        # we want a history entry when a email was sent
+        self.assertEqual(Note.objects.count(), len(test_fe_urls))
 
     def test_links_environment_env_var_not_set(self):
         """Deals with the case where nothing is overridden and `environment` not set."""

--- a/api/app/tests/apps/feedback/test_feedback.py
+++ b/api/app/tests/apps/feedback/test_feedback.py
@@ -316,8 +316,8 @@ class TestUtils(TestCase):
     def setUp(self):
         self.feedback = FeedbackFactory()
 
-    @override_settings(FE_URL=None)
-    def test_link_generation_with_environment_set_fe_url_not_set(self):
+    @override_settings(FRONTEND_URL=None)
+    def test_link_generation_with_environment_set_frontend_url_not_set(self):
         env_fe_mapping = copy.deepcopy(getattr(
             settings,
             'FEEDBACK_ENV_FE_MAPPING',
@@ -332,14 +332,15 @@ class TestUtils(TestCase):
                 self.assertIn(fe_location, pos_url)
                 self.assertIn(fe_location, neg_url)
 
-    def test_link_generation_with_environment_set_fe_url_set(self):
-        test_fe_urls = ['https://acc.meldingen.amsterdam.nl', 'https://meldingen.amsterdam.nl', 'https://random.net', ]
-        for test_fe_url in test_fe_urls:
-            with override_settings(FE_URL=test_fe_url):
+    def test_link_generation_with_environment_set_frontend_url_set(self):
+        test_frontend_urls = ['https://acc.meldingen.amsterdam.nl', 'https://meldingen.amsterdam.nl',
+                              'https://random.net', ]
+        for test_frontend_url in test_frontend_urls:
+            with override_settings(FRONTEND_URL=test_frontend_url):
                 pos_url, neg_url = get_feedback_urls(self.feedback)
 
-                self.assertIn(test_fe_url, pos_url)
-                self.assertIn(test_fe_url, neg_url)
+                self.assertIn(test_frontend_url, pos_url)
+                self.assertIn(test_frontend_url, neg_url)
 
     def test_link_generation_no_environment_set(self):
         with mock.patch.dict('os.environ', {}, clear=True):


### PR DESCRIPTION
Added a setting to contain the frontend url, FE_URL. This setting replaces the FEEDBACK_ENV_FE_MAPPING setting currently available. The feedback util function get_fe_application_location will return the FE_URL and if it is not set it will fallback on the FEEDBACK_ENV_FE_MAPPING. This will be refactored in the near future

## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
