### PR TITLE
Remove DataDog Tracing package as it is not being used any more

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -21,7 +21,6 @@ coverage==5.5
 cryptography==3.4.7
 cssselect2==0.4.1
 datapunt-authorization-django==1.3.0
-ddtrace==0.48.0
 debtcollector==2.2.0
 defusedxml==0.7.1
 distlib==0.3.1

--- a/api/requirements/req-base.txt
+++ b/api/requirements/req-base.txt
@@ -36,9 +36,6 @@ Celery
 # Sentry
 raven
 
-# DataDog Tracing
-ddtrace
-
 # PDF
 lxml
 WeasyPrint

--- a/docs/topics/application-design.md
+++ b/docs/topics/application-design.md
@@ -176,11 +176,3 @@ through the aforementioned checks.
 SIA uses Sentry to track application errors. SIA HTTP traffic is logged in the
 general Datapunt logging as well, because SIA is running on Datapunt
 infrastructure.
-
-Also DataDog can also be used to track application errors. To enable [ddtrace]
-(https://ddtrace.readthedocs.io/) configure the environment variable
-`DD_AGENT_HOST` to the DataDog agent and override the run command:
-
-```bash
-ddtrace-run uwsgi --enable-threads ...
-```


### PR DESCRIPTION
## Description

We now monitor endpoints using [Linkerd](https://linkerd.io/) and we collect container logs with [Promtail](https://grafana.com/docs/loki/latest/clients/promtail/).

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Documentation has been updated if needed
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts
- [ ] There are no conflicting Django migrations

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 90% (the higher the better)
- [ ] No iSort issues are present in the code
- [ ] No Flake8 issues are present in the code
