### PR TITLE
SIG-3896 use woonplaats field from PDOK derived addresses for CityCon…

### DIFF
--- a/api/app/signals/apps/sigmax/templates/sigmax/creeerZaak_Lk01.xml
+++ b/api/app/signals/apps/sigmax/templates/sigmax/creeerZaak_Lk01.xml
@@ -43,7 +43,7 @@
                 <ZKN:heeftBetrekkingOp StUF:entiteittype="ZAKOBJ" StUF:verwerkingssoort="T">
                     <ZKN:gerelateerde>
                         <ZKN:adres StUF:entiteittype="AOA" StUF:verwerkingssoort="T">
-                            <BG:wpl.woonplaatsNaam>Amsterdam</BG:wpl.woonplaatsNaam>
+                            <BG:wpl.woonplaatsNaam>{{ signal.location.address.woonplaats }}</BG:wpl.woonplaatsNaam>
                             <BG:gor.openbareRuimteNaam>{{ signal.location.address.openbare_ruimte }}</BG:gor.openbareRuimteNaam>
                             <BG:huisnummer>{{ signal.location.address.huisnummer }}</BG:huisnummer>
                             <BG:huisletter StUF:noValue="geenWaarde" xsi:nil="true"/>


### PR DESCRIPTION
## Description

Woonplaats property of addresses is not used properly when communicating with CityControl. Fix is a one-liner.


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
