### PR TITLE
add day variable to dsl context

### DIFF
--- a/api/app/signals/apps/services/domain/dsl.py
+++ b/api/app/signals/apps/services/domain/dsl.py
@@ -55,6 +55,7 @@ class SignalContext:
             'location': signal.location.geometrie,
             'stadsdeel': signal.location.stadsdeel,
             'time': time.strptime(t, "%H:%M:%S"),
+            'day': signal.incident_date_start.strftime("%A"),
             'areas': self.areas
         }
 


### PR DESCRIPTION
## Description

We need to make a distinction between days when routing a signal. Signals in the weekend can be routed differently compared to weekdays. For this purpose a variable 'day' is introduced similar to 'time'

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Documentation has been updated if needed
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts
- [ ] There are no conflicting Django migrations

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 90% (the higher the better)
- [ ] No iSort issues are present in the code
- [ ] No Flake8 issues are present in the code
