### PR TITLE
Fix Elasticsearch index setting that is not working

### DIFF
--- a/api/app/signals/apps/search/documents/signal.py
+++ b/api/app/signals/apps/search/documents/signal.py
@@ -6,6 +6,7 @@ from elasticsearch_dsl import Date, InnerDoc, Keyword, Nested, Object, Text
 from elasticsearch_dsl.query import Bool
 
 from signals.apps.search.documents.base import DocumentBase
+from signals.apps.search.settings import app_settings
 from signals.apps.signals.models import Signal
 
 log = logging.getLogger(__name__)
@@ -61,7 +62,7 @@ class SignalDocument(DocumentBase):
     updated_at = Date()
 
     class Index:
-        name = 'signals'
+        name = app_settings.CONNECTION['INDEX']
         using = 'default'
 
     def get_model(self):

--- a/api/app/signals/apps/search/settings.py
+++ b/api/app/signals/apps/search/settings.py
@@ -7,7 +7,7 @@ DEFAULTS = dict(
     PAGE_SIZE=100,
     CONNECTION=dict(
         HOST='http://127.0.0.1:9200',
-        INDEX_NAME='sia_signals',
+        INDEX='signals',
     ),
 )
 

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -463,7 +463,7 @@ SEARCH = {
     'PAGE_SIZE': 500,
     'CONNECTION': {
         'HOST': os.getenv('ELASTICSEARCH_HOST', 'elastic-index.service.consul:9200'),
-        'INDEX': os.getenv('ELASTICSEARCH_INDEX', 'sia_signals'),
+        'INDEX': os.getenv('ELASTICSEARCH_INDEX', 'signals'),
     },
 }
 


### PR DESCRIPTION
## Description

This PR fixes a bug that the Elasticsearch index is not configurable. It always defaulted to `sia_signals`. 

⚠️  This change is breaking for deployments that currently configure `ELASTICSEARCH_INDEX` to something else then `signals`.

Closes https://github.com/Signalen/backend/issues/161

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts

## How has this been tested?

- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
