### PR TITLE
Feature/sig 3927 session submit endpoint

### DIFF
--- a/api/app/signals/apps/questionnaires/rest_framework/views/public.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public.py
@@ -119,3 +119,13 @@ class PublicSessionViewSet(HALViewSetRetrieve):
             raise Gone('Expired!')
 
         return session
+
+    @action(detail=True, url_path=r'submit/?$', methods=['POST', ])
+    def submit(self, request, *args, **kwargs):
+        # TODO: calls to this endpoint are not idempotent, investigate whether
+        # they should be.
+        session = self.get_object()
+        QuestionnairesService.freeze_session(session)
+
+        serializer = self.serializer_detail_class(session, context=self.get_serializer_context())
+        return Response(serializer.data, status=200)

--- a/api/app/signals/apps/questionnaires/rest_framework/views/public.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public.py
@@ -109,6 +109,8 @@ class PublicSessionViewSet(HALViewSetRetrieve):
 
         try:
             session = QuestionnairesService.get_session(session_uuid)
+        except Session.DoesNotExist:
+            raise Http404
         except Exception as e:
             # For now just re-raise the exception as a DRF APIException
             raise APIException(str(e))

--- a/api/app/signals/apps/questionnaires/services/questionnaires.py
+++ b/api/app/signals/apps/questionnaires/services/questionnaires.py
@@ -113,6 +113,14 @@ class QuestionnairesService:
         return answer
 
     @staticmethod
+    def freeze_session(session):
+        session.frozen = True
+        session.save()
+
+        QuestionnairesService.handle_frozen_session(session)
+        return session
+
+    @staticmethod
     def handle_frozen_session(session):
         if session.questionnaire.flow == Questionnaire.REACTION_REQUEST:
             ReactionRequestService.handle_frozen_session_REACTION_REQUEST(session)

--- a/api/app/signals/apps/questionnaires/templates/questionnaires/swagger/public_openapi.yaml
+++ b/api/app/signals/apps/questionnaires/templates/questionnaires/swagger/public_openapi.yaml
@@ -129,6 +129,33 @@ paths:
         '404':
           description: Question not found
 
+  /public/qa/questions/{UUID}/submit:
+    parameters:
+      - name: UUID
+        in: path
+        description: UUID of Question
+        required: true
+        schema:
+          type: string
+          pattern: '^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$'
+          example: '00000000-0000-0000-0000-000000000000'
+    post:
+      description: Submit a session (i.e. freeze it)
+
+      responses:
+        '200':
+          description: Detail of the frozen Session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicSession'
+        '400':
+          description: Request invalid
+        '404':
+          description: Question not found
+        '410':
+          description: Session already used or expired.
+
   /public/qa/sessions/{UUID}:
     parameters:
       - name: UUID

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_sessions_endpoint.py
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_sessions_endpoint.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2021 Gemeente Amsterdam
 import os
+import uuid
 from unittest.mock import patch
 
 from django.test import override_settings
@@ -128,7 +129,7 @@ class TestPublicSessionEndpoint(ValidateJsonSchemaMixin, APITestCase):
         self.assertEqual(response.status_code, 405)
 
     @patch('signals.apps.questionnaires.services.questionnaires.QuestionnairesService.handle_frozen_session')
-    def test_session_submit(self, patched):
+    def test_session_submit_OLD(self, patched):
         session = SessionFactory.create(questionnaire=self.questionnaire)
 
         response = self.client.post(f'{self.base_endpoint}{session.uuid}/submit/')
@@ -138,3 +139,10 @@ class TestPublicSessionEndpoint(ValidateJsonSchemaMixin, APITestCase):
 
         response = self.client.post(f'{self.base_endpoint}{session.uuid}/submit/')
         self.assertEqual(response.status_code, 410)
+
+        generated = uuid.uuid4()
+        while generated == session.uuid:
+            generated = uuid.uuid4()
+        response = self.client.post(f'{self.base_endpoint}{str(generated)}/submit/')
+
+        self.assertEqual(response.status_code, 404)

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_sessions_endpoint.py
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_sessions_endpoint.py
@@ -129,7 +129,7 @@ class TestPublicSessionEndpoint(ValidateJsonSchemaMixin, APITestCase):
         self.assertEqual(response.status_code, 405)
 
     @patch('signals.apps.questionnaires.services.questionnaires.QuestionnairesService.handle_frozen_session')
-    def test_session_submit_OLD(self, patched):
+    def test_session_submit(self, patched):
         session = SessionFactory.create(questionnaire=self.questionnaire)
 
         response = self.client.post(f'{self.base_endpoint}{session.uuid}/submit/')


### PR DESCRIPTION
## Description

Freeze a session by POSTing to a separate endpoint (in stead of the special "submit" question).

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
