### PR TITLE
Pinned rabbitmq to version 3.8, in rabbitmq 3.9 and up the use of env…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - postgres-data:/var/lib/postgresql/data
 
   rabbit:
-    image: rabbitmq:3
+    image: rabbitmq:3.8
     ports:
      - "5672:5672"
     environment:


### PR DESCRIPTION
## Description

Pinned rabbitmq to version 3.8, in rabbitmq 3.9 and up the use of env variables is deprecated

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
