### PR TITLE
Differentiate analysis_key and retrieval_key fields for questionnaire…

### DIFF
--- a/api/app/signals/apps/questionnaires/admin/admins.py
+++ b/api/app/signals/apps/questionnaires/admin/admins.py
@@ -36,10 +36,10 @@ class QuestionGraphAdmin(admin.ModelAdmin):
 
 
 class QuestionAdmin(admin.ModelAdmin):
-    fields = ('key', 'uuid', 'label', 'short_label', 'field_type', 'required', 'created_at',)
+    fields = ('retrieval_key', 'analysis_key', 'uuid', 'label', 'short_label', 'field_type', 'required', 'created_at',)
     readonly_fields = ('uuid', 'created_at',)
 
-    list_display = ('key', 'uuid', 'field_type', 'created_at',)
+    list_display = ('retrieval_key', 'analysis_key', 'uuid', 'field_type', 'created_at',)
     list_per_page = 20
     list_select_related = True
 

--- a/api/app/signals/apps/questionnaires/factories.py
+++ b/api/app/signals/apps/questionnaires/factories.py
@@ -19,7 +19,8 @@ fake = Faker()
 
 
 class QuestionFactory(DjangoModelFactory):
-    key = Sequence(lambda n: f'question-{n}')
+    retrieval_key = Sequence(lambda n: f'question-{n}')
+    analysis_key = Sequence(lambda n: f'analysis-key-for-question-{n}')
     # Note we only create plain_text questions in this factory, with no
     # next question reference present. Tests that need those will have to
     # create model instances themselves.

--- a/api/app/signals/apps/questionnaires/managers.py
+++ b/api/app/signals/apps/questionnaires/managers.py
@@ -11,14 +11,14 @@ from django.db.models.functions import Now
 class QuestionManager(models.Manager):
     def get_by_reference(self, ref):
         """
-        Retrieve question key or uuid (either can be the ref).
+        Retrieve question retrieval_key or uuid (either can be the ref).
         """
         if ref is None:
             msg = 'Cannot get Question instance for ref=None'
             raise self.model.DoesNotExist(msg)
 
         try:
-            return self.get(key=ref)
+            return self.get(retrieval_key=ref)
         except self.model.DoesNotExist:
             try:
                 question_uuid = uuid.UUID(ref)

--- a/api/app/signals/apps/questionnaires/migrations/0005_retrieval_key_and_analysis_key.py
+++ b/api/app/signals/apps/questionnaires/migrations/0005_retrieval_key_and_analysis_key.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2021 Gemeente Amsterdam
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('questionnaires', '0004_alter_questiongraph_name'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='question',
+            old_name='key',
+            new_name='retrieval_key',
+        ),
+        migrations.AddField(
+            model_name='question',
+            name='analysis_key',
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+    ]

--- a/api/app/signals/apps/questionnaires/migrations/0006_retrieval_key_and_analysis_key.py
+++ b/api/app/signals/apps/questionnaires/migrations/0006_retrieval_key_and_analysis_key.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('questionnaires', '0004_alter_questiongraph_name'),
+        ('questionnaires', '0005_make_session_duration_nullable'),
     ]
 
     operations = [

--- a/api/app/signals/apps/questionnaires/models/question.py
+++ b/api/app/signals/apps/questionnaires/models/question.py
@@ -17,7 +17,8 @@ class Question(models.Model):
     appear in several graphs and hence Questionnaires. See the QuestionGraph and
     Edge models as to how the questions are referred to.
     """
-    key = models.CharField(unique=True, max_length=255, null=True, blank=True)
+    retrieval_key = models.CharField(unique=True, max_length=255, null=True, blank=True)
+    analysis_key = models.CharField(max_length=255, null=True, blank=True)
     uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     created_at = models.DateTimeField(editable=False, auto_now_add=True)
 
@@ -30,8 +31,8 @@ class Question(models.Model):
     objects = QuestionManager()
 
     def __str__(self):
-        return f'{self.key or self.uuid} ({self.field_type})'
+        return f'{self.retrieval_key or self.uuid} ({self.field_type})'
 
     @property
     def ref(self):
-        return self.key if self.key else str(self.uuid)
+        return self.retrieval_key if self.retrieval_key else str(self.uuid)

--- a/api/app/signals/apps/questionnaires/rest_framework/fields.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/fields.py
@@ -44,14 +44,14 @@ class QuestionnairePublicHyperlinkedIdentityField(HyperlinkedRelatedFieldMixin, 
 
 
 class QuestionHyperlinkedIdentityField(HyperlinkedRelatedFieldMixin, serializers.HyperlinkedIdentityField):
-    lookup_field = 'key'
+    lookup_field = 'retrieval_key'
 
     def to_representation(self, value):
         return OrderedDict([
             ('self', dict(href=self._get_url(value, 'public-question-detail'))),
-            ('sia:uuid-self', dict(href=self._reverse('public-question-detail', kwargs={'key': value.uuid}))),
+            ('sia:uuid-self', dict(href=self._reverse('public-question-detail', kwargs={'retrieval_key': value.uuid}))),
             ('sia:post-answer', dict(href=self._reverse('public-question-answer',
-                                                        kwargs={'key': value.key or value.uuid}))),
+                                                        kwargs={'retrieval_key': value.retrieval_key or value.uuid}))),
         ])
 
 

--- a/api/app/signals/apps/questionnaires/rest_framework/serializers.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/serializers.py
@@ -19,12 +19,14 @@ class PublicQuestionSerializer(HALSerializer):
     serializer_url_field = QuestionHyperlinkedIdentityField
     next_rules = serializers.SerializerMethodField()
     _display = DisplayField()
+    key = serializers.CharField(source='retrieval_key')
 
     class Meta:
         model = Question
         fields = (
             '_links',
             '_display',
+            'key',
             'retrieval_key',
             'analysis_key',
             'uuid',

--- a/api/app/signals/apps/questionnaires/rest_framework/serializers.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/serializers.py
@@ -25,7 +25,8 @@ class PublicQuestionSerializer(HALSerializer):
         fields = (
             '_links',
             '_display',
-            'key',
+            'retrieval_key',
+            'analysis_key',
             'uuid',
             'label',
             'short_label',

--- a/api/app/signals/apps/questionnaires/rest_framework/views/public.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public.py
@@ -35,8 +35,8 @@ class PublicQuestionnaireViewSet(DatapuntViewSet):
 
 
 class PublicQuestionViewSet(DatapuntViewSet):
-    lookup_field = 'key'
-    lookup_url_kwarg = 'key'
+    lookup_field = 'retrieval_key'
+    lookup_url_kwarg = 'retrieval_key'
 
     queryset = Question.objects.all()
     queryset_detail = Question.objects.all()

--- a/api/app/signals/apps/questionnaires/services/questionnaires.py
+++ b/api/app/signals/apps/questionnaires/services/questionnaires.py
@@ -146,7 +146,7 @@ class QuestionnairesService:
             next_question = None
         else:
             try:
-                next_question = Question.objects.get_by_reference(ref=next_ref)
+                next_question = Question.objects.get_by_reference(next_ref)
             except Question.DoesNotExist:
                 return None  # TODO: consider raising an exception
 

--- a/api/app/signals/apps/questionnaires/templates/questionnaires/swagger/public_openapi.yaml
+++ b/api/app/signals/apps/questionnaires/templates/questionnaires/swagger/public_openapi.yaml
@@ -312,6 +312,17 @@ components:
           type: string
           nullable: true
           example: 'a-key-describing-the-question'
+          description: The `key` property is a copy of the `retrieval_key`.
+        retrieval_key:
+          type: string
+          nullable: true
+          example: 'a-key-describing-the-question'
+          description: Key for retrieval of a question, must be unique.
+        analysis_key:
+          type: string
+          nullable: true
+          example: "question-key"
+          description: Key that answer data will be collected under.
         uuid:
           type: string
           pattern: '^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$'
@@ -442,3 +453,13 @@ components:
         created_at:
           type: string
           example: '2021-01-01T00:00:00+00:00'
+
+  securitySchemes:
+    OAuth2:
+      description: SIA API is using OAuth2 implicit grant flow.
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: '/oauth2/authorize'
+          scopes:
+            SIG/ALL: General access to SIA Django application.

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_get_question_detail.json
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_get_question_detail.json
@@ -51,6 +51,36 @@
 		"uuid": {
 			"type": "string"
 		},
+		"key": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string"
+				}
+			]
+		},
+		"retrieval_key": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string"
+				}
+			]
+		},
+		"analysis_key": {
+			"anyOf": [
+				{
+					"type": "null"
+				},
+				{
+					"type": "string"
+				}
+			]
+		},
 		"label": {
 			"type": "string"
 		},
@@ -81,10 +111,14 @@
 		"_links",
 		"_display",
 		"uuid",
+		"key",
+		"retrieval_key",
+		"analysis_key",
 		"label",
 		"short_label",
 		"field_type",
 		"next_rules",
 		"required"
-	]
+	],
+	"additionalProperties": false
 }

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_get_question_list.json
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_get_question_list.json
@@ -117,6 +117,36 @@
 						"uuid": {
 							"type": "string"
 						},
+						"key": {
+							"anyOf": [
+								{
+									"type": "null"
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
+						"retrieval_key": {
+							"anyOf": [
+								{
+									"type": "null"
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
+						"analysis_key": {
+							"anyOf": [
+								{
+									"type": "null"
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
 						"label": {
 							"type": "string"
 						},
@@ -147,12 +177,16 @@
 						"_links",
 						"_display",
 						"uuid",
+						"key",
+						"retrieval_key",
+						"analysis_key",
 						"label",
 						"short_label",
 						"field_type",
 						"next_rules",
 						"required"
-					]
+					],
+					"additionalProperties": false
 				}
 			]
 		}

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_get_questionnaire_detail.json
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_get_questionnaire_detail.json
@@ -85,6 +85,36 @@
 						"uuid": {
 							"type": "string"
 						},
+						"key": {
+							"anyOf": [
+								{
+									"type": "null"
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
+						"retrieval_key": {
+							"anyOf": [
+								{
+									"type": "null"
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
+						"analysis_key": {
+							"anyOf": [
+								{
+									"type": "null"
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
 						"label": {
 							"type": "string"
 						},
@@ -115,12 +145,16 @@
 						"_links",
 						"_display",
 						"uuid",
+						"key",
+						"retrieval_key",
+						"analysis_key",
 						"label",
 						"short_label",
 						"field_type",
 						"next_rules",
 						"required"
-					]
+					],
+					"additionalProperties": false
 				},
 				{
 					"type": "null"

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_get_questionnaire_list.json
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_get_questionnaire_list.json
@@ -151,6 +151,36 @@
 										"uuid": {
 											"type": "string"
 										},
+										"key": {
+											"anyOf": [
+												{
+													"type": "null"
+												},
+												{
+													"type": "string"
+												}
+											]
+										},
+										"retrieval_key": {
+											"anyOf": [
+												{
+													"type": "null"
+												},
+												{
+													"type": "string"
+												}
+											]
+										},
+										"analysis_key": {
+											"anyOf": [
+												{
+													"type": "null"
+												},
+												{
+													"type": "string"
+												}
+											]
+										},
 										"label": {
 											"type": "string"
 										},
@@ -181,12 +211,16 @@
 										"_links",
 										"_display",
 										"uuid",
+										"key",
+										"retrieval_key",
+										"analysis_key",
 										"label",
 										"short_label",
 										"field_type",
 										"next_rules",
 										"required"
-									]
+									],
+									"additionalProperties": false
 								},
 								{
 									"type": "null"

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_post_question_answer_response.json
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/json_schema/public_post_question_answer_response.json
@@ -83,6 +83,36 @@
 						"uuid": {
 							"type": "string"
 						},
+						"key": {
+							"anyOf": [
+								{
+									"type": "null"
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
+						"retrieval_key": {
+							"anyOf": [
+								{
+									"type": "null"
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
+						"analysis_key": {
+							"anyOf": [
+								{
+									"type": "null"
+								},
+								{
+									"type": "string"
+								}
+							]
+						},
 						"label": {
 							"type": "string"
 						},
@@ -113,12 +143,16 @@
 						"_links",
 						"_display",
 						"uuid",
+						"key",
+						"retrieval_key",
+						"analysis_key",
 						"label",
 						"short_label",
 						"field_type",
 						"next_rules",
 						"required"
-					]
+					],
+					"additionalProperties": false
 				},
 				{
 					"type": "null"

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_questions_endpoint.py
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_questions_endpoint.py
@@ -133,11 +133,11 @@ class TestPublicQuestionEndpoint(ValidateJsonSchemaMixin, APITestCase):
         self.assertEqual(0, Session.objects.count())
 
         # Setup questions
-        test_question_1 = QuestionFactory(key='test-question-1')
-        test_question_2 = QuestionFactory(key='test-question-2')
-        test_question_3 = QuestionFactory(key='test-question-3')
-        test_question_4 = QuestionFactory(key='test-question-4')
-        test_question_5 = QuestionFactory(key='test-question-5')
+        test_question_1 = QuestionFactory(retrieval_key='test-question-1')
+        test_question_2 = QuestionFactory(retrieval_key='test-question-2')
+        test_question_3 = QuestionFactory(retrieval_key='test-question-3')
+        test_question_4 = QuestionFactory(retrieval_key='test-question-4')
+        test_question_5 = QuestionFactory(retrieval_key='test-question-5')
 
         # Setup graph relations between questions
         graph = QuestionGraphFactory.create(first_question=test_question_1)
@@ -201,10 +201,10 @@ class TestPublicQuestionEndpoint(ValidateJsonSchemaMixin, APITestCase):
         self.assertEqual(0, Session.objects.count())
 
         # Setup questions
-        test_question_1 = QuestionFactory(key='test-question-1')
-        test_question_2 = QuestionFactory(key='test-question-2')
-        test_question_3 = QuestionFactory(key='test-question-3')
-        test_question_4 = QuestionFactory(key='test-question-4')
+        test_question_1 = QuestionFactory(retrieval_key='test-question-1')
+        test_question_2 = QuestionFactory(retrieval_key='test-question-2')
+        test_question_3 = QuestionFactory(retrieval_key='test-question-3')
+        test_question_4 = QuestionFactory(retrieval_key='test-question-4')
 
         # Setup graph relations between questions
         graph = QuestionGraphFactory.create(first_question=test_question_1)

--- a/api/app/signals/apps/questionnaires/tests/services/test_questionnaires.py
+++ b/api/app/signals/apps/questionnaires/tests/services/test_questionnaires.py
@@ -23,17 +23,17 @@ from signals.apps.signals.factories import SignalFactory, StatusFactory
 
 def _question_graph_with_decision():
     q1 = QuestionFactory.create(
-        key='q_yesno',
+        retrieval_key='q_yesno',
         short_label='Yes or no?',
         label='Yes or no, what do you choose?',
     )
     q_yes = QuestionFactory.create(
-        key='q_yes',
+        retrieval_key='q_yes',
         short_label='yes',
         label='The yes question. Happy now?'
     )
     q_no = QuestionFactory.create(
-        key='q_no',
+        retrieval_key='q_no',
         short_label='no',
         label='The no question. Still unhappy?'
     )
@@ -47,17 +47,17 @@ def _question_graph_with_decision():
 
 def _question_graph_with_decision_null_keys():
     q1 = QuestionFactory.create(
-        key=None,
+        retrieval_key=None,
         short_label='Yes or no?',
         label='Yes or no, what do you choose?',
     )
     q_yes = QuestionFactory.create(
-        key=None,
+        retrieval_key=None,
         short_label='yes',
         label='The yes question. Happy now?'
     )
     q_no = QuestionFactory.create(
-        key=None,
+        retrieval_key=None,
         short_label='no',
         label='The no question. Still unhappy?'
     )
@@ -71,17 +71,17 @@ def _question_graph_with_decision_null_keys():
 
 def _question_graph_with_decision_with_default():
     q1 = QuestionFactory.create(
-        key='q_yesno',
+        retrieval_key='q_yesno',
         short_label='Yes or no?',
         label='Yes or no, what do you choose?',
     )
     q_yes = QuestionFactory.create(
-        key='q_yes',
+        retrieval_key='q_yes',
         short_label='yes',
         label='The yes question. Happy now?'
     )
     q_no = QuestionFactory.create(
-        key='q_no',
+        retrieval_key='q_no',
         short_label='no',
         label='The no question. Still unhappy?'
     )
@@ -96,13 +96,13 @@ def _question_graph_with_decision_with_default():
 
 def _question_graph_no_required_answers():
     q1 = QuestionFactory.create(
-        key='one',
+        retrieval_key='one',
         required=False,
         short_label='First not required',
         label='First not required',
     )
     q2 = QuestionFactory(
-        key='two',
+        retrieval_key='two',
         required=False,
         short_label='Second not required',
         label='Second not required',
@@ -116,18 +116,18 @@ def _question_graph_no_required_answers():
 
 def _question_graph_with_decision_with_default_no_required_answers():
     q1 = QuestionFactory.create(
-        key='q_yesno',
+        retrieval_key='q_yesno',
         required=False,
         short_label='Yes or no?',
         label='Yes or no, what do you choose?',
     )
     q_yes = QuestionFactory.create(
-        key='q_yes',
+        retrieval_key='q_yes',
         short_label='yes',
         label='The yes question. Happy now?'
     )
     q_no = QuestionFactory.create(
-        key='q_no',
+        retrieval_key='q_no',
         short_label='no',
         label='The no question. Still unhappy?'
     )
@@ -143,12 +143,12 @@ def _question_graph_with_decision_with_default_no_required_answers():
 
 def _question_graph_with_cycle():
     q1 = QuestionFactory.create(
-        key='one',
+        retrieval_key='one',
         short_label='First question.',
         label='First question.',
     )
     q2 = QuestionFactory.create(
-        key='two',
+        retrieval_key='two',
         short_label='Second question.',
         label='Second question.',
     )
@@ -162,7 +162,7 @@ def _question_graph_with_cycle():
 
 def _question_graph_one_question():
     q1 = QuestionFactory.create(
-        key='only',
+        retrieval_key='only',
         short_label='Only question.',
         label='Only question.',
     )
@@ -272,7 +272,7 @@ class TestQuestionnairesService(TestCase):
     def test_get_next_question_ref(self):
         get_next_ref = QuestionnairesService.get_next_question_ref
 
-        q_start = QuestionFactory.create(key='start', field_type='plain_text')
+        q_start = QuestionFactory.create(retrieval_key='start', field_type='plain_text')
 
         # No next rules:
         empty_graph = QuestionGraphFactory.create(first_question=q_start)
@@ -289,8 +289,8 @@ class TestQuestionnairesService(TestCase):
         self.assertEqual(next_ref, q2.ref)
 
         # conditional next, no default option:
-        q_no = QuestionFactory.create(key='NO')
-        q_yes = QuestionFactory.create(key='YES')
+        q_no = QuestionFactory.create(retrieval_key='NO')
+        q_yes = QuestionFactory.create(retrieval_key='YES')
         conditional_graph = QuestionGraphFactory.create(first_question=q_start)
         EdgeFactory(graph=conditional_graph, question=q_start, next_question=q_no, payload='no')
         EdgeFactory(graph=conditional_graph, question=q_start, next_question=q_yes, payload='yes')
@@ -300,7 +300,7 @@ class TestQuestionnairesService(TestCase):
         self.assertEqual(q_no.ref, get_next_ref('no', q_start, conditional_graph))
 
         # conditional next with default:
-        q_default = QuestionFactory.create(key='DEFAULT')
+        q_default = QuestionFactory.create(retrieval_key='DEFAULT')
         conditional_with_default_graph = QuestionGraphFactory.create(first_question=q_start)
         EdgeFactory(graph=conditional_with_default_graph, question=q_start, next_question=q_no, payload='no')
         EdgeFactory(graph=conditional_with_default_graph, question=q_start, next_question=q_yes, payload='yes')

--- a/api/app/signals/apps/questionnaires/tests/test_models.py
+++ b/api/app/signals/apps/questionnaires/tests/test_models.py
@@ -50,7 +50,7 @@ def create_diamond(graph_name='diamond'):
 
 
 def create_diamond_plus(graph_name='diamond_plus'):
-    graph = create_diamond(graph_name='diamond_plus')
+    graph = create_diamond(graph_name=graph_name)
     # sketch:
     #    q1 <- first_question
     #   /  \
@@ -335,7 +335,7 @@ class TestChoices(TestCase):
 
 class TestGetByReference(TestCase):
     def setUp(self):
-        self.question = QuestionFactory.create(key='question')
+        self.question = QuestionFactory.create(retrieval_key='question')
 
     def test_get_by_reference_none(self):
         with self.assertRaises(Question.DoesNotExist):
@@ -368,7 +368,7 @@ class TestGetByReference(TestCase):
         while generated == question.uuid:
             generated = uuid.uuid4()
 
-        question.key = generated
+        question.retrieval_key = generated
         question.save()
         question.refresh_from_db()
 


### PR DESCRIPTION
…s.Question

## Description

The Question.key field was doing double duty. It gave a human readable key to retrieve Questions with (optionally that is, otherwise a UUID can be used) and it marks answers so that they may be picked up by downstream software / systems. This PR propose a split in a `retrieval_key` and an `analysis_key` where the latter need not be unique and hence easier to have several questionnaires all provide questions and answers that "write" to the same `analysis_key`.

For backwards compatibility the `analysis_key` will have to be mapped to `key` in Signal `extra_properties` generated from a new-style Questionnaire.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
