### PR TITLE
Chore add missing migration for QuestionGraph.name

### DIFF
--- a/api/app/signals/apps/questionnaires/migrations/0004_alter_questiongraph_name.py
+++ b/api/app/signals/apps/questionnaires/migrations/0004_alter_questiongraph_name.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2021 Gemeente Amsterdam
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('questionnaires', '0003_add_triggers'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='questiongraph',
+            name='name',
+            field=models.CharField(blank=True, max_length=255, null=True),
+        ),
+    ]


### PR DESCRIPTION
## Description

Add missing migration from PR 839, that is QuestionGraph.name became non-unique and nullable. That was not reflected by the migrations. This PR fixes that.
