### PR TITLE
feature/SIG-3923

### DIFF
--- a/api/app/signals/apps/api/serializers/stored_signal_filter.py
+++ b/api/app/signals/apps/api/serializers/stored_signal_filter.py
@@ -22,10 +22,14 @@ class StoredSignalFilterSerializer(HALSerializer):
             'created_at',
             'options',
             'refresh',
+            'show_on_overview',
         )
 
     def validate(self, attrs):
-        if 'options' not in attrs:
+        if 'options' not in attrs and self.context['view'].action != 'partial_update':
+            """
+            When doing a partial_update the "options" are not mandatory, for all other actions they are!
+            """
             raise ValidationError('No filters specified, "options" object missing.')
 
         return super().validate(attrs)

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -1122,6 +1122,125 @@ paths:
         - OAuth2:
           - SIG/ALL
 
+  /signals/v1/private/me/:
+    get:
+      description: Retrieve loggedin user data.
+      responses:
+        '200':
+          description: JSON serialization of detailed SIA loggedin user data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/privateUserDetailResponse'
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden.
+      security:
+        - OAuth2:
+            - SIG/ALL
+
+  /signals/v1/private/me/filters/:
+    get:
+      description: Retrieve stored signal filters for the loggedin User
+      responses:
+        '200':
+          description: JSON serialization of the stored Signal filters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/privateStoredSignalFilterResponseList'
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden.
+      security:
+        - OAuth2:
+            - SIG/ALL
+    post:
+      description: Creation of a stored Signal filter.
+      requestBody:
+        description: JSON serialized stored Signal filter data.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/privateStoredSignalFilterRequest'
+      responses:
+        '201':
+          description: stored Signal filter successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/privateStoredSignalFilterResponse'
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden.
+      security:
+        - OAuth2:
+            - SIG/ALL
+
+  /signals/v1/private/me/filters/{id}:
+    parameters:
+      - name: id
+        in: path
+        description: ID of stored Signal filter
+        required: true
+        schema:
+          type: integer
+    get:
+      description: Retrieve stored Signal filter
+      responses:
+        '200':
+          description: JSON serialization of the stored Signal filter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/privateStoredSignalFilterResponse'
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden.
+      security:
+        - OAuth2:
+            - SIG/ALL
+    patch:
+      description: Partial update of the stored Signal filter.
+      requestBody:
+        description: JSON serialized stored Signal filter data.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/privateStoredSignalFilterRequest'
+      responses:
+        '200':
+          description: stored Signal filter successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/privateStoredSignalFilterResponse'
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden.
+      security:
+        - OAuth2:
+            - SIG/ALL
+    delete:
+      description: Delete a stored Signal filter.
+      responses:
+        '410':
+          description: stored Signal filter successfully deleted.
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden.
+      security:
+        - OAuth2:
+            - SIG/ALL
+
   /signals/v1/private/departments/:
     get:
       description: Retrieve list of departments.
@@ -1795,8 +1914,8 @@ components:
       type: object
       properties:
         text:
-          type: string
           nullable: true
+          type: string
           example: null
         state:
           $ref: '#/components/schemas/StatusStateChoices'
@@ -3804,6 +3923,110 @@ components:
                 type: integer
                 example: 12345
             minItems: 0
+
+    privateStoredSignalFilterResponseList:
+      description: JSON serialization of paginated list of stored Signal filters
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              type: object
+              properties:
+                href:
+                  type: string
+                  description: URI of current page
+                  format: uri
+                  example: http://127.0.0.1:8000/signals/v1/private/me/filters
+            next:
+              type: object
+              properties:
+                href:
+                  type: string
+                  description: URI of the next page
+                  format: uri
+                  nullable: true
+                  example: http://127.0.0.1:8000/signals/v1/private/me/filters/?page=2
+            previous:
+              type: object
+              properties:
+                href:
+                  type: string
+                  description: URI of the previous page
+                  format: uri
+                  nullable: true
+                  example: null
+        count:
+          type: integer
+          description: Total count of results for the request
+          example: 10
+        results:
+          type: array
+          description: A list of stored Signal filters, paginated
+          items:
+            $ref: '#/components/schemas/privateStoredSignalFilterResponse'
+
+    privateStoredSignalFilterResponse:
+      description: Detailed JSON serialization of a stored Signal filter.
+      type: object
+      properties:
+        _link:
+          description: HAL JSON links
+          type: object
+          properties:
+            self:
+              type: object
+              properties:
+                href:
+                  description: URI of this stored Signal filter in API
+                  type: string
+                  format: uri
+                  example: http://127.0.0.1:8000/signals/v1/private/me/filters/123
+        _display:
+          description: Textual representation of the stored Signal filter for display purposes.
+          type: string
+        id:
+          description: ID of stored Signal filter
+          type: integer
+          example: 123
+        name:
+          type: string
+          example: "My stored filter"
+        created_at:
+          type: string
+          format: date-time
+          example: "2021-08-16T00:00:00+00:00"
+        options:
+          type: object
+          example: {}
+        refresh:
+          type: boolean
+          default: False
+        show_on_overview:
+          type: boolean
+          default: False
+
+    privateStoredSignalFilterRequest:
+      description: Detailed JSON post/patch serialization for a stored Signal filter.
+      type: object
+      properties:
+        name:
+          type: string
+          example: "My stored filter"
+        created_at:
+          type: string
+          format: date-time
+          example: "2021-08-16T00:00:00+00:00"
+        options:
+          type: object
+          example: { }
+        refresh:
+          type: boolean
+          default: False
+        show_on_overview:
+          type: boolean
+          default: False
 
   securitySchemes:
     OAuth2:

--- a/api/app/signals/apps/signals/factories/stored_signal_filter.py
+++ b/api/app/signals/apps/signals/factories/stored_signal_filter.py
@@ -11,6 +11,7 @@ class StoredSignalFilterFactory(DjangoModelFactory):
     name = FuzzyText(length=100)
     created_by = SubFactory('signals.apps.users.factories.UserFactory')
     refresh = FuzzyChoice((True, False))
+    show_on_overview = False
 
     class Meta:
         model = StoredSignalFilter

--- a/api/app/signals/apps/signals/migrations/0143_storedsignalfilter_show_on_overview.py
+++ b/api/app/signals/apps/signals/migrations/0143_storedsignalfilter_show_on_overview.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2021 Gemeente Amsterdam
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0142_auto_20210719_0057'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='storedsignalfilter',
+            name='show_on_overview',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/api/app/signals/apps/signals/models/stored_signal_filter.py
+++ b/api/app/signals/apps/signals/models/stored_signal_filter.py
@@ -15,6 +15,7 @@ class StoredSignalFilter(CreatedUpdatedModel):
     created_by = models.EmailField(null=True, blank=True)
     options = models.JSONField(default=dict)
     refresh = models.BooleanField(default=False)
+    show_on_overview = models.BooleanField(default=False)
 
     class Meta:
         ordering = ('-created_at', )


### PR DESCRIPTION
## Description

SIG-3923: Added option "show_on_overview" to StoredSignalFilter + updated unit tests and swagger documentation

## Checklist

- X ] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Documentation has been updated if needed
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
