### PR TITLE
fix/SIG-3934

### DIFF
--- a/api/app/signals/apps/api/views/source.py
+++ b/api/app/signals/apps/api/views/source.py
@@ -10,7 +10,7 @@ from signals.auth.backend import JWTAuthBackend
 
 class PrivateSourcesViewSet(DatapuntViewSet):
     """
-    Private ViewSet to display all sources, excluded the "onine" (Signal.SOURCE_DEFAULT_ANONYMOUS_USER) source
+    Private ViewSet to display all sources, excluding the "online" (Signal.SOURCE_DEFAULT_ANONYMOUS_USER) source
     """
     serializer_class = SourceSerializer
     serializer_detail_class = SourceSerializer

--- a/api/app/signals/apps/api/views/source.py
+++ b/api/app/signals/apps/api/views/source.py
@@ -4,18 +4,23 @@ from datapunt_api.rest import DatapuntViewSet
 from django_filters.rest_framework import DjangoFilterBackend
 
 from signals.apps.api.serializers.source import SourceSerializer
-from signals.apps.signals.models import Source
+from signals.apps.signals.models import Signal, Source
 from signals.auth.backend import JWTAuthBackend
 
 
 class PrivateSourcesViewSet(DatapuntViewSet):
     """
-    Private ViewSet to display all sources in the database
+    Private ViewSet to display all sources, excluded the "onine" (Signal.SOURCE_DEFAULT_ANONYMOUS_USER) source
     """
     serializer_class = SourceSerializer
     serializer_detail_class = SourceSerializer
 
-    queryset = Source.objects.all()
+    # Bug: SIG-3934
+    #
+    # The "online" source (Signal.SOURCE_DEFAULT_ANONYMOUS_USER) should not be returned in the response of
+    # the private list endpoint. This source is only used when a anonymous user creates a Signal using the public
+    # Signal endpoint
+    queryset = Source.objects.exclude(name=Signal.SOURCE_DEFAULT_ANONYMOUS_USER)
 
     authentication_classes = (JWTAuthBackend, )
 

--- a/api/app/tests/apps/api/test_private_source_endpoint.py
+++ b/api/app/tests/apps/api/test_private_source_endpoint.py
@@ -41,7 +41,7 @@ class TestPrivateSourceEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(5, len(data['results']))
         self.assertJsonSchema(self.list_sources_schema, data)
 
-    def test_get_list_exclude_signal_SOURCE_DEFAULT_ANONYMOUS_USER(self):
+    def test_get_list_excluding_signal_SOURCE_DEFAULT_ANONYMOUS_USER(self):
         """
         Bug: SIG-3934
 

--- a/api/app/tests/apps/api/test_private_source_endpoint.py
+++ b/api/app/tests/apps/api/test_private_source_endpoint.py
@@ -5,6 +5,7 @@ import os
 from rest_framework import status
 
 from signals.apps.signals.factories import SourceFactory
+from signals.apps.signals.models import Signal, Source
 from tests.test import SIAReadWriteUserMixin, SignalsBaseApiTestCase
 
 THIS_DIR = os.path.dirname(__file__)
@@ -30,6 +31,8 @@ class TestPrivateSourceEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         )
 
     def test_get_list(self):
+        self.assertEqual(Source.objects.count(), 5)
+
         response = self.client.get(f'{self.list_endpoint}')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -37,6 +40,28 @@ class TestPrivateSourceEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(5, data['count'])
         self.assertEqual(5, len(data['results']))
         self.assertJsonSchema(self.list_sources_schema, data)
+
+    def test_get_list_exclude_signal_SOURCE_DEFAULT_ANONYMOUS_USER(self):
+        """
+        Bug: SIG-3934
+
+        The "online" source (Signal.SOURCE_DEFAULT_ANONYMOUS_USER) should not be returned in the response of
+        the private list endpoint. This source is only used when a anonymous user creates a Signal using the public
+        Signal endpoint
+        """
+        SourceFactory.create(name=Signal.SOURCE_DEFAULT_ANONYMOUS_USER)
+        self.assertEqual(Source.objects.count(), 6)
+
+        response = self.client.get(f'{self.list_endpoint}')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(5, data['count'])
+        self.assertEqual(5, len(data['results']))
+        self.assertJsonSchema(self.list_sources_schema, data)
+
+        # Check that the Signal.SOURCE_DEFAULT_ANONYMOUS_USER is not present in the response
+        self.assertNotIn(Signal.SOURCE_DEFAULT_ANONYMOUS_USER, [source['name'] for source in data['results']])
 
     def test_post_method_not_allowed(self):
         response = self.client.post(f'{self.list_endpoint}1', data={}, format='json')


### PR DESCRIPTION
## Description

SIG-3934 - Exclude the Signals.SOURCE_DEFAULT_ANONYMOUS_USER ('online') in the response of the PrivateSourcesViewset

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Documentation has been updated if needed
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
