### PR TITLE
SIG-3938 changed order of get_session checks

### DIFF
--- a/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_sessions_endpoint.py
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_sessions_endpoint.py
@@ -97,7 +97,8 @@ class TestPublicSessionEndpoint(ValidateJsonSchemaMixin, APITestCase):
 
         response = self.client.get(f'{self.base_endpoint}{session.uuid}')
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.json()['detail'], f'Session {session.uuid} is invalidated.')
+        self.assertEqual(response.json()['detail'],
+                         f'Session {session.uuid} is invalidated, associated signal not in state REACTIE_GEVRAAGD.')
 
         status = StatusFactory(state=REACTIE_GEVRAAGD, _signal=signal)
         signal.status = status
@@ -107,7 +108,8 @@ class TestPublicSessionEndpoint(ValidateJsonSchemaMixin, APITestCase):
 
         response = self.client.get(f'{self.base_endpoint}{session.uuid}')
         self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.json()['detail'], f'Session {session.uuid} is invalidated.')
+        self.assertEqual(response.json()['detail'],
+                         f'Session {session.uuid} is invalidated, a newer reaction request was issued.')
 
         response = self.client.get(f'{self.base_endpoint}{latest_session.uuid}')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Description

Change order of checks for QuestionnairesService.get_session in such a way that already submitted questionnaires cause a HTTP 410, same for expired sessions.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
