### PR TITLE
Bugfix/sig 3972 problem with rgba attachments

### DIFF
--- a/api/app/signals/apps/services/domain/images.py
+++ b/api/app/signals/apps/services/domain/images.py
@@ -54,6 +54,9 @@ class DataUriImageEncodeService:
                 if image.width > max_size or image.height > max_size:
                     image = DataUriImageEncodeService.resize(image, max_size)
 
+                if image.mode == 'RGBA':
+                    image = image.convert('RGB')
+
                 with io.BytesIO() as new_buffer:
                     new_buffer = io.BytesIO()
                     image.save(new_buffer, format='JPEG')

--- a/api/app/tests/apps/services/domain/test_images.py
+++ b/api/app/tests/apps/services/domain/test_images.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Gemeente Amsterdam
 from io import BytesIO
 from unittest.mock import MagicMock
+import unittest
 
 from PIL import Image
 
@@ -45,6 +46,19 @@ class TestImagesService(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
         AttachmentFactory.create(_signal=self.signal, file__filename='blah.jpg', file__data=buffer.getvalue())
         jpg_data_uris = DataUriImageEncodeService.get_context_data_images(self.signal, 80)
+        self.assertEqual(len(jpg_data_uris), 1)
+        self.assertEqual(jpg_data_uris[0][:22], 'data:image/jpg;base64,')
+        self.assertGreater(len(jpg_data_uris[0]), 22)
+
+    @unittest.expectedFailure
+    def test_get_context_data_images_for_rgba(self):
+        # Reproduce problem reported in SIG-3972, RGBA PNG image attachment causes a failure to create PDFs
+        image = Image.new("RGBA", (100, 100), (0, 0, 0, 0))
+        buffer = BytesIO()
+        image.save(buffer, format='PNG')
+
+        AttachmentFactory.create(_signal=self.signal, file__filename='blah.png', file__data=buffer.getvalue())
+        jpg_data_uris = DataUriImageEncodeService.get_context_data_images(self.signal, 200)
         self.assertEqual(len(jpg_data_uris), 1)
         self.assertEqual(jpg_data_uris[0][:22], 'data:image/jpg;base64,')
         self.assertGreater(len(jpg_data_uris[0]), 22)

--- a/api/app/tests/apps/services/domain/test_images.py
+++ b/api/app/tests/apps/services/domain/test_images.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2021 Gemeente Amsterdam
 from io import BytesIO
 from unittest.mock import MagicMock
-import unittest
 
 from PIL import Image
 
@@ -50,7 +49,6 @@ class TestImagesService(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(jpg_data_uris[0][:22], 'data:image/jpg;base64,')
         self.assertGreater(len(jpg_data_uris[0]), 22)
 
-    @unittest.expectedFailure
     def test_get_context_data_images_for_rgba(self):
         # Reproduce problem reported in SIG-3972, RGBA PNG image attachment causes a failure to create PDFs
         image = Image.new("RGBA", (100, 100), (0, 0, 0, 0))


### PR DESCRIPTION
## Description

PNG image attachments with alpha channel were a problem for PDF generation, that is now fixed.


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
