### PR TITLE
SIG-3982 Fill out feedback (KTO) questionnaire for old style feedback

### DIFF
--- a/api/app/signals/apps/feedback/serializers.py
+++ b/api/app/signals/apps/feedback/serializers.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from rest_framework import serializers
 
 from signals.apps.feedback.models import Feedback, StandardAnswer
+from signals.apps.questionnaires.services import FeedbackRequestService
 from signals.apps.signals import workflow
 from signals.apps.signals.models import Signal
 
@@ -64,4 +65,6 @@ class FeedbackSerializer(serializers.ModelSerializer):
                 }
                 Signal.actions.update_status(payload, signal)
 
-        return super().update(instance, validated_data)
+        feedback = super().update(instance, validated_data)
+        FeedbackRequestService.create_session_from_feedback(feedback)
+        return feedback


### PR DESCRIPTION
## Description

To allow a smoother transition between old-style feedback and new-style feedback via questionnaires, we store old-style feedback in the questionnaires app as well.

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Documentation has been updated if needed
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts
- [ ] There are no conflicting Django migrations

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 90% (the higher the better)
- [ ] No iSort issues are present in the code
- [ ] No Flake8 issues are present in the code
