### PR TITLE
Add checkbox about "Allow edits and access to secrets by maintainers"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@ Add a meaningful description explaining the change/fix that is provided in this 
 - [ ] Check that the PR targets `master`
 - [ ] There are no merge conflicts
 - [ ] There are no conflicting Django migrations
+- [ ] PR was created with "Allow edits and access to secrets by maintainers"
 
 ## How has this been tested?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Add a meaningful description explaining the change/fix that is provided in this 
 - [ ] Check that the PR targets `master`
 - [ ] There are no merge conflicts
 - [ ] There are no conflicting Django migrations
-- [ ] PR was created with "Allow edits and access to secrets by maintainers"
+- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked
 
 ## How has this been tested?
 


### PR DESCRIPTION
This will apply for any PR which is opened from another repository.

## Description

This adds a checkbox to the PR template so that upstream can make edits to incoming PRs.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
