### PR TITLE
_NestedPrivateCategoryDepartmentSerializer is_intern changed from CharField to BooleanField

### DIFF
--- a/api/app/signals/apps/api/serializers/category.py
+++ b/api/app/signals/apps/api/serializers/category.py
@@ -67,7 +67,7 @@ class _NestedPrivateCategoryDepartmentSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(source='department.id')
     code = serializers.CharField(source='department.code')
     name = serializers.CharField(source='department.name')
-    is_intern = serializers.CharField(source='department.is_intern')
+    is_intern = serializers.BooleanField(source='department.is_intern')
 
     class Meta:
         model = CategoryDepartment


### PR DESCRIPTION
## Description

Changed the is_intern flag on the _NestedPrivateCategoryDepartmentSerializer from a serializer.Charfield to a serializer.BooleanField so that it returns the correct data type

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
