### PR TITLE
propagate session_service to serializers

### DIFF
--- a/api/app/signals/apps/questionnaires/rest_framework/serializers.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/serializers.py
@@ -89,6 +89,12 @@ class PublicSessionSerializer(HALSerializer):
 
     _display = DisplayField()
 
+    can_freeze = serializers.SerializerMethodField()
+    path_questions = serializers.SerializerMethodField()
+    path_answered_question_uuids = serializers.SerializerMethodField()
+    path_unanswered_question_uuids = serializers.SerializerMethodField()
+    path_validation_errors_by_uuid = serializers.SerializerMethodField()
+
     class Meta:
         model = Session
         fields = (
@@ -99,12 +105,45 @@ class PublicSessionSerializer(HALSerializer):
             'submit_before',
             'duration',
             'created_at',
-        )
+            # generated using the SessionService in serializer context:
+            'can_freeze',
+            'path_questions',
+            'path_answered_question_uuids',
+            'path_unanswered_question_uuids',
+            'path_validation_errors_by_uuid'
+            )
         read_only_fields = (
             'id',
             'uuid',
             'created_at',
+            # generated using the SessionService in serializer context:
+            'can_freeze',
+            'path_questions',
+            'path_path_answered_question_uuids',
+            'path_unanswered_question_uuids',
+            'path_validation_errors_by_uuid'
         )
+
+    def get_can_freeze(self, obj):
+        session_service = self.context.get('session_service')
+        return session_service.can_freeze
+
+    def get_path_questions(self, obj):
+        session_service = self.context.get('session_service')
+        serializer = PublicQuestionSerializer(session_service.path_questions, many=True, context=self.context)
+        return serializer.data
+
+    def get_path_answered_question_uuids(self, obj):
+        session_service = self.context.get('session_service')
+        return session_service.path_unanswered_question_uuids
+
+    def get_path_unanswered_question_uuids(self, obj):
+        session_service = self.context.get('session_service')
+        return session_service.path_unanswered_question_uuids
+
+    def get_path_validation_errors_by_uuid(self, obj):
+        session_service = self.context.get('session_service')
+        return session_service.path_validation_errors_by_uuid
 
 
 class PublicSessionDetailedSerializer(PublicSessionSerializer):
@@ -157,3 +196,17 @@ class PublicAnswerSerializer(HALSerializer):
 
         session_service.refresh_from_db()
         return session_service.create_answer(payload, question)
+
+
+class PublicSessionAnswerSerializer(HALSerializer):
+    question_uuid = serializers.UUIDField()
+    payload = serializers.JSONField()
+
+    class Meta:
+        fields = (
+            'question_uuid',
+            'payload',
+        )
+        read_only_fields = (
+            'created_at',
+        )

--- a/api/app/signals/apps/questionnaires/rest_framework/serializers.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/serializers.py
@@ -135,7 +135,7 @@ class PublicSessionSerializer(HALSerializer):
 
     def get_path_answered_question_uuids(self, obj):
         session_service = self.context.get('session_service')
-        return session_service.path_unanswered_question_uuids
+        return session_service.path_answered_question_uuids
 
     def get_path_unanswered_question_uuids(self, obj):
         session_service = self.context.get('session_service')
@@ -143,7 +143,8 @@ class PublicSessionSerializer(HALSerializer):
 
     def get_path_validation_errors_by_uuid(self, obj):
         session_service = self.context.get('session_service')
-        return session_service.path_validation_errors_by_uuid
+        # Possibly turn all UUIDs into str(UUID)s in SessionService.
+        return {str(k): v for k, v in session_service.path_validation_errors_by_uuid.items()}
 
 
 class PublicSessionDetailedSerializer(PublicSessionSerializer):
@@ -198,7 +199,7 @@ class PublicAnswerSerializer(HALSerializer):
         return session_service.create_answer(payload, question)
 
 
-class PublicSessionAnswerSerializer(HALSerializer):
+class PublicSessionAnswerSerializer(serializers.Serializer):
     question_uuid = serializers.UUIDField()
     payload = serializers.JSONField()
 

--- a/api/app/signals/apps/questionnaires/rest_framework/views/public.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public.py
@@ -15,6 +15,7 @@ from signals.apps.questionnaires.rest_framework.serializers import (
     PublicQuestionnaireDetailedSerializer,
     PublicQuestionnaireSerializer,
     PublicQuestionSerializer,
+    PublicSessionAnswerSerializer,
     PublicSessionDetailedSerializer,
     PublicSessionSerializer
 )
@@ -134,6 +135,16 @@ class PublicSessionViewSet(HALViewSetRetrieve):
 
         return session_service.session
 
+    def retrieve(self, request, *args, **kwargs):
+        session = self.get_object()
+        session_service = get_session_service(session)  # TODO: error handling
+
+        context = self.get_serializer_context()
+        context['session_service'] = session_service
+
+        serializer = self.serializer_detail_class(session, context=context)
+        return Response(serializer.data, status=200)
+
     @action(detail=True, url_path=r'submit/?$', methods=['POST', ])
     def submit(self, request, *args, **kwargs):
         # TODO: calls to this endpoint are not idempotent, investigate whether
@@ -142,5 +153,41 @@ class PublicSessionViewSet(HALViewSetRetrieve):
         session_service = get_session_service(session)  # TODO: error handling
         session_service.freeze()
 
-        serializer = self.serializer_detail_class(session, context=self.get_serializer_context())
+        context = self.get_serializer_context()
+        context['session_service'] = session_service
+
+        serializer = self.serializer_detail_class(session, context=context)
+        return Response(serializer.data, status=200)
+
+    @action(detail=True, url_path=r'answers/?$', methods=['POST', ])
+    def answers(self, request, *args, **kwargs):
+        # TODO: finish / test
+        session = self.get_object()
+        session_service = get_session_service(session)
+
+        # We demand an array of answers, even if only a single answer is present.
+        serializer = PublicSessionAnswerSerializer(data=request.data, many=True)
+
+        answer_payloads = []
+        questions = []
+
+        retrieval_errors_by_uuid = []
+        for answer_data in serializer.data:
+            uuid = answer_data['question_uuid']
+            try:
+                question = Question.objects.get_by_reference(uuid)
+            except Question.DoesNotExist as e:
+                # we silently ignore retrieval errors for now (UUIDs to non existant questions)
+                retrieval_errors_by_uuid[answer_data[uuid]] = str(e)
+                continue
+
+            answer_payloads.append(answer_data['payload'])
+            questions.append(question)
+
+        session_service.create_answers(answer_payloads, questions)
+        context = self.get_serializer_context()
+        context['session_service'] = session_service  # session_service will have our validation errors
+
+        serializer = self.serializer_detail_class(session, context=context)
+        # TODO, consider status code - possibly return 400 if all answers were rejected
         return Response(serializer.data, status=200)

--- a/api/app/signals/apps/questionnaires/rest_framework/views/public.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public.py
@@ -167,6 +167,7 @@ class PublicSessionViewSet(HALViewSetRetrieve):
 
         # We demand an array of answers, even if only a single answer is present.
         serializer = PublicSessionAnswerSerializer(data=request.data, many=True)
+        serializer.is_valid()
 
         answer_payloads = []
         questions = []
@@ -174,6 +175,7 @@ class PublicSessionViewSet(HALViewSetRetrieve):
         retrieval_errors_by_uuid = []
         for answer_data in serializer.data:
             uuid = answer_data['question_uuid']
+            assert isinstance(uuid, str)
             try:
                 question = Question.objects.get_by_reference(uuid)
             except Question.DoesNotExist as e:

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_sessions_endpoint.py
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/views/test_public_sessions_endpoint.py
@@ -11,8 +11,15 @@ from rest_framework.test import APITestCase
 
 from signals.apps.api.generics.routers import SignalsRouter
 from signals.apps.api.views import PublicSignalViewSet
-from signals.apps.questionnaires.factories import QuestionnaireFactory, SessionFactory
-from signals.apps.questionnaires.models import Questionnaire
+from signals.apps.questionnaires.factories import (
+    ChoiceFactory,
+    EdgeFactory,
+    QuestionFactory,
+    QuestionGraphFactory,
+    QuestionnaireFactory,
+    SessionFactory
+)
+from signals.apps.questionnaires.models import Question, Questionnaire
 from signals.apps.questionnaires.tests.mixin import ValidateJsonSchemaMixin
 from signals.apps.signals.factories import SignalFactory, StatusFactory
 from signals.apps.signals.workflow import GEMELD, REACTIE_GEVRAAGD
@@ -145,3 +152,139 @@ class TestPublicSessionEndpoint(ValidateJsonSchemaMixin, APITestCase):
         response = self.client.post(f'{self.base_endpoint}{str(generated)}/submit/')
 
         self.assertEqual(response.status_code, 404)
+
+
+@override_settings(ROOT_URLCONF=test_urlconf)
+class TestPublicSessionEndpointAnswerFlow(ValidateJsonSchemaMixin, APITestCase):
+    base_endpoint = '/public/qa/sessions/'
+
+    def _get_questionnaire(self):
+        q1 = QuestionFactory.create(analysis_key='q1', label='q1', short_label='q1')
+        choice1_q2 = ChoiceFactory(question=q1, payload='q2', display='q2')
+        choice1_q3 = ChoiceFactory(question=q1, payload='q3', display='q3')
+
+        q2 = QuestionFactory.create(analysis_key='q2', label='q2', short_label='q2')
+        q3 = QuestionFactory.create(analysis_key='q3', label='q3', short_label='q3')
+        q4 = QuestionFactory.create(analysis_key='q4', label='q4', short_label='q4', required=True)
+        q5 = QuestionFactory.create(analysis_key='q5', label='q5', short_label='q5')
+
+        # sketch:
+        #    q1 <- first_question
+        #   /  \
+        # q2    q3
+        #   \  /
+        #    q4
+        #    |
+        #    q5
+        graph = QuestionGraphFactory.create(name='testgraph', first_question=q1)
+        EdgeFactory.create(graph=graph, question=q1, next_question=q2, choice=choice1_q2)
+        EdgeFactory.create(graph=graph, question=q2, next_question=q4, choice=None)
+        EdgeFactory.create(graph=graph, question=q1, next_question=q3, choice=choice1_q3)
+        EdgeFactory.create(graph=graph, question=q3, next_question=q4, choice=None)
+        EdgeFactory.create(graph=graph, question=q4, next_question=q5, choice=None)
+
+        return QuestionnaireFactory.create(graph=graph, name='diamond', flow=Questionnaire.EXTRA_PROPERTIES)
+
+    def setUp(self):
+        self.questionnaire = self._get_questionnaire()
+        self.session = SessionFactory(questionnaire=self.questionnaire, submit_before=None, duration=None, frozen=False)
+
+    def test_create_session(self):
+        pass
+
+    def test_retrieve_session(self):
+        response = self.client.get(f'{self.base_endpoint}{self.session.uuid}')
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+
+        self.assertIn('path_questions', response_json)
+        self.assertEqual(len(response_json['path_questions']), 1)
+        self.assertIn('path_answered_question_uuids', response_json)
+        self.assertEqual(len(response_json['path_answered_question_uuids']), 0)
+        self.assertIn('path_unanswered_question_uuids', response_json)
+        self.assertEqual(len(response_json['path_unanswered_question_uuids']), 1)
+        self.assertIn('path_validation_errors_by_uuid', response_json)
+        self.assertEqual(len(response_json['path_validation_errors_by_uuid']), 0)
+        self.assertIn('can_freeze', response_json)
+        self.assertEqual(response_json['can_freeze'], False)
+
+    def test_answer_question_incorrectly(self):
+        question = Question.objects.get(analysis_key='q1')
+        answer_data = [{
+            'question_uuid': str(question.uuid),
+            'payload': False
+        }]
+        request = self.client.post(f'{self.base_endpoint}{self.session.uuid}/answers', data=answer_data, format='json')
+        self.assertEqual(request.status_code, 200)  # Think about status code! (maybe 202)
+        response_json = request.json()
+
+        self.assertIn('path_questions', response_json)
+        self.assertEqual(len(response_json['path_questions']), 1)
+        self.assertIn('path_answered_question_uuids', response_json)
+        self.assertEqual(len(response_json['path_answered_question_uuids']), 0)
+        self.assertIn('path_unanswered_question_uuids', response_json)
+        self.assertEqual(len(response_json['path_unanswered_question_uuids']), 1)
+        self.assertIn('path_validation_errors_by_uuid', response_json)
+        self.assertEqual(len(response_json['path_validation_errors_by_uuid']), 1)
+        self.assertIn(str(question.uuid), response_json['path_validation_errors_by_uuid'])  # TBD, details of errors
+        self.assertIn('can_freeze', response_json)
+        self.assertEqual(response_json['can_freeze'], False)
+
+    def test_answer_question_correctly(self):
+        question = Question.objects.get(analysis_key='q1')
+        answer_data = [{
+            'question_uuid': str(question.uuid),
+            'payload': 'q2'
+        }]
+        request = self.client.post(f'{self.base_endpoint}{self.session.uuid}/answers', data=answer_data, format='json')
+        self.assertEqual(request.status_code, 200)  # Think about status code! (maybe 202)
+        response_json = request.json()
+
+        self.assertIn('path_questions', response_json)
+        self.assertEqual(len(response_json['path_questions']), 4)
+        self.assertIn('path_answered_question_uuids', response_json)
+        self.assertEqual(len(response_json['path_answered_question_uuids']), 1)
+        self.assertIn(str(question.uuid), response_json['path_answered_question_uuids'])
+        self.assertIn('path_unanswered_question_uuids', response_json)
+        self.assertEqual(len(response_json['path_unanswered_question_uuids']), 3)
+        self.assertIn('path_validation_errors_by_uuid', response_json)
+        self.assertEqual(len(response_json['path_validation_errors_by_uuid']), 0)
+        self.assertIn('can_freeze', response_json)
+        self.assertEqual(response_json['can_freeze'], False)
+
+    def test_answer_all_questions(self):
+        q1 = Question.objects.get(analysis_key='q1')
+        q2 = Question.objects.get(analysis_key='q2')
+        q3 = Question.objects.get(analysis_key='q4')
+        q4 = Question.objects.get(analysis_key='q5')
+        answer_data = [
+            {'question_uuid': str(q1.uuid), 'payload': 'q2'},
+            {'question_uuid': str(q2.uuid), 'payload': 'AAA'},
+            {'question_uuid': str(q3.uuid), 'payload': 'AAA'},
+            {'question_uuid': str(q4.uuid), 'payload': 'AAA'},
+        ]
+
+        request = self.client.post(f'{self.base_endpoint}{self.session.uuid}/answers', data=answer_data, format='json')
+        self.assertEqual(request.status_code, 200)  # Think about status code! (maybe 202)
+        response_json = request.json()
+
+        self.assertIn('path_questions', response_json)
+        self.assertEqual(len(response_json['path_questions']), 4)
+        self.assertIn('path_answered_question_uuids', response_json)
+
+        # TODO: debug problem where one answer does not show up.
+        self.assertIn(str(q1.uuid), response_json['path_answered_question_uuids'])
+        self.assertIn(str(q2.uuid), response_json['path_answered_question_uuids'])
+        self.assertIn(str(q3.uuid), response_json['path_answered_question_uuids'])
+        self.assertIn(str(q4.uuid), response_json['path_answered_question_uuids'])
+        self.assertEqual(len(response_json['path_answered_question_uuids']), 4)
+
+        self.assertIn('path_unanswered_question_uuids', response_json)
+        self.assertEqual(len(response_json['path_unanswered_question_uuids']), 0)
+        self.assertIn('path_validation_errors_by_uuid', response_json)
+        self.assertEqual(len(response_json['path_validation_errors_by_uuid']), 0)
+        self.assertIn('can_freeze', response_json)
+        self.assertEqual(response_json['can_freeze'], True)
+
+    def test_answer_question_that_does_not_exist(self):
+        pass


### PR DESCRIPTION
## Description

Draft for questionnaires app API that allows several questions and answers to be retrieved / created at once.