### PR TITLE
SIG-4076 Trim whitespaces from fields when making a request to PDOK

### DIFF
--- a/api/app/signals/apps/api/validation/address/pdok.py
+++ b/api/app/signals/apps/api/validation/address/pdok.py
@@ -38,24 +38,25 @@ class PDOKAddressValidation(BaseAddressValidation):
         query_dict.update({'fq': 'bron:BAG'})
         query_dict.update({'fq': 'type:adres'})
 
-        if 'woonplaats' in address and address["woonplaats"]:
-            query_dict.update({'fq': f'woonplaatsnaam:{address["woonplaats"]}'})
-        if 'postcode' in address and address["postcode"]:
-            query_dict.update({'fq': f'postcode:{address["postcode"]}'})
+        if 'woonplaats' in address and address['woonplaats'].strip():
+            query_dict.update({'fq': f'woonplaatsnaam:{address["woonplaats"].strip()}'})
+        if 'postcode' in address and address['postcode'].strip():
+            query_dict.update({'fq': f'postcode:{address["postcode"].strip()}'})
 
         # remove '', ' ' strings before formatting
         cleaned_pdok_list = filter(lambda item: item, map(str.strip, DEFAULT_PDOK_MUNICIPALITIES))
         query_dict.update({'fq': f'''gemeentenaam:("{'" "'.join(cleaned_pdok_list)}")'''})
 
-        straatnaam = address["openbare_ruimte"]
-        huisnummer = address["huisnummer"]
-        huisletter = address["huisletter"] if 'huisletter' in address and address["huisletter"] else ''
-        toevoeging = f'-{address["huisnummer_toevoeging"]}' if 'huisnummer_toevoeging' in address and address["huisnummer_toevoeging"] else ''  # noqa
+        straatnaam = address['openbare_ruimte'].strip()
+        huisnummer = str(address['huisnummer']).strip()
+        huisletter = address['huisletter'].strip() if 'huisletter' in address and address['huisletter'] else ''
+        toevoeging = f'-{address["huisnummer_toevoeging"].strip()}' if 'huisnummer_toevoeging' in address and address['huisnummer_toevoeging'] else ''  # noqa
 
         if lon and lat:
             query_dict.update({'lon': lon, 'lat': lat})
 
         query_dict.update({'q': f'{straatnaam} {huisnummer}{huisletter}{toevoeging}'})
+
         return query_dict
 
     def _search(self, address, lon=None, lat=None, *args, **kwargs):


### PR DESCRIPTION
## Description

SIG-4076 Trim whitespaces from fields when making a request to PDOK

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 89% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
- [X] No SPDX issues are present in the code
