### PR TITLE
feature/SIG-4026

### DIFF
--- a/api/app/signals/apps/api/generics/validators.py
+++ b/api/app/signals/apps/api/generics/validators.py
@@ -69,4 +69,14 @@ class SignalSourceValidator:
         if user.is_authenticated and value.lower() == Signal.SOURCE_DEFAULT_ANONYMOUS_USER:
             raise ValidationError('Invalid source given for authenticated user')
 
+        # If the user is not authenticated and the given Source is active and NOT flagged as is_public otherwise raise
+        # an ValidationError
+        if not user.is_authenticated and Source.objects.filter(name__iexact=value, is_public=False, is_active=True).exists():  # noqa
+            raise ValidationError('Invalid source given for anonymous user')
+
+        # If the user is authenticated and the given Source is active and flagged as is_public otherwise raise an
+        # ValidationError
+        if user.is_authenticated and Source.objects.filter(name__iexact=value, is_public=True, is_active=True).exists():
+            raise ValidationError('Invalid source given for authenticated user')
+
         return value

--- a/api/app/signals/apps/api/serializers/signal.py
+++ b/api/app/signals/apps/api/serializers/signal.py
@@ -21,7 +21,7 @@ from signals.apps.api.generics.permissions import (
     SignalCreateInitialPermission,
     SignalCreateNotePermission
 )
-from signals.apps.api.generics.validators import SignalSourceValidator
+from signals.apps.api.generics.validators import PublicSignalSourceValidator, SignalSourceValidator
 from signals.apps.api.serializers.nested import (
     _NestedCategoryModelSerializer,
     _NestedDepartmentModelSerializer,
@@ -501,6 +501,7 @@ class PublicSignalCreateSerializer(SignalValidationMixin, serializers.ModelSeria
     Note: this is only used in the creation of new Signal instances, not to
     create the response body after a succesfull POST.
     """
+    source = serializers.CharField(default='online', validators=[PublicSignalSourceValidator()])
     location = _NestedLocationModelSerializer()
     reporter = _NestedReporterModelSerializer()
     category = _NestedCategoryModelSerializer(source='category_assignment')
@@ -522,6 +523,7 @@ class PublicSignalCreateSerializer(SignalValidationMixin, serializers.ModelSeria
     class Meta(object):
         model = Signal
         fields = (
+            'source',
             'text',
             'text_extra',
             'location',
@@ -550,8 +552,8 @@ class PublicSignalCreateSerializer(SignalValidationMixin, serializers.ModelSeria
         category_assignment_data = validated_data.pop('category_assignment')
 
         status_data = {"state": workflow.GEMELD}
-        signal = Signal.actions.create_initial(
-            validated_data, location_data, status_data, category_assignment_data, reporter_data)
+        signal = Signal.actions.create_initial(validated_data, location_data, status_data, category_assignment_data,
+                                               reporter_data)
         return signal
 
 

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -2294,7 +2294,7 @@ components:
       type: object
       properties:
         source:
-          description: This field is optional, if not given the source will be set to "online". Only Sources that are defined public can used.
+          description: This field is optional, if not given the source will be set to "online". Only Sources that are defined public can be used.
           type: string
           example: online
         text:

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -2293,6 +2293,10 @@ components:
       description: JSON data for creation of Signal/melding (public version).
       type: object
       properties:
+        source:
+          description: This field is optional, if not given the source will be set to "online". Only Sources that are defined public can used.
+          type: string
+          example: online
         text:
           type: string
           description: The complaint

--- a/api/app/signals/apps/signals/factories/source.py
+++ b/api/app/signals/apps/signals/factories/source.py
@@ -14,3 +14,4 @@ class SourceFactory(DjangoModelFactory):
     description = Sequence(lambda n: f'Beschrijving bron {n}')
     order = Sequence(lambda n: n)
     is_active = True
+    is_public = False

--- a/api/app/signals/apps/signals/migrations/0145_source_is_public.py
+++ b/api/app/signals/apps/signals/migrations/0145_source_is_public.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2021 Gemeente Amsterdam
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0144_alter_question_field_type'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='source',
+            name='is_public',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/api/app/signals/apps/signals/models/source.py
+++ b/api/app/signals/apps/signals/models/source.py
@@ -8,6 +8,8 @@ class Source(models.Model):
     description = models.TextField(max_length=3000)
     order = models.PositiveIntegerField(null=True)
     is_active = models.BooleanField(default=False)
+
+    # When is_public is set to True this Source can only be used when creating Signals using the public endpoint
     is_public = models.BooleanField(default=False)
 
     class Meta:

--- a/api/app/signals/apps/signals/models/source.py
+++ b/api/app/signals/apps/signals/models/source.py
@@ -8,6 +8,7 @@ class Source(models.Model):
     description = models.TextField(max_length=3000)
     order = models.PositiveIntegerField(null=True)
     is_active = models.BooleanField(default=False)
+    is_public = models.BooleanField(default=False)
 
     class Meta:
         ordering = ('order', 'name', )

--- a/api/app/tests/apps/api/test_private_signal_endpoint_create.py
+++ b/api/app/tests/apps/api/test_private_signal_endpoint_create.py
@@ -506,7 +506,7 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation
     def test_create_initial_signal_public_source(self, validate_address):
-        public_source = SourceFactory.create(name='app', is_public=True, is_active=False)
+        public_source = SourceFactory.create(name='app', is_public=True, is_active=True)
         signal_count = Signal.objects.count()
 
         initial_data = copy.deepcopy(self.initial_data_base)

--- a/api/app/tests/apps/api/test_private_signal_endpoint_create.py
+++ b/api/app/tests/apps/api/test_private_signal_endpoint_create.py
@@ -45,7 +45,7 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
     }
 
     def setUp(self):
-        SourceFactory.create(name='online', is_active=True)
+        SourceFactory.create(name='online', is_active=True, is_public=True)
         SourceFactory.create(name='Telefoon – ASC', is_active=True)
 
         self.main_category = ParentCategoryFactory.create(name='main', slug='main')
@@ -426,7 +426,7 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
     def test_create_initial_child_signals_validate_source_online(self, validate_address):
         # Validating a valid source for child Signals causes a HTTP 500 in
         # SIA production, this testcase reproduces the problem.
-        SourceFactory.create(name='online', description='online')
+        SourceFactory.create(name='online', description='online', is_public=True)
 
         with self.settings(FEATURE_FLAGS=self.prod_feature_flags_settings):
             parent_signal = SignalFactory.create()
@@ -457,7 +457,7 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)
     def test_signal_ids_cannot_be_skipped(self, validate_address):
-        SourceFactory.create(name='online', description='online')
+        SourceFactory.create(name='online', description='online', is_public=True)
 
         with self.settings(FEATURE_FLAGS=self.prod_feature_flags_settings):
             parent_signal = SignalFactory.create()
@@ -502,3 +502,16 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
             ids = [entry['id'] for entry in response_json]
             self.assertEqual(ids[0] - parent_signal.id, 1)
             self.assertEqual(ids[1] - parent_signal.id, 2)
+
+    @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
+           side_effect=AddressValidationUnavailableException)  # Skip address validation
+    def test_create_initial_signal_public_source(self, validate_address):
+        public_source = SourceFactory.create(name='app', is_public=True, is_active=False)
+        signal_count = Signal.objects.count()
+
+        initial_data = copy.deepcopy(self.initial_data_base)
+        initial_data['source'] = public_source.name
+        response = self.client.post(self.list_endpoint, initial_data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Signal.objects.count(), signal_count)


### PR DESCRIPTION
## Description

It is now possible to specify a Source with the "is_public" flag set to True when creating a Signal using the public endpoint. If no Source is given the API will fallback on the "online" source (how the API always worked)

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Documentation has been updated if needed
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort, Flake8 & SPDX issues are present in the code
