### PR TITLE
Allow Signal delete from django shell.

### DIFF
--- a/api/app/signals/apps/signals/models/history.py
+++ b/api/app/signals/apps/signals/models/history.py
@@ -15,7 +15,7 @@ class History(models.Model):
     _signal = models.ForeignKey('signals.Signal',
                                 related_name='history',
                                 null=False,
-                                on_delete=models.CASCADE)
+                                on_delete=models.DO_NOTHING)
     when = models.DateTimeField(null=True)
     what = models.CharField(max_length=255)
     who = models.CharField(max_length=255, null=True)  # old entries in database may have no user

--- a/api/app/tests/apps/api/test_private_signal_endpoint.py
+++ b/api/app/tests/apps/api/test_private_signal_endpoint.py
@@ -2057,6 +2057,15 @@ class TestPrivateSignalViewSetPermissions(SIAReadUserMixin, SIAWriteUserMixin, S
         response = self.client.patch(detail_endpoint, data=data, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_delete_not_allowed_via_api(self):
+        # Signals are allowed to be deleted at the database level, but until it
+        # is known what requirements / restrictions are at REST API level we do
+        # not allow deletes via REST API.
+        self.client.force_authenticate(user=self.superuser)
+        detail_endpoint = self.detail_endpoint.format(pk=self.signal_2.id)
+        response = self.client.delete(detail_endpoint)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
 
 class TestSignalChildrenEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
     def setUp(self):


### PR DESCRIPTION
Note: this is precursor to a full implementation of a proper delete
taking into account buisiness rules etc. Current commit only allows
delete at model level and will be used to delete some test Signal
instances using shell access.

## Description

Add a meaningful description explaining the change/fix that is provided in this PR

