### PR TITLE
chore/email-integrations-utils-decode-urls

### DIFF
--- a/api/app/signals/apps/email_integrations/utils.py
+++ b/api/app/signals/apps/email_integrations/utils.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Gemeente Amsterdam
 import re
 from typing import Optional
+from urllib.parse import unquote
 
 from django.conf import settings
 from django.core.validators import URLValidator
@@ -74,12 +75,16 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
 
     For backwards compatibility the Signal and the Status are still added to the context
     """
+    # Decode the text and text_area before removing any URL to make sure that urlencoded URL's are also removed.
+    text = re.sub(URL_PATTERN, '', unquote(signal.text))
+    text_extra = re.sub(URL_PATTERN, '', unquote(signal.text_extra))
+
     context = {
         'signal_id': signal.id,
         'formatted_signal_id': signal.sia_id,
         'created_at': signal.created_at,
-        'text': re.sub(URL_PATTERN, '', signal.text),
-        'text_extra': re.sub(URL_PATTERN, '', signal.text_extra),
+        'text': text,
+        'text_extra': text_extra,
         'address': signal.location.address,
         'status_text': signal.status.text,
         'status_state': signal.status.state,


### PR DESCRIPTION
## Description

In the email-integrations utils.py any URL from the text/text_extra of a Signal is removed. However sometimes urlencoded URL's where not removed. Therefore now the text/text_extra is URL decoded before removing any URL from the text/text_extra.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort, Flake8 & SPDX issues are present in the code