### PR TITLE
SIG-4168 make sure unittests do not connect to external services

### DIFF
--- a/api/app/signals/apps/services/tests/domain/test_auto_create_children_containers.py
+++ b/api/app/signals/apps/services/tests/domain/test_auto_create_children_containers.py
@@ -234,7 +234,11 @@ class TestAutoCreateChildrenServiceService(TestCase):
         self.assertFalse(signal.is_parent)
         self.assertEqual(signal.children.count(), 0)
 
-    def test_signal_kapot_to_vol(self):
+    @mock.patch(
+        'signals.apps.services.domain.auto_create_children.service.CreateChildrenContainerAction._get_container_location',  # noqa
+        autospec=True
+    )
+    def test_signal_kapot_to_vol(self, mocked):
         """
         Check that complaints in one of the broken container categories get
         children in one of the full container categories.
@@ -253,6 +257,7 @@ class TestAutoCreateChildrenServiceService(TestCase):
             self.assertFalse(signal.is_parent)
             self.assertEqual(signal.children.count(), 0)
 
+            mocked.return_value = signal.location.geometrie
             AutoCreateChildrenService.run(signal_id=signal.pk)
 
             signal.refresh_from_db()


### PR DESCRIPTION
## Description

A unittest in our test suite is connecting to an external service, causing unwanted test suite failure when service is unavailable.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations


## How has this been tested?

- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
