### PR TITLE
add note export to csv

### DIFF
--- a/api/app/signals/apps/reporting/csv/datawarehouse/__init__.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/__init__.py
@@ -13,6 +13,7 @@ from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_
 from signals.apps.reporting.csv.datawarehouse.signals import (
     create_signals_assigned_user_csv,
     create_signals_csv,
+    create_signals_notes_csv,
     create_signals_routing_departments_csv
 )
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
@@ -31,6 +32,7 @@ __all__ = [
     'create_reporters_csv',
     'create_statuses_csv',
     'create_signals_assigned_user_csv',
+    'create_signals_notes_csv',
     'create_signals_routing_departments_csv',
     'create_signals_csv',
     'save_csv_file_datawarehouse',

--- a/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
@@ -11,7 +11,7 @@ from django.db.models import CharField, F, Value
 from django.db.models.functions import Cast, Coalesce
 
 from signals.apps.reporting.csv.utils import queryset_to_csv_file, reorder_csv
-from signals.apps.signals.models import Signal, SignalDepartments
+from signals.apps.signals.models import Note, Signal, SignalDepartments
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +110,34 @@ def create_signals_routing_departments_csv(location: str) -> str:
     csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'routing_departments.csv'))
 
     ordered_field_names = ['id', 'created_at', 'updated_at', '_signal_id', 'departments', ]
+    reorder_csv(csv_file.name, ordered_field_names)
+
+    return csv_file.name
+
+
+def create_signals_notes_csv(location: str) -> str:
+    """
+    Create the CSV file with all `Signal - notes relation` objects.
+
+    :param location: Directory for saving the CSV file
+    :returns: Path to CSV file
+    """
+    queryset = Note.objects.annotate(
+        image=Value(None, output_field=CharField()),
+    ).values(
+        'id',
+        'created_at',
+        'updated_at',
+        '_signal_id',
+        'text',
+    ).order_by(
+        '_signal_id',
+        '-created_at',
+    )
+
+    csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'signals_notes.csv'))
+
+    ordered_field_names = ['id', 'created_at', 'updated_at', '_signal_id', 'text']
     reorder_csv(csv_file.name, ordered_field_names)
 
     return csv_file.name

--- a/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
@@ -122,9 +122,7 @@ def create_signals_notes_csv(location: str) -> str:
     :param location: Directory for saving the CSV file
     :returns: Path to CSV file
     """
-    queryset = Note.objects.annotate(
-        image=Value(None, output_field=CharField()),
-    ).values(
+    queryset = Note.objects.values(
         'id',
         'created_at',
         'updated_at',

--- a/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
@@ -133,7 +133,7 @@ def create_signals_notes_csv(location: str) -> str:
         '-created_at',
     )
 
-    csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'signals_notes.csv'))
+    csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'notes.csv'))
 
     ordered_field_names = ['id', 'created_at', 'updated_at', '_signal_id', 'text']
     reorder_csv(csv_file.name, ordered_field_names)

--- a/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/tasks.py
@@ -16,6 +16,7 @@ from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_
 from signals.apps.reporting.csv.datawarehouse.signals import (
     create_signals_assigned_user_csv,
     create_signals_csv,
+    create_signals_notes_csv,
     create_signals_routing_departments_csv
 )
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
@@ -58,6 +59,7 @@ def save_csv_files_datawarehouse(using='datawarehouse'):
     csv_files.extend(save_csv_file_datawarehouse(create_category_sla_csv, using=using))
     csv_files.extend(save_csv_file_datawarehouse(create_directing_departments_csv, using=using))
     csv_files.extend(save_csv_file_datawarehouse(create_signals_routing_departments_csv, using=using))
+    csv_files.extend(save_csv_file_datawarehouse(create_signals_notes_csv, using=using))
 
     try:
         csv_files.extend(save_csv_file_datawarehouse(create_kto_feedback_csv, using=using))

--- a/api/app/signals/apps/reporting/management/commands/dumpcsv.py
+++ b/api/app/signals/apps/reporting/management/commands/dumpcsv.py
@@ -20,6 +20,7 @@ from signals.apps.reporting.csv.datawarehouse.reporters import create_reporters_
 from signals.apps.reporting.csv.datawarehouse.signals import (
     create_signals_assigned_user_csv,
     create_signals_csv,
+    create_signals_notes_csv,
     create_signals_routing_departments_csv
 )
 from signals.apps.reporting.csv.datawarehouse.statusses import create_statuses_csv
@@ -40,6 +41,7 @@ REPORT_OPTIONS = {
     'feedback': create_kto_feedback_csv,
     'directing_departments': create_directing_departments_csv,
     'routing_departments': create_signals_routing_departments_csv,
+    'notes': create_signals_notes_csv
 }
 
 

--- a/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
+++ b/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
@@ -18,7 +18,7 @@ from freezegun import freeze_time
 from signals.apps.feedback.factories import FeedbackFactory
 from signals.apps.reporting.csv import datawarehouse
 from signals.apps.reporting.utils import _get_storage_backend
-from signals.apps.signals.factories import DepartmentFactory, SignalFactory
+from signals.apps.signals.factories import DepartmentFactory, NoteFactory, SignalFactory
 from signals.apps.signals.models import SignalDepartments
 
 
@@ -339,7 +339,8 @@ class TestDatawarehouse(testcases.TestCase):
 
     def test_create_notes_csv(self):
         signal = SignalFactory.create()
-        notes = signal.notes
+        # Add one note to the signal
+        notes = NoteFactory(id=1, _signal=signal)
 
         csv_file = datawarehouse.create_signals_notes_csv(self.csv_tmp_dir)
 

--- a/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
+++ b/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
@@ -94,6 +94,7 @@ class TestDatawarehouse(testcases.TestCase):
         statuses_csv = path.join(self.file_backend_tmp_dir, '2020/09/10', '120000UTC_statuses.csv')
         sla_csv = path.join(self.file_backend_tmp_dir, '2020/09/10', '120000UTC_sla.csv')
         directing_departments_csv = path.join(self.file_backend_tmp_dir, '2020/09/10', '120000UTC_directing_departments.csv')  # noqa
+        notes_csv = path.join(self.file_backend_tmp_dir, '2020/09/10', '120000UTC_notes.csv')
         zip_package = path.join(self.file_backend_tmp_dir, '2020/09/10', '20200910_120000UTC.zip')
 
         self.assertTrue(path.exists(signals_csv))
@@ -108,6 +109,7 @@ class TestDatawarehouse(testcases.TestCase):
         self.assertTrue(path.getsize(statuses_csv))
         self.assertTrue(path.getsize(sla_csv))
         self.assertTrue(path.getsize(directing_departments_csv))
+        self.assertTrue(path.getsize(notes_csv))
         self.assertTrue(path.getsize(zip_package))
 
     @mock.patch.dict('os.environ', {}, clear=True)
@@ -334,6 +336,22 @@ class TestDatawarehouse(testcases.TestCase):
 
                 for department in departments:
                     self.assertIn(department.name, row['departments'].split(', '))
+
+    def test_create_notes_csv(self):
+        signal = SignalFactory.create()
+        notes = signal.notes
+
+        csv_file = datawarehouse.create_signals_notes_csv(self.csv_tmp_dir)
+
+        self.assertEqual(path.join(self.csv_tmp_dir, 'notes.csv'),
+                         csv_file)
+
+        with open(csv_file) as opened_csv_file:
+            reader = csv.DictReader(opened_csv_file)
+            for row in reader:
+                self.assertEqual(row['id'], str(notes.id))
+                self.assertEqual(row['_signal_id'], str(notes._signal_id))
+                self.assertEqual(row['text'], str(notes.text))
 
 
 class TestFeedbackHandling(testcases.TestCase):

--- a/api/app/signals/apps/reporting/tests/management/commands/test_command.py
+++ b/api/app/signals/apps/reporting/tests/management/commands/test_command.py
@@ -18,7 +18,7 @@ class TestCommand(TransactionTestCase):
         self.assertNotEqual(out.getvalue(), '')
         self.assertEqual(err.getvalue(), '')
 
-        self.assertEqual(patched_save_csv_files_datawarehouse.call_count, 10)
+        self.assertEqual(patched_save_csv_files_datawarehouse.call_count, 11)
 
 
 class TestCSVHorecaCommand(TransactionTestCase):


### PR DESCRIPTION
## Description

This PR adds the export of the signal notes (as extra csv file) requested by Den Bosch to the dwh export.
The export creates a cvs file in addition to existing files and contains at least the signal_id and notes for that signal. These notes are used to record 'vuurwerk' specific data.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 89% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
