### PR TITLE
Bugfix/handle csv dump rotation correctly

### DIFF
--- a/api/app/signals/apps/reporting/csv/utils.py
+++ b/api/app/signals/apps/reporting/csv/utils.py
@@ -42,13 +42,13 @@ def zip_csv_files(files_to_zip: list, using: str) -> None:
 
 def rotate_zip_files(using: str, max_csv_amount: int = 30) -> None:
     """
-    rotate csv zip file in the {now:%Y}/{now:%m}/{now:%d} folder
+    rotate csv zip file in the {now:%Y} folder
 
     :returns:
     """
     storage = _get_storage_backend(using=using)
     now = timezone.now()
-    src_folder = f'{storage.location}/{now:%Y}/{now:%m}/{now:%d}'
+    src_folder = f'{storage.location}/{now:%Y}'
     if os.path.exists(src_folder):
         list_of_files = glob(f'{src_folder}/*.zip', recursive=True)
         if len(list_of_files) > max_csv_amount:

--- a/api/app/signals/apps/reporting/csv/utils.py
+++ b/api/app/signals/apps/reporting/csv/utils.py
@@ -50,7 +50,7 @@ def rotate_zip_files(using: str, max_csv_amount: int = 30) -> None:
     now = timezone.now()
     src_folder = f'{storage.location}/{now:%Y}'
     if os.path.exists(src_folder):
-        list_of_files = glob(f'{src_folder}/*.zip', recursive=True)
+        list_of_files = glob(f'{src_folder}/**/*.zip', recursive=True)
         if len(list_of_files) > max_csv_amount:
             list_of_files.sort(key=os.path.getmtime)
             for file_to_be_deleted in list_of_files[:len(list_of_files) - max_csv_amount]:

--- a/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
+++ b/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
@@ -127,8 +127,8 @@ class TestDatawarehouse(testcases.TestCase):
         with freeze_time('2020-09-10T15:00:00+00:00'):
             datawarehouse.save_and_zip_csv_files_endpoint(max_csv_amount=1)
 
-        src_folder = f'{self.file_backend_tmp_dir}/2020/09/10'
-        list_of_files = glob(f'{src_folder}/*.zip', recursive=True)
+        src_folder = f'{self.file_backend_tmp_dir}/2020'
+        list_of_files = glob(f'{src_folder}/**/*.zip', recursive=True)
         self.assertEqual(1, len(list_of_files))
         self.assertTrue(list_of_files[0].endswith('20200910_150000UTC.zip'))
 


### PR DESCRIPTION
## Description

Every time a csv/dwh dump is made, we try to rotate up to a predefined number (n=30) of dump files.
Currently we only look into the year/month/day folder to do rotation. This is incorrect, we should rotate files for a whole year.


## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Documentation has been updated if needed
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts
- [ ] There are no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 90% (the higher the better)
- [ ] No iSort issues are present in the code
- [ ] No Flake8 issues are present in the code
