### PR TITLE
Bumped Pillow to 9.0.0 (CVE-2022-22817)

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -80,7 +80,7 @@ oslo.utils==4.8.0
 packaging==20.9
 pbr==5.5.1
 pilkit==2.0
-Pillow==8.3.2
+Pillow==9.0.0
 pluggy==0.13.1
 prompt-toolkit==3.0.18
 protobuf==3.15.7


### PR DESCRIPTION
Bumped Pillow to 9.0.0

"PIL.ImageMath.eval in Pillow before 9.0.0 allows evaluation of
arbitrary expressions, such as ones that use the Python exec method."

More info on https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22817

## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass