### PR TITLE
Bumped Django 3.2.11 (CVE-2021-45115, CVE-2021-45452 and CVE-2021-45116)

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,7 +24,7 @@ datapunt-authorization-django==1.3.0
 debtcollector==2.2.0
 defusedxml==0.7.1
 distlib==0.3.1
-Django==3.2.10
+Django==3.2.11
 django-appconf==1.0.4
 django-celery-beat==2.2.0
 django-celery-email==3.0.0


### PR DESCRIPTION
## Description

CVE-2021-45115: An issue was discovered in Django 2.2 before 2.2.26, 3.2 before 3.2.11, and 4.0 before 4.0.1. UserAttributeSimilarityValidator incurred significant overhead in evaluating a submitted password that was artificially large in relation to the comparison values. In a situation where access to user registration was unrestricted, this provided a potential vector for a denial-of-service attack.

CVE-2021-45452: Storage.save in Django 2.2 before 2.2.26, 3.2 before 3.2.11, and 4.0 before 4.0.1 allows directory traversal if crafted filenames are directly passed to it.

CVE-2021-45116: An issue was discovered in Django 2.2 before 2.2.26, 3.2 before 3.2.11, and 4.0 before 4.0.1. Due to leveraging the Django Template Language's variable resolution logic, the dictsort template filter was potentially vulnerable to information disclosure, or an unintended method call, if passed a suitably crafted key.


## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
