### PR TITLE
Bumped mistune to 2.0.1

### DIFF
--- a/api/app/signals/apps/email_integrations/markdown/renderers.py
+++ b/api/app/signals/apps/email_integrations/markdown/renderers.py
@@ -67,3 +67,6 @@ class PlaintextRenderer(BaseRenderer):
 
     def list_item(self, text, level):
         return '- {}\n'.format(text)
+
+    def finalize(self, data):
+        return ''.join(data)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -67,7 +67,7 @@ kombu==5.2.3
 lxml==4.6.5
 MarkupSafe==1.1.1
 mccabe==0.6.1
-mistune==2.0.0a6
+mistune==2.0.1
 msgpack==1.0.2
 netaddr==0.8.0
 netifaces==0.11.0


### PR DESCRIPTION
## Description

Bumped mistune to 2.0.1

Affected versions of this package are vulnerable to Cross-site Scripting (XSS) via image link that is not sanitized.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
