### PR TITLE
bugfix/attachment-image-DecompressionBombError

### DIFF
--- a/api/app/signals/apps/api/serializers/attachment.py
+++ b/api/app/signals/apps/api/serializers/attachment.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
 from datapunt_api.rest import DisplayField, HALSerializer
 from django.conf import settings
+from PIL.Image import DecompressionBombError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -54,7 +55,7 @@ class SignalAttachmentSerializer(HALSerializer):
 
         try:
             UploadScannerService.scan_file(file)
-        except FileRejectedError as e:
+        except (FileRejectedError, DecompressionBombError) as e:
             raise ValidationError(str(e))
 
         return file

--- a/api/app/signals/apps/services/domain/filescanner.py
+++ b/api/app/signals/apps/services/domain/filescanner.py
@@ -7,6 +7,7 @@ import logging
 import mimetypes
 
 import magic
+from PIL import Image
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,9 @@ class UploadScannerService:
         seen.add(UploadScannerService._get_mime_from_content(uploaded_file))
 
         if len(seen) == 1 and list(seen)[0] in ALLOWED_MIME_TYPES:
+            # Let's see if PIL raises the DecompressionBombError
+            Image.open(uploaded_file.file)
+
             return uploaded_file
 
         if len(seen) > 1:


### PR DESCRIPTION
## Description

Try to open the uploaded file in the filescanner to see if PIL is raising the DecompressionBombError. 
Capture the DecompressionBombError and return this as an 400 with correct body in the API. 
Added unit tests.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Documentation has been updated if needed
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 89% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
- [X] No SPDX issues are present in the code
