### PR TITLE
CBS published a new municipal and neighborhood map data, use it.

### DIFF
--- a/api/app/signals/apps/dataset/sources/cbs.py
+++ b/api/app/signals/apps/dataset/sources/cbs.py
@@ -8,23 +8,23 @@ class CBSBoundariesLoader(ShapeBoundariesLoader):
     """
     Load municipal (and neigbhorhood) boundaries as SIA Area instances.
     """
-    DATASET_URL = 'https://www.cbs.nl/-/media/cbs/dossiers/nederland-regionaal/wijk-en-buurtstatistieken/wijkbuurtkaart_2019_v2up.zip'  # noqa
+    DATASET_URL = 'https://www.cbs.nl/-/media/cbs/dossiers/nederland-regionaal/wijk-en-buurtstatistieken/wijkbuurtkaart_2021_v1.zip'  # noqa
     # Unfortunately, these filenames are not uniformly named over the years,
     # so a hard-coded mapping is provided for the most recent data file (as of
     # this writing 2019).
     DATASET_INFO = {
-        'cbs-gemeente-2019': {
-            'shp_file': 'gemeente_2019_v2up.shp',
+        'cbs-gemeente-2021': {
+            'shp_file': 'WijkBuurtkaart_2021_v1/gemeente_2021_v1.shp',
             'code_field': 'GM_CODE',
             'name_field': 'GM_NAAM',
         },
-        'cbs-wijk-2019': {
-            'shp_file': 'wijk_2019_v2up.shp',
+        'cbs-wijk-2021': {
+            'shp_file': 'WijkBuurtkaart_2021_v1/wijk_2021_v1.shp',
             'code_field': 'WK_CODE',
             'name_field': 'WK_NAAM',
         },
-        'cbs-buurt-2019': {
-            'shp_file': 'buurt_2019_v2up.shp',
+        'cbs-buurt-2021': {
+            'shp_file': 'WijkBuurtkaart_2021_v1/buurt_2021_v1.shp',
             'code_field': 'BU_CODE',
             'name_field': 'BU_NAAM',
         }

--- a/api/app/signals/apps/dataset/sources/shape.py
+++ b/api/app/signals/apps/dataset/sources/shape.py
@@ -70,7 +70,12 @@ class ShapeBoundariesLoader(AreaLoader):
         # municipality.
         for feature in ds[0]:
             code = feature.get(self.code_field)
-            name_by_code[code] = feature.get(self.name_field)
+            name = feature.get(self.name_field)
+            assert name and code  # At least one of these must be different from None.
+
+            if not name and code:
+                name = code   # No name present, use code as name.
+            name_by_code[code] = name
 
             # Transform to WGS84 and merge if needed.
             transformed = feature.geom.transform('WGS84', clone=True)

--- a/scripts/initialize.sh
+++ b/scripts/initialize.sh
@@ -31,7 +31,7 @@ python manage.py collectstatic --no-input
 if [[ ${INITIALIZE_WITH_DUMMY_DATA:-0} == 1 ]]; then
   echo "Load dummy data"
   python manage.py load_areas stadsdeel
-  python manage.py load_areas cbs-gemeente-2019
+  python manage.py load_areas cbs-gemeente-2021
   python manage.py load_areas sia-stadsdeel
 
   # Other scripts to load data should be placed here


### PR DESCRIPTION
## Description

The Dutch bureau for statistics (Centraal Bureau voor de Statistiek, CBS) periodically publishes new datasets containing municipal and neighborhood map data for the Netherlands. We have the ability to import this data, but that breaks when old datasets are (re)moved by the CBS. This PR contains some small fixes to be able to ingest the newest CBS data.

Because the dataset is too large to just include please test by running the relevant management commands:
```
python manage.py load_areas cbs-gemeente-2021
python manage.py load_areas cbs-wijk-2021
python manage.py load_areas cbs-buurt-2021
```


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations

## How has this been tested?

- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
