### PR TITLE
Load neighborhoods from CBS data given CBS code for municipality

### DIFF
--- a/api/app/signals/apps/dataset/management/commands/load_cbs_for_municipality.py
+++ b/api/app/signals/apps/dataset/management/commands/load_cbs_for_municipality.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+"""
+Extract neighborhood data for a given municipality from CBS data.
+
+Note:
+- Centraal Bureau voor de Statistiek (CBS) neighborhood and municipal map data
+  must be present in the Signalen database.
+- The Signalen instance that we run this script for must serve one municipality.
+- AreaTypes will be added that have names `<municipal_code>-wijk` and
+  `<municipal_code>-buurt`.
+- The Dutch "buurt" and "wijk" both translate to neighborhood, but in the
+  Netherlands "wijk" areas are larger and consist of "buurt" areas. We use the
+  Dutch terms below - the use of CBS data makes this code specific to the
+  Netherlands.
+"""
+from django.core.management import BaseCommand, CommandError
+from django.db import transaction
+
+from signals.apps.signals.models import Area, AreaType
+
+REQUIRED_DATASETS = {
+    # Dataset names must match those defined in signals.apps.dataset.sources.cbs
+    'CBS_MUNICIPAL_BORDERS_DATASET': 'cbs-gemeente-2021',
+    'CBS_WIJK_DATASET': 'cbs-wijk-2021',
+    'CBS_BUURT_DATASET': 'cbs-buurt-2021',
+}
+
+
+class Command(BaseCommand):
+    def _cbs_data_present(self):
+        """
+        We need the CBS data municipal borders and neighborhood borders
+        """
+        all_present = True
+        for value in REQUIRED_DATASETS.values():
+            if not AreaType.objects.filter(code=value).exists():
+                all_present = False
+                msg = f'Required area type {value} is not present in database!'
+                self.stdout.write(msg)
+                continue
+
+            area_type = AreaType.objects.get(code=value)
+            if not Area.objects.filter(_type=area_type).count():
+                all_present = False
+                msg = f'No area data associated with AreaType {value}!'
+                self.stdout.write(msg)
+
+        return all_present
+
+    def _municipal_code_is_correct(self, municipal_code):
+        """Municipal code must be present in CBS data"""
+        # Assumes that required dataset (municipal borders) is present.
+        area_type = AreaType.objects.get(code=REQUIRED_DATASETS['CBS_MUNICIPAL_BORDERS_DATASET'])
+        return Area.objects.filter(_type=area_type, code=municipal_code).exists()
+
+    def _derive_dataset_codes(self, municipal_code):
+        """Newly created datasets will use names based on municipal code"""
+        municipal_code = municipal_code.lower()
+        return f'{municipal_code}-wijk', f'{municipal_code}-buurt'
+
+    def _copy_areas_to_area_type(self, area_qs, to_area_type):
+        """Create a copy of a number of areas to a different area type"""
+        for area in area_qs:
+            area._type = to_area_type
+            area.id = None
+            area.save()
+
+    def add_arguments(self, parser):
+        parser.add_argument('--municipal_code', type=str, default=None, help='Municipal code (CBS GM_CODE).')
+
+    def handle(self, *args, **options):
+        """
+        Find neighborhoods in requested municipality store them as a dataset.
+
+        Note: storing as a dataset in this context means that a we derive
+        area type names for the neighborhoods in the municipality under
+        consideration. We store a copy of all relevant neighborhoods (both the
+        Dutch "wijk" and "buurt" types of neighborhood) associated with the
+        newly created AreaTypes.
+        """
+        cbs_wijk_dataset = REQUIRED_DATASETS['CBS_WIJK_DATASET']
+        cbs_buurt_dataset = REQUIRED_DATASETS['CBS_BUURT_DATASET']
+        municipal_code = options['municipal_code']
+
+        if not self._cbs_data_present():
+            raise CommandError('Required datasets are not available, exiting!')
+        if not self._municipal_code_is_correct(municipal_code):
+            raise CommandError('Provided municipal code is not present in CBS data, exiting!')
+        self.stdout.write('Required CBS data are available.')
+
+        # Datatype for our newly loaded data, note we drop the old copy.
+        wijk_dataset_code, buurt_dataset_code = self._derive_dataset_codes(municipal_code)
+        wijk_area_type, _ = AreaType.objects.get_or_create(code=wijk_dataset_code, name=wijk_dataset_code)
+        buurt_area_type, _ = AreaType.objects.get_or_create(code=buurt_dataset_code, name=buurt_dataset_code)
+
+        with transaction.atomic():
+            to_remove_w = Area.objects.filter(_type=wijk_area_type)
+            to_remove_b = Area.objects.filter(_type=buurt_area_type)
+
+            self.stdout.write(f'\nThere are {to_remove_w.count()} old (wijk) area instances to remove')
+            self.stdout.write(f'There are {to_remove_b.count()} old (buurt) area instances to remove')
+
+            to_remove_w.delete()
+            to_remove_b.delete()
+
+            # We duplicate the neighborhoods in the municipality we are interested in, we select the geometry for
+            # the municipality and use it to find the neighborhoods ("wijk" and "buurt") we want to copy.
+            municipality_area_type = AreaType.objects.get(code=REQUIRED_DATASETS['CBS_MUNICIPAL_BORDERS_DATASET'])
+            municipality = Area.objects.get(_type=municipality_area_type, code=municipal_code)
+            self.stdout.write(f'\nNeighborhoods for the municipality of "{municipality.name}" will be copied')
+
+            to_copy_w = Area.objects.filter(_type__code=cbs_wijk_dataset, geometry__intersects=municipality.geometry)
+            to_copy_b = Area.objects.filter(_type__code=cbs_buurt_dataset, geometry__intersects=municipality.geometry)
+
+            self.stdout.write(f'There are {to_copy_w.count()} new "wijk" area instances to copy.')
+            self.stdout.write(f'"Wijk" area instances will be copied to dataset/AreaType {wijk_area_type.name}.')
+            self.stdout.write(f'There are {to_copy_b.count()} new "buurt area instances to copy.')
+            self.stdout.write(f'"Buurt" area instances will be copied to dataset/AreaType {buurt_area_type.name}.')
+
+            self._copy_areas_to_area_type(to_copy_w, wijk_area_type)
+            self._copy_areas_to_area_type(to_copy_b, buurt_area_type)
+
+            self.stdout.write('Done.')

--- a/api/app/signals/apps/dataset/sources/cbs.py
+++ b/api/app/signals/apps/dataset/sources/cbs.py
@@ -11,7 +11,7 @@ class CBSBoundariesLoader(ShapeBoundariesLoader):
     DATASET_URL = 'https://www.cbs.nl/-/media/cbs/dossiers/nederland-regionaal/wijk-en-buurtstatistieken/wijkbuurtkaart_2021_v1.zip'  # noqa
     # Unfortunately, these filenames are not uniformly named over the years,
     # so a hard-coded mapping is provided for the most recent data file (as of
-    # this writing 2019).
+    # this writing early 2022).
     DATASET_INFO = {
         'cbs-gemeente-2021': {
             'shp_file': 'WijkBuurtkaart_2021_v1/gemeente_2021_v1.shp',

--- a/api/app/signals/apps/dataset/sources/shape.py
+++ b/api/app/signals/apps/dataset/sources/shape.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import os
 import zipfile
 from urllib.parse import urlsplit
@@ -71,7 +71,7 @@ class ShapeBoundariesLoader(AreaLoader):
         for feature in ds[0]:
             code = feature.get(self.code_field)
             name = feature.get(self.name_field)
-            assert name and code  # At least one of these must be different from None.
+            assert name or code  # At least one of these must be different from None.
 
             if not name and code:
                 name = code   # No name present, use code as name.

--- a/api/app/signals/apps/dataset/tests/management/commands/test_load_cbs_for_municipality.py
+++ b/api/app/signals/apps/dataset/tests/management/commands/test_load_cbs_for_municipality.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+from io import StringIO
+
+from django.contrib.gis.geos import MultiPolygon, Polygon
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+
+from signals.apps.dataset.management.commands.load_cbs_for_municipality import REQUIRED_DATASETS
+from signals.apps.signals.factories import AreaFactory, AreaTypeFactory
+from signals.apps.signals.models import Area, AreaType
+
+# Fake rectangular Amsterdam:
+BBOX = [4.58565, 52.03560, 5.31360, 52.48769]
+
+
+class TestLoadCBSForMunicipality(TestCase):
+    def setUp(self):
+        # This setUp stands in for the cbs.py data loading script run for the
+        # relevant datasets. Note that REQUIRED_DATASETS must match what's in
+        # the CBS dataloader cbs.py.
+        self.area_type_code_m = REQUIRED_DATASETS['CBS_MUNICIPAL_BORDERS_DATASET']
+        self.area_type_code_w = REQUIRED_DATASETS['CBS_WIJK_DATASET']
+        self.area_type_code_b = REQUIRED_DATASETS['CBS_BUURT_DATASET']
+
+        self.area_type_m = AreaTypeFactory.create(code=self.area_type_code_m, name=self.area_type_code_m)
+        self.area_type_w = AreaTypeFactory.create(code=self.area_type_code_w, name=self.area_type_code_w)
+        self.area_type_b = AreaTypeFactory.create(code=self.area_type_code_b, name=self.area_type_code_b)
+
+        min_lon, min_lat, max_lon, max_lat = BBOX
+        extent_lon = max_lon - min_lon
+        extent_lat = max_lat - min_lat
+
+        amsterdam_geom = MultiPolygon([Polygon.from_bbox((min_lon, min_lat, max_lon, max_lat))])
+        self.area_amsterdam = AreaFactory(
+            name='Amsterdam', code='GM0363', _type=self.area_type_m, geometry=amsterdam_geom)
+
+        # Area in fake Amsterdam:
+        polygon_in = Polygon.from_bbox((
+            min_lon + extent_lon * 0.25,
+            min_lat + extent_lat * 0.25,
+            min_lon + extent_lon * 0.75,
+            min_lat + extent_lat * 0.75,
+        ))
+        # Area in fake Amsterdam:
+        polygon_out = Polygon.from_bbox((
+            min_lon + extent_lon * 1.25,
+            min_lat + extent_lat * 0.25,
+            min_lon + extent_lon * 1.75,
+            min_lat + extent_lat * 0.75,
+        ))
+
+        # Neighborhoods (note these are not valid CBS codes!)
+        self.area_in_amsterdam_w = AreaFactory.create(
+            name='Wijk in Amsterdam', code='WK036301', _type=self.area_type_w, geometry=MultiPolygon([polygon_in]))
+        self.area_in_amsterdam_b = AreaFactory(
+            name='Buurt in Amsterdam', code='BU03630101', _type=self.area_type_b, geometry=MultiPolygon(polygon_in))
+
+        self.area_outside_amsterdam_w = AreaFactory(
+            name='Wijk buiten Amsterdam', code='WK01', _type=self.area_type_w, geometry=MultiPolygon([polygon_out]))
+        self.area_outside_amsterdam_b = AreaFactory(
+            name='Buurt buiten', code='BU01234', _type=self.area_type_b, geometry=MultiPolygon([polygon_out]))
+
+    # happy flow
+    def test_load_wijk_and_buurt(self):
+        self.assertEqual(AreaType.objects.count(), 3)
+        self.assertEqual(Area.objects.count(), 5)
+
+        buffer = StringIO()
+        call_command('load_cbs_for_municipality', '--municipal_code=GM0363', stdout=buffer)
+
+        output = buffer.getvalue()
+        self.assertIn('Done.', output)
+
+        self.assertEqual(AreaType.objects.count(), 5)
+        self.assertEqual(Area.objects.count(), 7)
+
+        self.assertEqual(Area.objects.filter(_type__code='gm0363-wijk').count(), 1)  # one "wijk" in Amsterdam
+        self.assertEqual(Area.objects.filter(_type__code='gm0363-buurt').count(), 1)  # one "buurt" in Amsterdam
+
+    # unhappy flow
+    def test_municipal_code_does_not_exist(self):
+        self.assertEqual(AreaType.objects.count(), 3)
+        self.assertEqual(Area.objects.count(), 5)
+
+        # Data present, but no valid municipal code is supplied
+        with self.assertRaises(CommandError) as cm:
+            call_command('load_cbs_for_municipality', '--municipal_code=DOES_NOT_EXIST')
+        e = cm.exception
+        self.assertIn(str(e), 'Provided municipal code is not present in CBS data, exiting!')
+
+        # Check that we loaded nothing
+        self.assertEqual(AreaType.objects.count(), 3)
+        self.assertEqual(Area.objects.count(), 5)
+
+    def test_CBS_BUURT_DATASET_area_type_missing(self):
+        self.assertEqual(AreaType.objects.count(), 3)
+        self.assertEqual(Area.objects.count(), 5)
+
+        # AreaType for CBS buurt data is missing
+        AreaType.objects.filter(code=self.area_type_code_b).delete()
+
+        with self.assertRaises(CommandError) as cm:
+            call_command('load_cbs_for_municipality', '--municipal_code=GM0363')
+        e = cm.exception
+        self.assertIn(str(e), 'Required datasets are not available, exiting!')
+
+        # Check that we loaded nothing
+        self.assertEqual(AreaType.objects.count(), 2)  # we did delete one AreaType
+        self.assertEqual(Area.objects.count(), 3)  # cascading delete removed two Areas
+
+    def test_CBS_BUURT_DATASET_areas_missing(self):
+        self.assertEqual(AreaType.objects.count(), 3)
+        self.assertEqual(Area.objects.count(), 5)
+
+        # AreaType for CBS buurt data is missing
+        Area.objects.filter(_type__code=self.area_type_code_b).delete()
+
+        with self.assertRaises(CommandError) as cm:
+            call_command('load_cbs_for_municipality', '--municipal_code=GM0363')
+        e = cm.exception
+        self.assertIn(str(e), 'Required datasets are not available, exiting!')
+
+        # Check that we loaded nothing
+        self.assertEqual(AreaType.objects.count(), 3)
+        self.assertEqual(Area.objects.count(), 3)  # we deleted two Areas


### PR DESCRIPTION
## Description

Signalen is set up to load CBS data for municipal borders and neighborhood borders. This PR adds a management command that can extract the neighborhoods for a given municipality identified by its CBS code. These extracted neighborhoods can than be used by the feature of Signalen which automatically assigns a nuisance complaint to an area.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Documentation has been updated if needed
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts
- [x] There are no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 90% (the higher the better)
- [x] No iSort issues are present in the code
- [x] No Flake8 issues are present in the code
