### PR TITLE
Public signals raised a 500 instead of a 404

### DIFF
--- a/api/app/signals/apps/api/tests/test_public_signal_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_public_signal_endpoint.py
@@ -162,6 +162,11 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         self.assertEqual(200, response.status_code)
         self.assertJsonSchema(self.retrieve_schema, response.json())
 
+    def test_get_by_uuid_does_not_exists(self):
+        response = self.client.get(self.detail_endpoint.format(uuid='00000000-0000-0000-0000-000000000000'),
+                                   format='json')
+        self.assertEqual(404, response.status_code)
+
     def test_get_by_uuid_access_status(self):
         # SIA must not publicly expose what step in the resolution process a certain
         # Signal/melding is

--- a/api/app/signals/apps/api/views/signal.py
+++ b/api/app/signals/apps/api/views/signal.py
@@ -12,6 +12,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.generics import get_object_or_404
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet, ViewSet
@@ -65,8 +66,7 @@ class PublicSignalViewSet(PublicSignalGenericViewSet):
         return Response(data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, uuid):
-        signal = Signal.objects.get(uuid=uuid)
-
+        signal = get_object_or_404(Signal.objects.all(), uuid=uuid)
         data = PublicSignalSerializerDetail(signal, context=self.get_serializer_context()).data
         return Response(data)
 


### PR DESCRIPTION
## Description

The public/signals endpoint raised a 500 instead of a 404 if a signal was not found, this is fixed in this PR

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts
- [X] There are no conflicting Django migrations


## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 89% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
