### PR TITLE
The template filter "format_address" now can work with a Location object or a address dict

### DIFF
--- a/api/app/signals/apps/email_integrations/templates/email/signal_default.html
+++ b/api/app/signals/apps/email_integrations/templates/email/signal_default.html
@@ -28,7 +28,7 @@
         <br/>
         Nummer: <i>{{ formatted_signal_id }}</i>
         Gemeld op: <i>{{ created_at|date:"DATETIME_FORMAT" }}</i><br/>
-        Locatie: <i>{% if location %}{{ location|format_address:"O hlT, P W" }}{% endif %} </i><br/>
+        Locatie: <i>{% if address %}{{ address|format_address:"O hlT, P W" }}{% endif %} </i><br/>
     </p>
 
     <p>

--- a/api/app/signals/apps/email_integrations/templatetags/location.py
+++ b/api/app/signals/apps/email_integrations/templatetags/location.py
@@ -3,6 +3,7 @@
 from django import template
 from django.conf import settings
 
+from signals.apps.signals.models import Location
 from signals.apps.signals.utils.location import AddressFormatter
 
 register = template.Library()
@@ -12,5 +13,14 @@ DEFAULT_ADDRESS_FORMAT = getattr(settings, 'ADDRESS_FORMAT', 'O hl, P W')
 
 
 @register.filter
-def format_address(location, format_str=DEFAULT_ADDRESS_FORMAT):
-    return AddressFormatter(location.address).format(format_str=format_str)
+def format_address(obj, format_str=DEFAULT_ADDRESS_FORMAT):
+    if isinstance(obj, Location) and obj.address:
+        # Deprecated way to format the address when getting a Location object.
+        # Use in template {{ location|format_address:"O hlT, P W" }}
+        #
+        # This should be removed when all templates are using {{ address|format_address:"O hlT, P W" }}
+        return AddressFormatter(obj.address).format(format_str=format_str)
+    else:
+        # Will format the address.
+        # Use in template {{ address|format_address:"O hlT, P W" }}
+        return AddressFormatter(obj).format(format_str=format_str)

--- a/api/app/signals/apps/email_integrations/utils.py
+++ b/api/app/signals/apps/email_integrations/utils.py
@@ -86,7 +86,7 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
         'created_at': signal.created_at,
         'text': text,
         'text_extra': text_extra,
-        'address': signal.location.address,
+        'address': signal.location.address if signal.location and signal.location.address else None,
         'status_text': signal.status.text,
         'status_state': signal.status.state,
         'handling_message': signal.category_assignment.stored_handling_message,


### PR DESCRIPTION
## Description

The template filter "format_address" now can work with a Location object or a address dict

TODO: When the location template variable is removed from the context the "format_address" should only accept the address dict instead of a Location OR an address dict.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Documentation has been updated if needed
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 90% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
- [X] No SPDX issues are present in the code
