### PR TITLE
Upgrade pillow 9.0.0 -> 9.0.1

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -79,7 +79,7 @@ oslo.utils==4.8.0
 packaging==20.9
 pbr==5.5.1
 pilkit==2.0
-Pillow==9.0.0
+Pillow==9.0.1
 pluggy==0.13.1
 prompt-toolkit==3.0.18
 protobuf==3.15.7


### PR DESCRIPTION
## Description

Affected versions of this package are vulnerable to Improper Input Validation. When the path to the temporary directory on Linux or macOS contained a space, this would break removal of the temporary image file after im.show() (and related actions), and potentially remove an unrelated file.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 89% (the higher the better)
- [X] No iSort issues are present in the code
- [X] No Flake8 issues are present in the code
- [X] No SPDX issues are present in the code
