### PR TITLE
Remove deprecated email template variables

### DIFF
--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -66,17 +66,6 @@
             <li>handling_message</li>
             <li>ORGANIZATION_NAME</li>
         </ul>
-
-        <h3>Verouderde variabelen</h3>
-        <p>
-            Mocht uw template nog een van de volgende variabellen gebruiken zet dit dan z.s.m. om.
-            Deze zullen z.s.m. worden verwijderd!
-        </p>
-        <ul>
-            <li>signal</li>
-            <li>status</li>
-            <li>location</li>
-        </ul>
     </div>
 
     {{ block.super }}

--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -66,6 +66,13 @@
             <li>handling_message</li>
             <li>ORGANIZATION_NAME</li>
         </ul>
+        <h3>Variabelen welke in bepaalde templates beschikbaar zijn</h3>
+        <ul>
+            <li>positive_feedback_url (alleen beschikbaar in de "afgehandeld" template)</li>
+            <li>negative_feedback_url (alleen beschikbaar in de "afgehandeld" template)</li>
+            <li>reaction_url (alleen beschikbaar in de "reactie gevraagd" template)</li>
+            <li>reaction_request_answer (alleen beschikbaar in de "reactie ontvangen" template)</li>
+        </ul>
     </div>
 
     {{ block.super }}

--- a/api/app/signals/apps/email_integrations/tests/test_utils.py
+++ b/api/app/signals/apps/email_integrations/tests/test_utils.py
@@ -156,17 +156,6 @@ class TestUtils(TestCase):
         self.assertEqual(context['signal_id'], signal.id)
         self.assertNotEqual(context['signal_id'], 'test')
 
-    def test_make_email_context_backwards_compatibility(self):
-        """
-        TODO: should be removed a.s.a.p.
-        """
-        signal = SignalFactory.create()
-        context = make_email_context(signal=signal)
-
-        self.assertEqual(context['signal'].id, signal.id)
-        self.assertEqual(context['status']._signal_id, signal.id)
-        self.assertEqual(context['status'].state, signal.status.state)
-
     def test_validate_email_template(self):
         email_template_valid = EmailTemplateFactory.create(key=EmailTemplate.SIGNAL_CREATED)
         result = validate_email_template(email_template_valid)

--- a/api/app/signals/apps/email_integrations/utils.py
+++ b/api/app/signals/apps/email_integrations/utils.py
@@ -91,12 +91,6 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
         'status_state': signal.status.state,
         'handling_message': signal.category_assignment.stored_handling_message,
         'ORGANIZATION_NAME': settings.ORGANIZATION_NAME,
-
-        # Backwards compatibility items
-        # TODO: Remove these items when all templates are updated to use the new context variables
-        'signal': signal,
-        'status': signal.status,
-        'location': signal.location,
     }
 
     if additional_context:
@@ -118,7 +112,7 @@ def validate_email_template(email_template: EmailTemplate) -> bool:
 
 def validate_template(template: str) -> bool:
     """
-    Used to validate an template string with a dummy context
+    Used to validate a template string with a dummy context
     """
     context = {
         'signal_id': 123,


### PR DESCRIPTION
## Description

Removed deprecated email template variables from the context (signal, status and location). All tests that relied on these deprecated variables have been fixed. The admin template no longer mention these variables. On the admin page a list of templates specific variables is added for the admin user to see.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
