### PR TITLE
area_type_code filtering that does not accept 'null' - it should

### DIFF
--- a/api/app/signals/apps/api/filters/utils.py
+++ b/api/app/signals/apps/api/filters/utils.py
@@ -25,7 +25,9 @@ def area_type_code_choices():
 
 
 def area_type_choices():
-    return [(c, f'{n} ({c})') for c, n in AreaType.objects.values_list('code', 'name')]
+    return [
+        ('null', 'null'),
+    ] + [(c, f'{n} ({c})') for c, n in AreaType.objects.values_list('code', 'name')]
 
 
 def area_choices():

--- a/api/app/signals/apps/api/tests/test_filters.py
+++ b/api/app/signals/apps/api/tests/test_filters.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
-import unittest
 from datetime import datetime, timedelta
 from random import shuffle
 
@@ -991,7 +990,6 @@ class TestAreaFilter(SignalsBaseApiTestCase):
         result_ids = self._request_filter_signals({'area_type_code': 'district', 'area_code': self.area.code})
         self.assertEqual(1, len(result_ids))
 
-    @unittest.expectedFailure
     def test_filter_area_code_null(self):
         # Demonstrate problem behind Signalen #118
         result_ids = self._request_filter_signals({'area_type_code': 'null'})

--- a/api/app/signals/apps/api/tests/test_filters.py
+++ b/api/app/signals/apps/api/tests/test_filters.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
+import unittest
 from datetime import datetime, timedelta
 from random import shuffle
 
@@ -947,6 +948,7 @@ class TestAreaFilter(SignalsBaseApiTestCase):
     def _request_filter_signals(self, filter_params: dict):
         """ Does a filter request and returns the signal ID's present in the request """
         self.client.force_authenticate(user=self.superuser)
+
         resp = self.client.get(self.LIST_ENDPOINT, data=filter_params)
 
         self.assertEqual(200, resp.status_code)
@@ -987,6 +989,12 @@ class TestAreaFilter(SignalsBaseApiTestCase):
         self.assertEqual(1, len(result_ids))
         # filter on both
         result_ids = self._request_filter_signals({'area_type_code': 'district', 'area_code': self.area.code})
+        self.assertEqual(1, len(result_ids))
+
+    @unittest.expectedFailure
+    def test_filter_area_code_null(self):
+        # Demonstrate problem behind Signalen #118
+        result_ids = self._request_filter_signals({'area_type_code': 'null'})
         self.assertEqual(1, len(result_ids))
 
 


### PR DESCRIPTION
## Description

It was not possible to filter the private Signals list endpoint on `area_type_code=null`, this PR adds that possibility. This is a partial fix for https://github.com/Signalen/frontend/issues/118 As an aside the Signalen frontend must also be changed to not filter on `area_type_code=district` when "Niet bepaald" (not determined) is selected for the Signal area filter.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
