### PR TITLE
chore/disable-extra-properties_lantaarnpaal-check

### DIFF
--- a/api/app/signals/apps/api/serializers/signal.py
+++ b/api/app/signals/apps/api/serializers/signal.py
@@ -453,15 +453,19 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
                     attrs['session'] = session
 
         # SIG-4382 additional check on the extra_properties if the category is lantaarpaal-straatverlichting
-        if attrs.get('category_assignment').get('category').slug == 'lantaarnpaal-straatverlichting':
-            validator = ExtraPropertiesValidator(filename=os.path.join(os.path.dirname(__file__), '..', 'json_schema',
-                                                                       'extra_properties_streetlights.json'))
-            try:
-                validator(attrs.get('extra_properties'))
-            except ValidationError:
-                errors.update({'extra_properties': [
-                    'Extra properties not valid for category "lantaarnpaal-straatverlichting"'
-                ]})
+        #
+        # Disabled additional check. This check prevents the creation of a "child" signal in the
+        # lantaarnpaal-straatverlichting category because there is no way to provide the streetlight
+        #
+        # if attrs.get('category_assignment').get('category').slug == 'lantaarnpaal-straatverlichting':
+        #     validator = ExtraPropertiesValidator(filename=os.path.join(os.path.dirname(__file__), '..', 'json_schema',
+        #                                                                'extra_properties_streetlights.json'))
+        #     try:
+        #         validator(attrs.get('extra_properties'))
+        #     except ValidationError:
+        #         errors.update({'extra_properties': [
+        #             'Extra properties not valid for category "lantaarnpaal-straatverlichting"'
+        #         ]})
 
         if errors:
             raise serializers.ValidationError(errors)
@@ -617,16 +621,20 @@ class PublicSignalCreateSerializer(SignalValidationMixin, serializers.ModelSeria
                     data['session'] = session
 
         # SIG-4382 additional check on the extra_properties if the category is lantaarpaal-straatverlichting
-        if data.get('category_assignment').get('category').slug == 'lantaarnpaal-straatverlichting':
-            validator = ExtraPropertiesValidator(
-                filename=os.path.join(os.path.dirname(__file__), '..', 'json_schema',
-                                      'extra_properties_streetlights.json'))
-            try:
-                validator(data.get('extra_properties'))
-            except ValidationError:
-                errors.update({'extra_properties': [
-                    'Extra properties not valid for category "lantaarnpaal-straatverlichting"'
-                ]})
+        #
+        # Disabled additional check. This check prevents the creation of a "child" signal in the
+        # lantaarnpaal-straatverlichting category because there is no way to provide the streetlight
+        #
+        # if data.get('category_assignment').get('category').slug == 'lantaarnpaal-straatverlichting':
+        #     validator = ExtraPropertiesValidator(
+        #         filename=os.path.join(os.path.dirname(__file__), '..', 'json_schema',
+        #                               'extra_properties_streetlights.json'))
+        #     try:
+        #         validator(data.get('extra_properties'))
+        #     except ValidationError:
+        #         errors.update({'extra_properties': [
+        #             'Extra properties not valid for category "lantaarnpaal-straatverlichting"'
+        #         ]})
 
         if errors:
             raise serializers.ValidationError(errors)

--- a/api/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
+++ b/api/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import copy
 import os
-from unittest import expectedFailure
+from unittest import expectedFailure, skip
 from unittest.mock import patch
 
 from django.conf import settings
@@ -578,10 +578,14 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
         self.assertEqual(response.json()['session'][0], 'Session already used')
         self.assertEqual(signal_count, Signal.objects.count())
 
+    @skip('Disbaled the check on the extra propeties, this causes an issue when creating "child" signals')
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation
     def test_create_and_validate_extra_properties_for_streetlights(self, validate_address):
         """
+        Disabled the additional check. This check prevents the creation of a "child" signal in the
+        lantaarnpaal-straatverlichting category because there is no way to provide the streetlight
+
         SIG-4382 [BE] Extra check op formaat en inhoud van extra_properties bij de verlichting sub categorien
         (tbv koppeling Techview)
 

--- a/api/app/signals/apps/api/tests/test_public_signal_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_public_signal_endpoint.py
@@ -3,6 +3,7 @@
 import copy
 import json
 import os
+from unittest import skip
 from unittest.mock import patch
 
 from django.conf import settings
@@ -478,10 +479,14 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         session.refresh_from_db()
         self.assertEqual(session._signal_id, another_signal.id)
 
+    @skip('Disbaled the check on the extra propeties, this causes an issue when creating "child" signals')
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation
     def test_create_and_validate_extra_properties_for_streetlights(self, validate_address):
         """
+        Disabled the additional check. This check prevents the creation of a "child" signal in the
+        lantaarnpaal-straatverlichting category because there is no way to provide the streetlight
+
         SIG-4382 [BE] Extra check op formaat en inhoud van extra_properties bij de verlichting sub categorien
         (tbv koppeling Techview)
 


### PR DESCRIPTION
## Description

Disabled the additional check on the extra_properties for lantaarnpaal-straatverlichting. This check prevents the creation of a "child" signal in the lantaarnpaal-straatverlichting category because there is no way to provide the streetlight in these cases.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
