### PR TITLE
Expose created_by in attachment serializer, copy created_by correctly…

### DIFF
--- a/api/app/signals/apps/api/serializers/__init__.py
+++ b/api/app/signals/apps/api/serializers/__init__.py
@@ -2,8 +2,7 @@
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
 from signals.apps.api.serializers.attachment import (
     PrivateSignalAttachmentSerializer,
-    PublicSignalAttachmentSerializer,
-    SignalAttachmentSerializer
+    PublicSignalAttachmentSerializer
 )
 from signals.apps.api.serializers.category import (
     CategoryHALSerializer,
@@ -52,7 +51,6 @@ __all__ = [
     'PublicSignalAttachmentSerializer',
     'PublicSignalCreateSerializer',
     'PublicSignalSerializerDetail',
-    'SignalAttachmentSerializer',
     'SignalContextGeoSerializer',
     'SignalContextReporterSerializer',
     'SignalContextSerializer',

--- a/api/app/signals/apps/api/serializers/signal.py
+++ b/api/app/signals/apps/api/serializers/signal.py
@@ -513,7 +513,7 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
         )
 
         if attachments:
-            Signal.actions.copy_attachments(data=attachments, signal=signal)
+            Signal.actions.copy_attachments(data=attachments, signal=signal, created_by=logged_in_user.email)
 
         signal.refresh_from_db()
         return signal

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -4400,16 +4400,22 @@ components:
                   type: string
                   description: URI to the attachment detail
         location:
-          description: The location of the attachment, for downloading
+          description: The location of the attachment, for downloading.
           type: string
           example: /signals/media/images/2020/01/01/happy-new-year.jpg
         is_image:
+          description: Boolean that indicates whether this attachment is image. Value is `true` if image else `false`.
           type: boolean
           example: true
         created_at:
+          description: Timestamp of attachment's creation (upload).
           type: string
           format: date-time
           example: "2020-01-01T00:00:00+00:00"
+        created_by:
+          description: Username of the attachment's uploader.
+          type: string
+          example: someuser@example.com
 
     privateContextResponse:
       description: JSON data describing the context overview of a Signal

--- a/api/app/signals/apps/services/domain/auto_create_children/actions.py
+++ b/api/app/signals/apps/services/domain/auto_create_children/actions.py
@@ -86,7 +86,7 @@ class CreateChildrenContainerAction(ExtraPropertiesMixin):
             # Copy attachments to the child signal
             attachments_qs = signal.attachments.filter(is_image=True)
             if attachments_qs.count():
-                Signal.actions.copy_attachments(data=attachments_qs.all(), signal=child_signal)
+                Signal.actions.copy_attachments(data=attachments_qs.all(), signal=child_signal, created_by=None)
 
     def __str__(self):
         return f'{self.__class__.__name__}'
@@ -136,7 +136,8 @@ class CreateChildrenEikenprocessierupsAction(ExtraPropertiesMixin):
             # Copy attachments to the child signal
             attachments_qs = signal.attachments.filter(is_image=True)
             if attachments_qs.count():
-                Signal.actions.copy_attachments(data=attachments_qs.all(), signal=child_signal)
+                # created_by=None, because this runs in a Celery task and no request.user is known here
+                Signal.actions.copy_attachments(data=attachments_qs.all(), signal=child_signal, created_by=None)
 
     def __str__(self):
         return f'{self.__class__.__name__}'


### PR DESCRIPTION
## Description

* `created_by` was not exposed for attachments, it is needed for the new backoffice UI with regards to attachments. This PR exposes it.
* When a child signal is created, we make sure to match the `created_by` for that attachments with the user that is in the logs for that child signal (which may or may not match the logged user for the parent signal).

**Note:**
_How we deal with the `created_by` field for child signals is still subject to some discussion with our users. Proposed implementation matches the logged user for location, status, etc. to logged user for attachments (in effect erasing who was the uploader of the attachments in the parent signal)._

**This behavior was discussed with our users, and is OK for now.**


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
