### PR TITLE
Security upgrade oslo.utils from 4.8.0 to 4.8.1

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -75,7 +75,7 @@ os-service-types==1.7.0
 oslo.config==8.5.0
 oslo.i18n==5.0.1
 oslo.serialization==4.1.0
-oslo.utils==4.8.0
+oslo.utils==4.8.1
 packaging==20.9
 pbr==5.5.1
 pilkit==2.0


### PR DESCRIPTION
## Description

Security upgrade oslo.utils from 4.8.0 to 4.8.1

More information: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0718

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
