### PR TITLE
Feature/attachments public upload state checks

### DIFF
--- a/api/app/signals/apps/api/serializers/attachment.py
+++ b/api/app/signals/apps/api/serializers/attachment.py
@@ -12,6 +12,9 @@ from signals.apps.api.fields import (
 )
 from signals.apps.services.domain.filescanner import FileRejectedError, UploadScannerService
 from signals.apps.signals.models import Attachment, Signal
+from signals.apps.signals.workflow import GEMELD, REACTIE_GEVRAAGD
+
+PUBLIC_UPLOAD_ALLOWED_STATES = (GEMELD, REACTIE_GEVRAAGD)
 
 
 class SignalAttachmentSerializerMixin:
@@ -62,6 +65,14 @@ class PublicSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSeria
         )
 
         extra_kwargs = {'file': {'write_only': True}}
+
+    def create(self, validated_data):
+        signal = self.context['view'].get_signal()
+        if signal.status.state not in PUBLIC_UPLOAD_ALLOWED_STATES:
+            msg = 'Public uploads not allowed in current signal state.'
+            raise ValidationError(msg)
+
+        return super().create(validated_data)
 
 
 class PrivateSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSerializer):


### PR DESCRIPTION
## Description

Allow uploads of attachments through public endpoint only in states GEMELD and REACTIE_GEVRAAGD. This is based on PR 
#937 and should be merged after that PR is merged.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
