### PR TITLE
Build and push Docker images when a release is published

### DIFF
--- a/.github/workflows/build_and_push_docker_image.yml
+++ b/.github/workflows/build_and_push_docker_image.yml
@@ -1,0 +1,27 @@
+name: Build a Docker image and push to Docker when a new release is published
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build_and_push:
+    name: Build an Docker image for the release and push it to Docker
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to Docker
+        run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
+      - name: Release tag
+        run: echo "${{ github.event.release.tag_name }}"
+
+      - name: Build the Docker image release
+        run: |
+          cd api/
+          docker build -t signalen/backend:${{ github.event.release.tag_name }} .
+
+      - name: Push the tagged image to Docker
+        run: docker push signalen/backend:${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Description

Added a github action to create a Docker image and push it to the docker registry when a new release is published (will trigger on released and prereleased)

Todo:
- [X] ~~Add the docker credentials to the github secrets~~

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`