### PR TITLE
feature/SIG-4430

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/abstract.py
+++ b/api/app/signals/apps/email_integrations/actions/abstract.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.template import Context, Template, loader
 
+from signals.apps.email_integrations.exceptions import URLEncodedCharsFoundInText
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.utils import make_email_context
 from signals.apps.signals.models import Signal
@@ -91,7 +92,18 @@ class AbstractAction(ABC):
         """
         Send the email to the reporter
         """
-        context = self.get_context(signal, dry_run)
+        try:
+            context = self.get_context(signal, dry_run)
+        except URLEncodedCharsFoundInText:
+            # Log a warning and add a note  to the Signal that the email could not be sent
+            logger.warning(f'URL encoded text found in Signal {signal.id}')
+            Signal.actions.create_note(
+                {'text':
+                 'E-mail kon niet verzonden worden door aanwezigheid van verdachte tekens in de meldtekst'},
+                signal=signal
+            )
+            return 0  # No mail sent, return 0. Same behaviour as send_mail()
+
         subject, message, html_message = self.render_mail_data(context)
         return send_mail(subject=subject, message=message, from_email=self.from_email,
                          recipient_list=[signal.reporter.email, ], html_message=html_message)

--- a/api/app/signals/apps/email_integrations/actions/abstract.py
+++ b/api/app/signals/apps/email_integrations/actions/abstract.py
@@ -99,7 +99,7 @@ class AbstractAction(ABC):
             logger.warning(f'URL encoded text found in Signal {signal.id}')
             Signal.actions.create_note(
                 {'text':
-                 'E-mail kon niet verzonden worden door aanwezigheid van verdachte tekens in de meldtekst'},
+                 'E-mail is niet verzonden omdat er verdachte tekens in de meldtekst staan.'},
                 signal=signal
             )
             return 0  # No mail sent, return 0. Same behaviour as send_mail()

--- a/api/app/signals/apps/email_integrations/exceptions.py
+++ b/api/app/signals/apps/email_integrations/exceptions.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+
+class URLEncodedCharsFoundInText(Exception):
+    """
+    Exception to be raised when a URL encoded character is found in a text
+    """
+    pass

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 - 2022 Gemeente Amsterdam
 from datetime import timedelta
 from unittest import mock
+from urllib.parse import quote
 
 from django.conf import settings
 from django.core import mail
@@ -160,6 +161,36 @@ class ActionTestMixin:
                                       status__send_email=True, reporter__email='test@example.com')
         self.assertFalse(self.action(signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 0)
+
+    def test_send_mail_fails_encoded_chars_in_text(self):
+        """
+        The action should not send an email if the text contains encoded characters. A note should be added so that
+        it is clear why the email was not sent. This is also logged in Sentry.
+        """
+        self.assertEqual(len(mail.outbox), 0)
+
+        unquoted_url = 'https://user:password@test-domain.com/?query=param&extra=param'
+        quoted_url = unquoted_url
+        # Let's encode the URL 10 times
+        for _ in range(10):
+            quoted_url = quote(quoted_url)
+
+        signal_text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut ' \
+                      f'labore et dolore magna aliqua. {quoted_url} Ut enim ad minim veniam, quis nostrud ' \
+                      'exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+
+        status_text = FuzzyText(length=200)
+
+        signal = SignalFactory.create(text=signal_text, text_extra=signal_text, status__state=self.state,
+                                      status__text=status_text, status__send_email=True,
+                                      reporter__email='test@example.com')
+        self.assertFalse(self.action(signal, dry_run=False))
+        self.assertEqual(len(mail.outbox), 0)
+
+        signal.refresh_from_db()
+        self.assertEqual(signal.notes.count(), 1)
+        self.assertEquals(signal.notes.first().text,
+                          'E-mail kon niet verzonden worden door aanwezigheid van verdachte tekens in de meldtekst')
 
 
 class TestSignalCreatedAction(ActionTestMixin, TestCase):

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -190,7 +190,7 @@ class ActionTestMixin:
         signal.refresh_from_db()
         self.assertEqual(signal.notes.count(), 1)
         self.assertEquals(signal.notes.first().text,
-                          'E-mail kon niet verzonden worden door aanwezigheid van verdachte tekens in de meldtekst')
+                          'E-mail is niet verzonden omdat er verdachte tekens in de meldtekst staan.')
 
 
 class TestSignalCreatedAction(ActionTestMixin, TestCase):


### PR DESCRIPTION
## Description

Added the util function '_cleanup_signal_text' that will cleanup URLs from a signal text. It will decode URL encoded characters for X time (for now 5 has been decided) and tries to remove any URLs from the text. If there are any encoded characters left it raises the exception 'URLEncodedCharsFoundInText'. The action should not send any emails if this exception is raised. Instead it should log to Sentry and add a note to the Signal explaining why the email was not sent.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
