### PR TITLE
Django admin changes: add comma seperated category line to questions,…

### DIFF
--- a/api/app/signals/apps/signals/admin.py
+++ b/api/app/signals/apps/signals/admin.py
@@ -34,11 +34,15 @@ class CategoryQuestionInline(admin.StackedInline):
 class QuestionAdmin(admin.ModelAdmin):
     inlines = (CategoryQuestionInline, )
     fields = ('key', 'field_type', 'meta', 'required')
-    list_display = ('key', 'field_type', 'meta', 'required')
+    list_display = ('key', 'field_type', 'meta', 'required', 'categories')
     ordering = ('-key',)
     list_per_page = 20
     list_select_related = True
     list_filter = ['category__slug']
+
+    def categories(self, obj):
+        categories = obj.category_set.values_list('name', flat=True)
+        return ', '.join(categories)
 
 
 admin.site.register(Question, QuestionAdmin)
@@ -224,6 +228,7 @@ admin.site.register(RoutingExpression, RoutingExpressionAdmin)
 
 class ExpressionAdmin(admin.ModelAdmin):
     list_filter = ['_type__name']
+    list_display = ['name', 'code', '_type']
 
 
 admin.site.register(Expression, ExpressionAdmin)


### PR DESCRIPTION
… add code column for routingexpressions

## Description

Implements https://github.com/Signalen/product-steering/issues/78
- add code to expression tab
- add categories to questions
- Changes for users *not* implemented, this is not needed

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
