### PR TITLE
bug/SIG-4458

### DIFF
--- a/api/app/signals/apps/api/serializers/email_preview.py
+++ b/api/app/signals/apps/api/serializers/email_preview.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2022 Gemeente Amsterdam
 from rest_framework import serializers
 
+from signals.apps.signals.workflow import STATUS_CHOICES
+
 
 class EmailPreviewSerializer(serializers.Serializer):
     subject = serializers.SerializerMethodField()
@@ -20,3 +22,8 @@ class EmailPreviewSerializer(serializers.Serializer):
     def get_html(self, *args, **kwargs):
         email_preview = self.context.get('email_preview')
         return email_preview['html_message'] if 'html_message' in email_preview else ''
+
+
+class EmailPreviewPostSerializer(serializers.Serializer):
+    status = serializers.ChoiceField(choices=STATUS_CHOICES, required=True)
+    text = serializers.CharField(max_length=3000, required=False)

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -861,21 +861,20 @@ paths:
         required: true
         schema:
           type: integer
-      - name: status
-        in: query
-        description: The status a email preview is requested for
-        schema:
-          $ref: '#/components/schemas/StatusStateChoices'
-        example: ingepland
-        required: true
-      - name: text
-        in: query
-        description: The status text that must appear in the email preview
-        required: false
-        schema:
-          type: string
-    get:
+    post:
       description: A email preview for the given status
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  description: The status a email preview is requested for
+                  example: ingepland
+                text:
+                  description: The status text that must appear in the email preview
+                  type: string
       responses:
         '200':
           description: Email preview (subject and html body)
@@ -894,7 +893,7 @@ paths:
                     description: The rendered body (HTML) of the email
                     example: <!DOCTYPE html><html lang="nl"><head><meta charset="UTF-8"><title>Uw melding SIA-123456789</title></head><body><p>Geachte melder,</p><p>Lorem ipsum...</p><p>Met vriendelijke groet,</p><p>Gemeente Amsterdam</p></body></html>
         '400':
-          description: Missing a required query parameter
+          description: Bad request
         '401':
           description: Not authenticated, may be caused by expired token.
         '403':

--- a/api/app/signals/apps/api/tests/test_private_signal_email_preview_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_private_signal_email_preview_endpoint.py
@@ -37,10 +37,9 @@ class TestPrivateSignalEmailPreview(SIAReadUserMixin, SIAReadWriteUserMixin, Sig
         status_count = self.signal.statuses.count()
 
         text = f'Lorem ipsum {workflow.REACTIE_GEVRAAGD} ...'
-        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/' \
-                   f'?status={workflow.REACTIE_GEVRAAGD}&text={text}'
+        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
 
-        response = self.client.get(endpoint)
+        response = self.client.post(endpoint, data={'status': workflow.REACTIE_GEVRAAGD, 'text': text}, format='json')
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
@@ -74,10 +73,9 @@ class TestPrivateSignalEmailPreview(SIAReadUserMixin, SIAReadWriteUserMixin, Sig
         status_count = self.signal.statuses.count()
 
         text = f'Lorem ipsum {workflow.AFGEHANDELD} ...'
-        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/' \
-                   f'?status={workflow.AFGEHANDELD}&text={text}'
+        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
 
-        response = self.client.get(endpoint)
+        response = self.client.post(endpoint, data={'status': workflow.AFGEHANDELD, 'text': text}, format='json')
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
@@ -110,10 +108,9 @@ class TestPrivateSignalEmailPreview(SIAReadUserMixin, SIAReadWriteUserMixin, Sig
 
         for new_status in [workflow.GEMELD, workflow.AFWACHTING, workflow.BEHANDELING, workflow.GEANNULEERD, ]:
             text = f'Lorem ipsum {new_status} ...'
-            endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/' \
-                       f'?status={new_status}&text={text}'
+            endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
 
-            response = self.client.get(endpoint)
+            response = self.client.post(endpoint, data={'status': new_status, 'text': text}, format='json')
             self.assertEqual(response.status_code, 200)
 
             response_data = response.json()
@@ -142,10 +139,10 @@ class TestPrivateSignalEmailPreview(SIAReadUserMixin, SIAReadWriteUserMixin, Sig
         status_count = self.signal.statuses.count()
 
         text = f'Lorem ipsum {workflow.VERZOEK_TOT_AFHANDELING} ...'
-        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/' \
-                   f'?status={workflow.VERZOEK_TOT_AFHANDELING}&text={text}'
+        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
 
-        response = self.client.get(endpoint)
+        response = self.client.post(endpoint, data={'status': workflow.VERZOEK_TOT_AFHANDELING, 'text': text},
+                                    format='json')
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
@@ -167,23 +164,22 @@ class TestPrivateSignalEmailPreview(SIAReadUserMixin, SIAReadWriteUserMixin, Sig
     def test_no_email_preview_available(self):
         # From GEMELD to REACTIE_ONTVANGEN is not allowed therefore we expect a 404 not found
         text = f'Lorem ipsum {workflow.REACTIE_ONTVANGEN} ...'
-        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/' \
-                   f'?status={workflow.REACTIE_ONTVANGEN}&text={text}'
+        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
 
-        response = self.client.get(endpoint)
+        response = self.client.post(endpoint, data={'status': workflow.REACTIE_ONTVANGEN, 'text': text}, format='json')
         self.assertEqual(response.status_code, 404)
 
     def test_missing_required_query_parameter(self):
         # The status query parameter is required
         endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
-        response = self.client.get(endpoint)
+        response = self.client.post(endpoint, format='json')
         self.assertEqual(response.status_code, 400)
 
     def test_not_authenticated(self):
         self.client.logout()
 
         endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
-        response = self.client.get(endpoint)
+        response = self.client.post(endpoint)
         self.assertEqual(response.status_code, 401)
 
         self.client.force_authenticate(user=self.sia_read_write_user)
@@ -194,7 +190,7 @@ class TestPrivateSignalEmailPreview(SIAReadUserMixin, SIAReadWriteUserMixin, Sig
         self.client.force_authenticate(user=self.sia_read_user)
 
         endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
-        response = self.client.get(endpoint)
+        response = self.client.post(endpoint)
         self.assertEqual(response.status_code, 403)
 
         self.client.logout()


### PR DESCRIPTION
## Description

Email preview is now a POST instead of a GET request.

When providing a long text the length of the URL was causing issues. Therefore it was decided to transform this endpoint from a GET with query parameters to a POST with request body.

The response of the endpoint remains the same. A 200 OK with response body.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
