### PR TITLE
Add sub/main category name to email context

### DIFF
--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -65,8 +65,6 @@
             <li>status_state</li>
             <li>handling_message</li>
             <li>ORGANIZATION_NAME</li>
-            <li>main_category_name</li>
-            <li>sub_category_name</li>
             <li>main_category_public_name</li>
             <li>sub_category_public_name</li>
         </ul>

--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -67,6 +67,8 @@
             <li>ORGANIZATION_NAME</li>
             <li>main_category_name</li>
             <li>sub_category_name</li>
+            <li>main_category_public_name</li>
+            <li>sub_category_public_name</li>
         </ul>
         <h3>Variabelen welke in bepaalde templates beschikbaar zijn</h3>
         <ul>

--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -65,6 +65,8 @@
             <li>status_state</li>
             <li>handling_message</li>
             <li>ORGANIZATION_NAME</li>
+            <li>main_category_name</li>
+            <li>sub_category_name</li>
         </ul>
         <h3>Variabelen welke in bepaalde templates beschikbaar zijn</h3>
         <ul>

--- a/api/app/signals/apps/email_integrations/tests/test_utils.py
+++ b/api/app/signals/apps/email_integrations/tests/test_utils.py
@@ -133,6 +133,8 @@ class TestUtils(TestCase):
         self.assertEqual(context['status_state'], signal.status.state)
         self.assertEqual(context['handling_message'], signal.category_assignment.stored_handling_message)
         self.assertEqual(context['ORGANIZATION_NAME'], settings.ORGANIZATION_NAME)
+        self.assertEqual(context['main_category_name'], signal.category_assignment.category.parent.name)
+        self.assertEqual(context['sub_category_name'], signal.category_assignment.category.name)
 
     def test_make_email_context_additional_context(self):
         signal = SignalFactory.create()

--- a/api/app/signals/apps/email_integrations/tests/test_utils.py
+++ b/api/app/signals/apps/email_integrations/tests/test_utils.py
@@ -135,6 +135,8 @@ class TestUtils(TestCase):
         self.assertEqual(context['ORGANIZATION_NAME'], settings.ORGANIZATION_NAME)
         self.assertEqual(context['main_category_name'], signal.category_assignment.category.parent.name)
         self.assertEqual(context['sub_category_name'], signal.category_assignment.category.name)
+        self.assertEqual(context['main_category_public_name'], signal.category_assignment.category.parent.public_name)
+        self.assertEqual(context['sub_category_public_name'], signal.category_assignment.category.public_name)
 
     def test_make_email_context_additional_context(self):
         signal = SignalFactory.create()

--- a/api/app/signals/apps/email_integrations/utils.py
+++ b/api/app/signals/apps/email_integrations/utils.py
@@ -116,6 +116,10 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
     text_extra = _cleanup_signal_text(signal.text_extra, dry_run=dry_run)
 
     category = signal.category_assignment.category
+    parent_public_name = ''
+    if category.parent:
+        parent_public_name = category.parent.public_name if category.parent.public_name else category.parent.name
+
     context = {
         'signal_id': signal.id,
         'formatted_signal_id': signal.sia_id,
@@ -129,8 +133,8 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
         'ORGANIZATION_NAME': settings.ORGANIZATION_NAME,
         'main_category_name': category.parent.name if category.parent else '',
         'sub_category_name': category.name,
-        'main_category_public_name': category.parent.public_name if category.parent else '',
-        'sub_category_public_name': category.public_name,
+        'main_category_public_name': parent_public_name,
+        'sub_category_public_name': category.public_name if category.public_name else category.name,
     }
 
     if additional_context:
@@ -165,8 +169,6 @@ def validate_template(template: str) -> bool:
         'status_state': 'm',
         'handling_message': 'Hartelijk dank voor uw melding. Wij gaan hier spoedig mee aan de slag',
         'ORGANIZATION_NAME': settings.ORGANIZATION_NAME,
-        'main_category_name': 'Hoofdcategorie naam',
-        'sub_category_name': 'Subcategorie naam',
         'main_category_public_name': 'Hoofdcategorie publieke naam',
         'sub_category_public_name': 'Subcategorie publieke naam',
     }

--- a/api/app/signals/apps/email_integrations/utils.py
+++ b/api/app/signals/apps/email_integrations/utils.py
@@ -129,6 +129,8 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
         'ORGANIZATION_NAME': settings.ORGANIZATION_NAME,
         'main_category_name': category.parent.name if category.parent else '',
         'sub_category_name': category.name,
+        'main_category_public_name': category.parent.public_name if category.parent else '',
+        'sub_category_public_name': category.public_name,
     }
 
     if additional_context:
@@ -162,7 +164,11 @@ def validate_template(template: str) -> bool:
         'status_text': 'Gemeld',
         'status_state': 'm',
         'handling_message': 'Hartelijk dank voor uw melding. Wij gaan hier spoedig mee aan de slag',
-        'ORGANIZATION_NAME': settings.ORGANIZATION_NAME
+        'ORGANIZATION_NAME': settings.ORGANIZATION_NAME,
+        'main_category_name': 'Hoofdcategorie naam',
+        'sub_category_name': 'Subcategorie naam',
+        'main_category_public_name': 'Hoofdcategorie publieke naam',
+        'sub_category_public_name': 'Subcategorie publieke naam',
     }
 
     try:

--- a/api/app/signals/apps/email_integrations/utils.py
+++ b/api/app/signals/apps/email_integrations/utils.py
@@ -115,6 +115,7 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
     text = _cleanup_signal_text(signal.text, dry_run=dry_run)
     text_extra = _cleanup_signal_text(signal.text_extra, dry_run=dry_run)
 
+    category = signal.category_assignment.category
     context = {
         'signal_id': signal.id,
         'formatted_signal_id': signal.sia_id,
@@ -126,6 +127,8 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
         'status_state': signal.status.state,
         'handling_message': signal.category_assignment.stored_handling_message,
         'ORGANIZATION_NAME': settings.ORGANIZATION_NAME,
+        'main_category_name': category.parent.name if category.parent else '',
+        'sub_category_name': category.name,
     }
 
     if additional_context:

--- a/api/app/signals/apps/email_integrations/utils.py
+++ b/api/app/signals/apps/email_integrations/utils.py
@@ -116,9 +116,15 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
     text_extra = _cleanup_signal_text(signal.text_extra, dry_run=dry_run)
 
     category = signal.category_assignment.category
-    parent_public_name = ''
-    if category.parent:
-        parent_public_name = category.parent.public_name if category.parent.public_name else category.parent.name
+    if category.parent and category.parent.public_name:
+        # Category has a parent with a public name
+        parent_public_name = category.parent.public_name
+    elif category.parent and not category.parent.public_name:
+        #  Category has a parent without a public name
+        parent_public_name = category.parent.name
+    else:
+        # Fallback to a blank parent category name, this should not happen
+        parent_public_name = ''
 
     context = {
         'signal_id': signal.id,
@@ -131,8 +137,6 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
         'status_state': signal.status.state,
         'handling_message': signal.category_assignment.stored_handling_message,
         'ORGANIZATION_NAME': settings.ORGANIZATION_NAME,
-        'main_category_name': category.parent.name if category.parent else '',
-        'sub_category_name': category.name,
         'main_category_public_name': parent_public_name,
         'sub_category_public_name': category.public_name if category.public_name else category.name,
     }


### PR DESCRIPTION
## Description

Email templates for some VNG administrated Signalen installations need acces to category names. This PR add them.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
