### PR TITLE
Feature/attachments allow delete

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -757,10 +757,10 @@ paths:
         schema:
           type: integer
     get:
-      description: A list of attachments that belong to the Signal
+      description: Details for an attachment to a Signal.
       responses:
         '200':
-          description: A list of attachments
+          description: Details for an attachment to a Signal.
           content:
             application/json:
               schema:
@@ -770,7 +770,18 @@ paths:
         '403':
           description: Forbidden, user not authorized to request signal attachments.
         '404':
-          description: Signal not found.
+          description: Signal or attachment not found.
+    delete:
+      description: Delete attachment
+      responses:
+        '204':
+          description: Successfully deleted the attachment.
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden, user not authorized to delete this attachment.
+        '404':
+          description: Signal or attachment not found.
 
   /signals/v1/private/signals/{id}/context/:
     parameters:

--- a/api/app/signals/apps/api/tests/test_attachment_permissions.py
+++ b/api/app/signals/apps/api/tests/test_attachment_permissions.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2021 Gemeente Amsterdam
+from django.contrib.auth.models import Permission
+
 from signals.apps.signals.factories import (
     CategoryFactory,
     DepartmentFactory,
@@ -13,6 +15,8 @@ from signals.test.utils import SIAReadWriteUserMixin, SignalsBaseApiTestCase
 class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
     # Accessing Attachments must follow the same access rules as the signals.
     # Specifically: rules around categories and departments must be followed.
+    # This test also checks that the special permissions around deletion of
+    # attachments are followed.
     detail_endpoint = '/signals/v1/private/signals/{}'
     attachments_endpoint = '/signals/v1/private/signals/{}/attachments/'
     attachments_endpoint_detail = '/signals/v1/private/signals/{}/attachments/{}'
@@ -21,7 +25,13 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.department = DepartmentFactory.create()
         self.category = CategoryFactory.create(departments=[self.department])
         self.signal = SignalFactory.create(category_assignment__category=self.category)
-        self.attachment = ImageAttachmentFactory.create(_signal=self.signal)
+        self.attachment = ImageAttachmentFactory.create(_signal=self.signal, created_by='ambtenaar@example.com')
+
+        # Various Attachment delete permissions
+        self.permission_delete_other = Permission.objects.get(codename='delete_attachment_of_other_user')
+        self.permission_delete_normal = Permission.objects.get(codename='delete_attachment_of_normal_signal')
+        self.permission_delete_parent = Permission.objects.get(codename='delete_attachment_of_parent_signal')
+        self.permission_delete_child = Permission.objects.get(codename='delete_attachment_of_child_signal')
 
     def test_cannot_access_without_proper_department_detail(self):
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
@@ -55,3 +65,229 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         url = self.attachments_endpoint_detail.format(self.signal.pk, self.attachment.pk)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+    # Rules for deletion of attachments
+    # 1: you need correct department to delete attachments as above
+    # 2: you need correct permission to delete attachments. One or more of:
+    #    - permission to delete a normal signal's attachments
+    #    - permission to delete a parent signal's attachments
+    #    - permission to delete a child signal's attachments
+    # 3: you need extra permissions to delete attachments not uploaded
+    #    by yourself
+
+    def test_delete_own_attachments_with_proper_department_i(self):
+        """
+        Test that user without "delete_attachment_of_other_user" permission
+        cannot delete somebody else's attachments.
+        """
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+        self.client.force_authenticate(user=self.sia_read_write_user)
+        self.sia_read_write_user.profile.departments.add(self.department)
+
+        # hand out all of normal, parent, child signal's attachment delete permissions
+        self.sia_read_write_user.user_permissions.set([
+            self.permission_delete_normal,
+            self.permission_delete_parent,
+            self.permission_delete_child,
+        ])
+        self.sia_read_write_user.save()
+
+        # should not be able to delete other's attachment
+        url = self.attachments_endpoint.format(self.signal.pk)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+
+    def test_delete_own_attachments_with_proper_department_ii(self):
+        """
+        Test that user without "delete_attachment_of_other_user" permission
+        can delete their own attachments.
+        """
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+        self.client.force_authenticate(user=self.sia_read_write_user)
+        self.sia_read_write_user.profile.departments.add(self.department)
+
+        # hand out all of normal, parent, child signal's attachment delete permissions
+        self.sia_read_write_user.user_permissions.set([
+            self.permission_delete_normal,
+            self.permission_delete_parent,
+            self.permission_delete_child,
+        ])
+        self.sia_read_write_user.save()
+
+        # let's pretend our test user uploaded the attachment
+        self.attachment.created_by = self.sia_read_write_user.email
+        self.attachment.save()
+
+        url = self.attachments_endpoint.format(self.signal.pk)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
+
+    def test_delete_others_attachments_with_proper_department_i(self):
+        """
+        Test that user with "delete_attachment_of_other_user" permission
+        can delete somebody else's attachments.
+        """
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+        self.client.force_authenticate(user=self.sia_read_write_user)
+        self.sia_read_write_user.profile.departments.add(self.department)
+
+        # hand out all of normal, parent, child signal's attachment delete permissions
+        # and permission to delete other's attachments
+        self.sia_read_write_user.user_permissions.set([
+            self.permission_delete_other,
+            self.permission_delete_normal,
+            self.permission_delete_parent,
+            self.permission_delete_child,
+        ])
+        self.sia_read_write_user.save()
+
+        # should be able to delete other's attachment
+        url = self.attachments_endpoint.format(self.signal.pk)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
+
+    def test_delete_others_attachments_with_proper_department_ii(self):
+        """
+        Test that user with "delete_attachment_of_other_user" permission
+        can delete a reporter's attachments.
+        """
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+        self.client.force_authenticate(user=self.sia_read_write_user)
+        self.sia_read_write_user.profile.departments.add(self.department)
+
+        # hand out all of normal, parent, child signal's attachment delete permissions
+        # and permission to delete other's attachments
+        self.sia_read_write_user.user_permissions.set([
+            self.permission_delete_other,
+            self.permission_delete_normal,
+            self.permission_delete_parent,
+            self.permission_delete_child,
+        ])
+        self.sia_read_write_user.save()
+
+        # let's pretend a reporter (i.e. never logged-in) uploaded the attachment
+        self.attachment.created_by = None
+        self.attachment.save()
+
+        # should be able to delete a reporter's attachment
+        url = self.attachments_endpoint.format(self.signal.pk)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
+
+    def test_delete_others_attachments_with_proper_department_iii(self):
+        """
+        Test that user with "delete_attachment_of_other_user" permission
+        can delete a their own attachments.
+        """
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+        self.client.force_authenticate(user=self.sia_read_write_user)
+        self.sia_read_write_user.profile.departments.add(self.department)
+
+        # hand out all of normal, parent, child signal's attachment delete permissions
+        # and permission to delete other's attachments
+        self.sia_read_write_user.user_permissions.set([
+            self.permission_delete_other,
+            self.permission_delete_normal,
+            self.permission_delete_parent,
+            self.permission_delete_child,
+        ])
+        self.sia_read_write_user.save()
+
+        # let's pretend our test user uploaded the attachment
+        self.attachment.created_by = self.sia_read_write_user.email
+        self.attachment.save()
+
+        # should be able to delete a reporter's attachment
+        url = self.attachments_endpoint.format(self.signal.pk)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
+
+    def test_delete_normal_signals_attachments(self):
+        """
+        Check that "delete_attachment_of_normal_signal" is needed to delete a
+        normal signal's attachments.
+        """
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+        self.client.force_authenticate(user=self.sia_read_write_user)
+        self.sia_read_write_user.profile.departments.add(self.department)
+
+        # let's pretend our test user uploaded the attachment (no "delete_attachment_of_other_user" needed)
+        self.attachment.created_by = self.sia_read_write_user.email
+        self.attachment.save()
+
+        # Try to delete without "delete_attachment_of_normal_signal"
+        url = self.attachments_endpoint.format(self.signal.pk)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+
+        # Try to delete with "delete_attachment_of_normal_signal"
+        self.sia_read_write_user.user_permissions.set([self.permission_delete_normal])
+        self.sia_read_write_user.save()
+
+        url = self.attachments_endpoint.format(self.signal.pk)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
+
+    def test_delete_parent_signal_attachments(self):
+        """
+        Check that "delete_attachment_of_parent_signal" is needed to delete a
+        parent signal's attachments.
+        """
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+        self.client.force_authenticate(user=self.sia_read_write_user)
+        self.sia_read_write_user.profile.departments.add(self.department)
+
+        # Create a child signal and create an attachment, let's pretend our test
+        # user uploaded the attachment (no "delete_attachment_of_parent_signal" needed)
+        child_signal = SignalFactory.create(parent=self.signal)
+        ImageAttachmentFactory.create(_signal=child_signal, created_by=self.sia_read_write_user.email)
+
+        # Try to delete without "delete_attachment_of_parent_signal"
+        parent_signal = self.signal
+        parent_attachment_url = self.attachments_endpoint.format(parent_signal.pk)
+        response = self.client.delete(parent_attachment_url)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(Attachment.objects.filter(_signal=parent_signal).count(), 1)
+
+        # Try to delete with "delete_attachment_of_parent_signal"
+        self.sia_read_write_user.user_permissions.set([self.permission_delete_parent])
+        self.sia_read_write_user.save()
+
+        response = self.client.delete(parent_attachment_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Attachment.objects.filter(_signal=parent_signal).count(), 0)
+
+    def test_delete_child_signal_attachments(self):
+        """
+        Check that "delete_attachment_of_child_signal" is needed to delete a
+        child signal's attachments.
+        """
+        self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
+        self.client.force_authenticate(user=self.sia_read_write_user)
+        self.sia_read_write_user.profile.departments.add(self.department)
+
+        # let's pretend our test user uploaded the attachment (no "delete_attachment_of_parent_signal" needed)
+        child_signal = SignalFactory.create(parent=self.signal)
+        child_attachment = ImageAttachmentFactory.create(
+            _signal=child_signal, created_by=self.sia_read_write_user.email)
+
+        # Try to delete without "delete_attachment_of_child_signal"
+        child_attachment_url = self.attachments_endpoint.format(child_attachment.pk)
+        response = self.client.delete(child_attachment_url)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(Attachment.objects.filter(_signal=child_signal).count(), 1)
+
+        # Try to delete with "delete_attachment_of_child_signal"
+        self.sia_read_write_user.user_permissions.set([self.permission_delete_child])
+        self.sia_read_write_user.save()
+
+        response = self.client.delete(child_attachment_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Attachment.objects.filter(_signal=child_signal).count(), 0)

--- a/api/app/signals/apps/api/tests/test_attachment_permissions.py
+++ b/api/app/signals/apps/api/tests/test_attachment_permissions.py
@@ -28,10 +28,10 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.attachment = ImageAttachmentFactory.create(_signal=self.signal, created_by='ambtenaar@example.com')
 
         # Various Attachment delete permissions
-        self.permission_delete_other = Permission.objects.get(codename='delete_attachment_of_other_user')
-        self.permission_delete_normal = Permission.objects.get(codename='delete_attachment_of_normal_signal')
-        self.permission_delete_parent = Permission.objects.get(codename='delete_attachment_of_parent_signal')
-        self.permission_delete_child = Permission.objects.get(codename='delete_attachment_of_child_signal')
+        self.permission_delete_other = Permission.objects.get(codename='sia_delete_attachment_of_other_user')
+        self.permission_delete_normal = Permission.objects.get(codename='sia_delete_attachment_of_normal_signal')
+        self.permission_delete_parent = Permission.objects.get(codename='sia_delete_attachment_of_parent_signal')
+        self.permission_delete_child = Permission.objects.get(codename='sia_delete_attachment_of_child_signal')
 
     def test_cannot_access_without_proper_department_detail(self):
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
@@ -77,7 +77,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
     def test_delete_own_attachments_with_proper_department_i(self):
         """
-        Test that user without "delete_attachment_of_other_user" permission
+        Test that user without "sia_delete_attachment_of_other_user" permission
         cannot delete somebody else's attachments.
         """
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
@@ -102,7 +102,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
     def test_delete_own_attachments_with_proper_department_ii(self):
         """
-        Test that user without "delete_attachment_of_other_user" permission
+        Test that user without "sia_delete_attachment_of_other_user" permission
         can delete their own attachments.
         """
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
@@ -130,7 +130,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
     def test_delete_others_attachments_with_proper_department_i(self):
         """
-        Test that user with "delete_attachment_of_other_user" permission
+        Test that user with "sia_delete_attachment_of_other_user" permission
         can delete somebody else's attachments.
         """
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
@@ -157,7 +157,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
     def test_delete_others_attachments_with_proper_department_ii(self):
         """
-        Test that user with "delete_attachment_of_other_user" permission
+        Test that user with "sia_delete_attachment_of_other_user" permission
         can delete a reporter's attachments.
         """
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
@@ -188,7 +188,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
     def test_delete_others_attachments_with_proper_department_iii(self):
         """
-        Test that user with "delete_attachment_of_other_user" permission
+        Test that user with "sia_delete_attachment_of_other_user" permission
         can delete a their own attachments.
         """
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
@@ -219,24 +219,24 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
     def test_delete_normal_signals_attachments(self):
         """
-        Check that "delete_attachment_of_normal_signal" is needed to delete a
+        Check that "sia_delete_attachment_of_normal_signal" is needed to delete a
         normal signal's attachments.
         """
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
         self.client.force_authenticate(user=self.sia_read_write_user)
         self.sia_read_write_user.profile.departments.add(self.department)
 
-        # let's pretend our test user uploaded the attachment (no "delete_attachment_of_other_user" needed)
+        # let's pretend our test user uploaded the attachment (no "sia_delete_attachment_of_other_user" needed)
         self.attachment.created_by = self.sia_read_write_user.email
         self.attachment.save()
 
-        # Try to delete without "delete_attachment_of_normal_signal"
+        # Try to delete without "sia_delete_attachment_of_normal_signal"
         url = self.attachments_endpoint_detail.format(self.signal.pk, self.attachment.pk)
         response = self.client.delete(url)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
 
-        # Try to delete with "delete_attachment_of_normal_signal"
+        # Try to delete with "sia_delete_attachment_of_normal_signal"
         self.sia_read_write_user.user_permissions.set([self.permission_delete_normal])
         self.sia_read_write_user.save()
         self.sia_read_write_user.refresh_from_db()
@@ -248,7 +248,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
     def test_delete_parent_signal_attachments(self):
         """
-        Check that "delete_attachment_of_parent_signal" is needed to delete a
+        Check that "sia_delete_attachment_of_parent_signal" is needed to delete a
         parent signal's attachments.
         """
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
@@ -256,13 +256,13 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.sia_read_write_user.profile.departments.add(self.department)
 
         # Create a child signal and create an attachment, let's pretend our test
-        # user uploaded the attachment (no "delete_attachment_of_parent_signal" needed)
+        # user uploaded the attachment (no "sia_delete_attachment_of_parent_signal" needed)
         child_signal = SignalFactory.create(parent=self.signal, category_assignment__category=self.category)
         ImageAttachmentFactory.create(_signal=child_signal)
         self.attachment.created_by = self.sia_read_write_user.email
         self.attachment.save()
 
-        # Try to delete without "delete_attachment_of_parent_signal"
+        # Try to delete without "sia_delete_attachment_of_parent_signal"
         parent_signal = self.signal
         parent_attachment = self.attachment
         parent_attachment_url = self.attachments_endpoint_detail.format(parent_signal.pk, parent_attachment.pk)
@@ -270,7 +270,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         response = self.client.delete(parent_attachment_url)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(Attachment.objects.filter(_signal=parent_signal).count(), 1)
-        self.assertIn('delete_attachment_of_parent_signal', response.json()['detail'])
+        self.assertIn('sia_delete_attachment_of_parent_signal', response.json()['detail'])
 
         # Try to delete with "delete_attachment_of_parent_signal"
         self.sia_read_write_user.user_permissions.set([self.permission_delete_parent])
@@ -284,35 +284,35 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
     def test_delete_child_signal_attachments(self):
         """
-        Check that "delete_attachment_of_child_signal" is needed to delete a
+        Check that "sia_delete_attachment_of_child_signal" is needed to delete a
         child signal's attachments.
         """
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
         self.client.force_authenticate(user=self.sia_read_write_user)
         self.sia_read_write_user.profile.departments.add(self.department)
 
-        # let's pretend our test user uploaded the attachment (no "delete_attachment_of_parent_signal" needed)
+        # let's pretend our test user uploaded the attachment (no "sia_delete_attachment_of_parent_signal" needed)
         child_signal = SignalFactory.create(parent=self.signal, category_assignment__category=self.category)
         child_attachment = ImageAttachmentFactory.create(
             _signal=child_signal, created_by=self.sia_read_write_user.email)
         child_attachment_url = self.attachments_endpoint_detail.format(child_signal.pk, child_attachment.pk)
 
-        # Try to delete without "delete_attachment_of_child_signal"
+        # Try to delete without "sia_delete_attachment_of_child_signal"
         response = self.client.get(child_attachment_url)
         self.assertEqual(response.status_code, 200)
 
         response = self.client.delete(child_attachment_url)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(Attachment.objects.filter(_signal=child_signal).count(), 1)
-        self.assertIn('delete_attachment_of_child_signal', response.json()['detail'])
+        self.assertIn('sia_delete_attachment_of_child_signal', response.json()['detail'])
 
-        # Try to delete with "delete_attachment_of_child_signal"
+        # Try to delete with "sia_delete_attachment_of_child_signal"
         self.sia_read_write_user.user_permissions.set([self.permission_delete_child])
         self.sia_read_write_user.save()
         self.sia_read_write_user.refresh_from_db()
-        self.client.force_authenticate(user=self.sia_read_write_user)  # <---!!! is needed!!!
+        self.client.force_authenticate(user=self.sia_read_write_user)
 
-        self.assertTrue(self.sia_read_write_user.has_perm('signals.delete_attachment_of_child_signal'))
+        self.assertTrue(self.sia_read_write_user.has_perm('signals.sia_delete_attachment_of_child_signal'))
 
         response = self.client.delete(child_attachment_url)
         self.assertEqual(response.status_code, 204)

--- a/api/app/signals/apps/api/views/attachment.py
+++ b/api/app/signals/apps/api/views/attachment.py
@@ -10,7 +10,6 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from signals.apps.api.generics import mixins
-from signals.apps.api.generics.permissions import SIAPermissions, SignalViewObjectPermission
 from signals.apps.api.serializers import (
     PrivateSignalAttachmentSerializer,
     PublicSignalAttachmentSerializer
@@ -45,8 +44,6 @@ class PrivateSignalAttachmentsViewSet(
     serializer_detail_class = PrivateSignalAttachmentSerializer
 
     authentication_classes = (JWTAuthBackend,)
-    permission_classes = (SIAPermissions,)
-    object_permission_classes = (SignalViewObjectPermission, )
 
     def get_queryset(self, *args, **kwargs):
         user = self.request.user

--- a/api/app/signals/apps/api/views/attachment.py
+++ b/api/app/signals/apps/api/views/attachment.py
@@ -68,21 +68,21 @@ class PrivateSignalAttachmentsViewSet(
         signal = self.get_signal()
         attachment = self.get_object()
 
-        if signal.is_parent and not user.has_perm('signals.delete_attachment_of_parent_signal'):
-            msg = 'Cannot delete attachment need "delete_attachment_of_parent_signal" permission.'
+        if signal.is_parent and not user.has_perm('signals.sia_delete_attachment_of_parent_signal'):
+            msg = 'Cannot delete attachment need "sia_delete_attachment_of_parent_signal" permission.'
             raise PermissionDenied(msg)
-        elif signal.is_child and not user.has_perm('signals.delete_attachment_of_child_signal'):
-            msg = 'Cannot delete attachment need "delete_attachment_of_child_signal" permission.'
+        elif signal.is_child and not user.has_perm('signals.sia_delete_attachment_of_child_signal'):
+            msg = 'Cannot delete attachment need "sia_delete_attachment_of_child_signal" permission.'
             raise PermissionDenied(msg)
         elif (
                 not signal.is_parent and
                 not signal.is_child and
-                not user.has_perm('signals.delete_attachment_of_normal_signal')):
-            msg = 'Cannot delete attachment need "delete_attachment_of_normal_signal" permission.'
+                not user.has_perm('signals.sia_delete_attachment_of_normal_signal')):
+            msg = 'Cannot delete attachment need "sia_delete_attachment_of_normal_signal" permission.'
             raise PermissionDenied(msg)
 
-        if attachment.created_by != user.email and not user.has_perm('signals.delete_attachment_of_other_user'):
-            msg = 'Cannot delete attachment need "delete_attachment_of_other_user" permission.'
+        if attachment.created_by != user.email and not user.has_perm('signals.sia_delete_attachment_of_other_user'):
+            msg = 'Cannot delete attachment need "sia_delete_attachment_of_other_user" permission.'
             raise PermissionDenied(msg)
 
         return super().destroy(*args, **kwargs)

--- a/api/app/signals/apps/signals/migrations/0155_alter_attachment_options.py
+++ b/api/app/signals/apps/signals/migrations/0155_alter_attachment_options.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0154_statusmessagetemplate_is_active'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='attachment',
+            options={
+                'ordering': ('created_at',),
+                'permissions': [
+                    ('delete_attachment_of_normal_signal', 'Can delete attachment on normal signal.'),
+                    ('delete_attachment_of_parent_signal', 'Can delete attachment on parent signal.'),
+                    ('delete_attachment_of_child_signal', 'Can delete attachment on child signal.'),
+                    ('delete_attachment_of_other_user', 'Can delete attachment uploaded by another user.')
+                ]
+            },
+        ),
+    ]

--- a/api/app/signals/apps/signals/migrations/0155_alter_attachment_options.py
+++ b/api/app/signals/apps/signals/migrations/0155_alter_attachment_options.py
@@ -15,10 +15,10 @@ class Migration(migrations.Migration):
             options={
                 'ordering': ('created_at',),
                 'permissions': [
-                    ('delete_attachment_of_normal_signal', 'Can delete attachment on normal signal.'),
-                    ('delete_attachment_of_parent_signal', 'Can delete attachment on parent signal.'),
-                    ('delete_attachment_of_child_signal', 'Can delete attachment on child signal.'),
-                    ('delete_attachment_of_other_user', 'Can delete attachment uploaded by another user.')
+                    ('sia_delete_attachment_of_normal_signal', 'Can delete attachment on normal signal.'),
+                    ('sia_delete_attachment_of_parent_signal', 'Can delete attachment on parent signal.'),
+                    ('sia_delete_attachment_of_child_signal', 'Can delete attachment on child signal.'),
+                    ('sia_delete_attachment_of_other_user', 'Can delete attachment uploaded by another user.')
                 ]
             },
         ),

--- a/api/app/signals/apps/signals/models/attachment.py
+++ b/api/app/signals/apps/signals/models/attachment.py
@@ -37,6 +37,12 @@ class Attachment(CreatedUpdatedModel):
             models.Index(fields=['is_image']),
             models.Index(fields=['_signal', 'is_image']),
         ]
+        permissions = [
+            ('delete_attachment_of_normal_signal', 'Can delete attachment on normal signal.'),
+            ('delete_attachment_of_parent_signal', 'Can delete attachment on parent signal.'),
+            ('delete_attachment_of_child_signal',  'Can delete attachment on child signal.'),
+            ('delete_attachment_of_other_user', 'Can delete attachment uploaded by another user.'),
+        ]
 
     def _check_if_file_is_image(self):
         try:

--- a/api/app/signals/apps/signals/models/attachment.py
+++ b/api/app/signals/apps/signals/models/attachment.py
@@ -38,10 +38,10 @@ class Attachment(CreatedUpdatedModel):
             models.Index(fields=['_signal', 'is_image']),
         ]
         permissions = [
-            ('delete_attachment_of_normal_signal', 'Can delete attachment on normal signal.'),
-            ('delete_attachment_of_parent_signal', 'Can delete attachment on parent signal.'),
-            ('delete_attachment_of_child_signal',  'Can delete attachment on child signal.'),
-            ('delete_attachment_of_other_user', 'Can delete attachment uploaded by another user.'),
+            ('sia_delete_attachment_of_normal_signal', 'Can delete attachment on normal signal.'),
+            ('sia_delete_attachment_of_parent_signal', 'Can delete attachment on parent signal.'),
+            ('sia_delete_attachment_of_child_signal',  'Can delete attachment on child signal.'),
+            ('sia_delete_attachment_of_other_user', 'Can delete attachment uploaded by another user.'),
         ]
 
     def _check_if_file_is_image(self):

--- a/api/app/signals/apps/users/tests/v1/test_permissions.py
+++ b/api/app/signals/apps/users/tests/v1/test_permissions.py
@@ -11,8 +11,8 @@ class TestPermissionsViews(SIAReadUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
-        self.assertEqual(data['count'], 19)
-        self.assertEqual(len(data['results']), 19)
+        self.assertEqual(data['count'], 23)
+        self.assertEqual(len(data['results']), 23)
 
     def test_get_permission(self):
         self.client.force_authenticate(user=self.sia_read_user)


### PR DESCRIPTION
## Description

Allow deletion of attachments.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
