### PR TITLE
SIG-4510 Status update to "reaction requested" should allow 400 characters instead of 200

### DIFF
--- a/api/app/signals/apps/api/tests/test_reaction_request_flow_trigger.py
+++ b/api/app/signals/apps/api/tests/test_reaction_request_flow_trigger.py
@@ -18,10 +18,8 @@ class TestReactionRequestFlowTrigger(SignalsBaseApiTestCase):
         self.signal = SignalFactory.create(status__state=workflow.GEMELD)
         self.client.force_authenticate(user=self.superuser)
 
-    def test_email_known_REACTIE_GEVRAAGD_state_allowed(self):
-        url = self.detail_endpoint.format(pk=self.signal.id)
         payload = {'status': {'state': workflow.REACTIE_GEVRAAGD, 'text': 'Our question.'}}
-        response = self.client.patch(url, data=payload, format='json')
+        response = self.client.patch(f'/signals/v1/private/signals/{self.signal.pk}', data=payload, format='json')
 
         self.assertEqual(response.status_code, 200)
 
@@ -30,8 +28,28 @@ class TestReactionRequestFlowTrigger(SignalsBaseApiTestCase):
         self.signal.reporter.save()
         self.signal.refresh_from_db()
 
-        url = self.detail_endpoint.format(pk=self.signal.id)
         payload = {'status': {'state': workflow.REACTIE_GEVRAAGD, 'text': 'Our question.'}}
-        response = self.client.patch(url, data=payload, format='json')
+        response = self.client.patch(f'/signals/v1/private/signals/{self.signal.pk}', data=payload, format='json')
 
         self.assertEqual(response.status_code, 400)
+
+    def test_SIG_4511_update_status_more_than_400_characters(self):
+        data = {
+            'status': {
+                'text': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut '
+                        'labore et dolore magna aliqua. Morbi tristique senectus et netus et malesuada fames. '
+                        'Vestibulum rhoncus est pellentesque elit ullamcorper dignissim cras tincidunt lobortis. Vitae '
+                        'auctor eu augue ut lectus arcu bibendum at varius. Luctus venenatis lectus magna fringilla '
+                        'urna. Adipiscing commodo elit at imperdiet dui accumsan sit. Venenatis urna cursus eget nunc '
+                        'scelerisque viverra mauris in. Aliquam sem et tortor consequat id porta. Massa enim nec dui '
+                        'nunc. Pellentesque adipiscing commodo elit at imperdiet dui accumsan sit.',
+                'state': 'reaction requested'
+            }
+        }
+
+        response = self.client.patch(f'/signals/v1/private/signals/{self.signal.pk}', data, format='json')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['status']['text'][0],
+                         'Zorg dat deze waarde niet meer dan 400 tekens bevat (het zijn er nu '
+                         f'{len(data["status"]["text"])}).')

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -71,7 +71,7 @@ class ActionTestMixin:
     def test_send_email(self):
         self.assertEqual(len(mail.outbox), 0)
 
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
         signal = SignalFactory.create(status__state=self.state, status__text=status_text,
                                       status__send_email=self.send_email, reporter__email='test@example.com')
         self.assertTrue(self.action(signal, dry_run=False))
@@ -85,7 +85,7 @@ class ActionTestMixin:
     def test_send_email_dry_run(self):
         self.assertEqual(len(mail.outbox), 0)
 
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
         signal = SignalFactory.create(status__state=self.state, status__text=status_text,
                                       status__send_email=self.send_email, reporter__email='test@example.com')
         self.assertTrue(self.action(signal, dry_run=True))
@@ -96,7 +96,7 @@ class ActionTestMixin:
     def test_send_email_anonymous(self):
         self.assertEqual(len(mail.outbox), 0)
 
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
         signal = SignalFactory.create(status__state=self.state, status__text=status_text,
                                       status__send_email=self.send_email, reporter__email='')
         self.assertFalse(self.action(signal, dry_run=False))
@@ -114,7 +114,7 @@ class ActionTestMixin:
     def test_send_email_for_parent_signals(self):
         self.assertEqual(len(mail.outbox), 0)
 
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
         parent_signal = SignalFactory.create(status__state=self.state, status__text=status_text,
                                              status__send_email=self.send_email, reporter__email='test@example.com')
         SignalFactory.create(status__state=self.state, status__text=status_text, reporter__email='test@example.com',
@@ -127,7 +127,7 @@ class ActionTestMixin:
     def test_do_not_send_email_for_child_signals(self):
         self.assertEqual(len(mail.outbox), 0)
 
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
         parent_signal = SignalFactory.create(status__state=self.state, status__text=status_text,
                                              status__send_email=self.send_email, reporter__email='test@example.com')
         child_signal = SignalFactory.create(status__state=self.state, status__text=status_text,
@@ -141,7 +141,7 @@ class ActionTestMixin:
     def test_do_not_send_email_invalid_states(self):
         self.assertEqual(len(mail.outbox), 0)
 
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
         states = list(map(lambda x: x[0] and x[0] == self.state, workflow.STATUS_CHOICES))
         for state in states:
             signal = SignalFactory.create(status__state=state, status__text=status_text,
@@ -156,7 +156,7 @@ class ActionTestMixin:
 
         self.assertEqual(len(mail.outbox), 0)
 
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
         signal = SignalFactory.create(status__state=self.state, status__text=status_text,
                                       status__send_email=True, reporter__email='test@example.com')
         self.assertFalse(self.action(signal, dry_run=False))

--- a/api/app/signals/apps/email_integrations/tests/test_rules.py
+++ b/api/app/signals/apps/email_integrations/tests/test_rules.py
@@ -27,13 +27,13 @@ class RuleTestMixin:
     send_email = False
 
     def test_happy_flow(self):
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
         signal = SignalFactory.create(status__state=self.state, status__text=status_text,
                                       status__send_email=self.send_email, reporter__email='test@example.com')
         self.assertTrue(self.rule(signal))
 
     def test_anonymous_reporter(self):
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
 
         signal = SignalFactory.create(status__state=self.state, status__text=status_text, reporter__email='')
         self.assertFalse(self.rule(signal))
@@ -42,7 +42,7 @@ class RuleTestMixin:
         self.assertFalse(self.rule(signal))
 
     def test_apply_for_parent_signals(self):
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
 
         parent_signal = SignalFactory.create(status__state=self.state, status__text=status_text,
                                              status__send_email=self.send_email, reporter__email='test@example.com')
@@ -52,7 +52,7 @@ class RuleTestMixin:
         self.assertTrue(self.rule(parent_signal))
 
     def test_do_not_apply_for_child_signals(self):
-        status_text = FuzzyText(length=200) if self.state == workflow.REACTIE_GEVRAAGD else FuzzyText(length=400)
+        status_text = FuzzyText(length=400)
 
         parent_signal = SignalFactory.create(status__state=self.state, status__text=status_text,
                                              reporter__email='test@example.com')

--- a/api/app/signals/apps/questionnaires/migrations/0008_auto_20220329_1929.py
+++ b/api/app/signals/apps/questionnaires/migrations/0008_auto_20220329_1929.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0154_statusmessagetemplate_is_active'),
+        ('questionnaires', '0007_auto_20210830_2156'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='question',
+            name='label',
+            field=models.CharField(max_length=1000),
+        ),
+        migrations.AlterField(
+            model_name='questionnaire',
+            name='is_active',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AlterField(
+            model_name='session',
+            name='_signal',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE,
+                                    to='signals.signal'),
+        ),
+    ]

--- a/api/app/signals/apps/questionnaires/models/question.py
+++ b/api/app/signals/apps/questionnaires/models/question.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
+# Copyright (C) 2021 -2022 Gemeente Amsterdam
 import uuid
 
 from django.contrib.gis.db import models
@@ -22,7 +22,7 @@ class Question(models.Model):
     uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     created_at = models.DateTimeField(editable=False, auto_now_add=True)
 
-    label = models.CharField(max_length=255)
+    label = models.CharField(max_length=1000)  # noqa SIG-4511 raised the max length. The ticket states a max length of 400, but to be future proof raised to 1000
     short_label = models.CharField(max_length=255)
     field_type = models.CharField(choices=field_type_choices(), max_length=255)
     required = models.BooleanField(default=False)

--- a/api/app/signals/apps/questionnaires/services/reaction_request.py
+++ b/api/app/signals/apps/questionnaires/services/reaction_request.py
@@ -48,7 +48,7 @@ def create_session_for_reaction_request(signal):
             required=True,
             field_type='plain_text',
             short_label='Reactie melder',
-            label=signal.status.text,  # <-- this should not be empty, max 200 characters
+            label=signal.status.text,  # <-- this should not be empty, max 400 characters
             analysis_key='reaction',
         )
         graph = QuestionGraph.objects.create(first_question=question, name='Reactie gevraagd.')


### PR DESCRIPTION
## Description

The label (the real question) of a Question could only hold 255 characters. For the reaction request flow this should be raised to 400. However to be more future proof the max_length is raised to 1000 characters. An additional check has been added to the status update of a Signal to check if the given text only contains 400 characters if the new state is "reaction requested", if it is more a 400 is returned with a response body. Added a migration containing the new max_length and 2 other changes that where not in a migration. Added a test and altered other tests for this change.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
