### PR TITLE
add user assigned at, add parsed json addresses

### DIFF
--- a/api/app/signals/apps/reporting/csv/datawarehouse/locations.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/locations.py
@@ -27,8 +27,16 @@ def create_locations_csv(location: str) -> str:
         lng=ExpressionWrapper(Func('geometrie', function='st_y'), output_field=FloatField()),
         _stadsdeel=Coalesce(map_choices('stadsdeel', STADSDELEN), Cast('area_code', output_field=CharField())),
         _address=Coalesce(Cast('address', output_field=CharField()), Value('null', output_field=CharField())),
-        _extra_properties=Coalesce(Cast('extra_properties', output_field=CharField()),
-                                   Value('null', output_field=CharField()))
+        _extra_properties=Coalesce(
+            Cast('extra_properties', output_field=CharField()), Value('null', output_field=CharField())),
+        address_street=Coalesce(
+            Cast('address__openbare_ruimte', output_field=CharField()), Value('null', output_field=CharField())),
+        address_number=Coalesce(
+            Cast('address__huisnummer', output_field=CharField()), Value('null', output_field=CharField())),
+        address_postalcode=Coalesce(
+            Cast('address__postcode', output_field=CharField()), Value('null', output_field=CharField())),
+        address_city=Coalesce(
+            Cast('address__woonplaats', output_field=CharField()), Value('null', output_field=CharField()))
     ).order_by(
         'id'
     )
@@ -36,7 +44,8 @@ def create_locations_csv(location: str) -> str:
     csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'locations.csv'))
 
     ordered_field_names = ['id', 'lat', 'lng', 'stadsdeel', 'buurt_code', 'address', 'address_text', 'created_at',
-                           'updated_at', 'extra_properties', '_signal_id', ]
+                           'updated_at', 'extra_properties', '_signal_id', 'address_street', 'address_number',
+                           'address_postalcode', 'address_city']
     reorder_csv(csv_file.name, ordered_field_names)
 
     return csv_file.name

--- a/api/app/signals/apps/reporting/csv/datawarehouse/locations.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/locations.py
@@ -46,6 +46,6 @@ def create_locations_csv(location: str) -> str:
     ordered_field_names = ['id', 'lat', 'lng', 'stadsdeel', 'buurt_code', 'address', 'address_text', 'created_at',
                            'updated_at', 'extra_properties', '_signal_id', 'address_street', 'address_number',
                            'address_postalcode', 'address_city']
-    reorder_csv(csv_file.name, ordered_field_names)
+    reorder_csv(csv_file.name, ordered_field_names, remove_leading_trailing_quotes=True)
 
     return csv_file.name

--- a/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/signals.py
@@ -79,11 +79,12 @@ def create_signals_assigned_user_csv(location: str) -> str:
     ).values(
         'id',
         assigned_to=F('user_assignment__user__email'),
+        assigned_at=F('user_assignment__created_at')
     ).exclude(user_assignment__user__isnull=True).exclude(user_assignment__user__email__exact='').order_by('created_at')
 
     csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'signals_assigned_user.csv'))
 
-    ordered_field_names = ['id', 'assigned_to', ]
+    ordered_field_names = ['id', 'assigned_to', 'assigned_at']
     reorder_csv(csv_file.name, ordered_field_names)
 
     return csv_file.name

--- a/api/app/signals/apps/reporting/csv/utils.py
+++ b/api/app/signals/apps/reporting/csv/utils.py
@@ -121,12 +121,15 @@ def map_choices(field_name: str, choices: list) -> Case:
     )
 
 
-def reorder_csv(file_path, ordered_field_names):
+def reorder_csv(file_path, ordered_field_names, remove_leading_trailing_quotes=False):
     reordered_file_path = f'{file_path[:-4]}_reordered.csv'
     with open(file_path, 'r') as infile, open(reordered_file_path, 'a') as outfile:
         writer = csv.DictWriter(outfile, fieldnames=ordered_field_names)
         writer.writeheader()
         for row in csv.DictReader(infile):
+            if remove_leading_trailing_quotes:
+                for k, v in row.items():
+                    row[k] = v.strip('"')
             writer.writerow(row)
 
     shutil.move(file_path, f'{file_path[:-4]}_original.csv')

--- a/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
+++ b/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
@@ -242,6 +242,12 @@ class TestDatawarehouse(testcases.TestCase):
 
                 self.assertEqual(row['extra_properties'], 'null')
 
+                # validate parsed json fields
+                self.assertEqual(row['address_street'], location.address['openbare_ruimte'])
+                self.assertEqual(row['address_number'], str(location.address['huisnummer']))
+                self.assertEqual(row['address_postalcode'], location.address['postcode'])
+                self.assertEqual(row['address_city'], location.address['woonplaats'])
+
     def test_create_reporters_csv(self):
         signal = SignalFactory.create()
         reporter = signal.reporter

--- a/api/app/signals/apps/signals/factories/location.py
+++ b/api/app/signals/apps/signals/factories/location.py
@@ -31,10 +31,10 @@ class LocationFactory(DjangoModelFactory):
     buurt_code = FuzzyText(length=4)
     stadsdeel = FuzzyChoice(choices=(s[0] for s in STADSDELEN))
     geometrie = get_puntje()
-    address = {'straat': 'Sesamstraat',
+    address = {'openbare_ruimte': 'Sesamstraat',
                'huisnummer': 666,
                'postcode': '1011AA',
-               'openbare_ruimte': 'Ergens'}
+               'woonplaats': 'Ergens'}
 
     @post_generation
     def set_one_to_one_relation(self, create, extracted, **kwargs):


### PR DESCRIPTION
## Description

implements https://github.com/Signalen/product-steering/issues/81
- The native db json operations like 'address__openbare_ruimte' are not stripping '"'. I could not find a nice way to strip this at query time. I've added an optional parameter to the reorder_csv to strip '"' if needed
- I noticed that the json structure of the dummy address factory is inconsistent with the stored json in production. Corrected this also

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
