### PR TITLE
Upload attachments for a specific Question and Session

### DIFF
--- a/api/app/signals/apps/questionnaires/fieldtypes/__init__.py
+++ b/api/app/signals/apps/questionnaires/fieldtypes/__init__.py
@@ -4,6 +4,7 @@ import inspect
 import re
 import sys
 
+from signals.apps.questionnaires.fieldtypes.attachment import Image
 from signals.apps.questionnaires.fieldtypes.base import FieldType
 from signals.apps.questionnaires.fieldtypes.boolean import Boolean
 from signals.apps.questionnaires.fieldtypes.integer import Integer
@@ -13,6 +14,7 @@ __all__ = [
     'PlainText',
     'Integer',
     'Boolean',
+    'Image',
 ]
 
 _PATTERN_CAMEL_CASE = re.compile(r'(?<!^)(?=[A-Z])')

--- a/api/app/signals/apps/questionnaires/fieldtypes/attachment.py
+++ b/api/app/signals/apps/questionnaires/fieldtypes/attachment.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+from signals.apps.questionnaires.fieldtypes.base import FieldType
+from signals.apps.services.domain.filescanner import UploadScannerService
+
+
+class Attachment(FieldType):
+    submission_schema = {
+        'type': 'object',
+        'properties': {
+            'original_filename': {
+                'type': 'string',
+            },
+            'file_path': {
+                'type': 'string',
+            },
+        },
+        'required': [
+            'original_filename',
+            'file_path'
+        ],
+    }
+
+    def validate_file(self, file):
+        """
+        Overwrite this function in the child class to validate the file.
+        """
+        return False
+
+
+class Image(Attachment):
+    def validate_file(self, file):
+        UploadScannerService.scan_file(file)

--- a/api/app/signals/apps/questionnaires/fieldtypes/attachment.py
+++ b/api/app/signals/apps/questionnaires/fieldtypes/attachment.py
@@ -10,6 +10,8 @@ class Attachment(ABC, FieldType):
     """
     The abstract Attachment class to be used as a base class for all attachment field types.
     """
+    # The content of this field is not given by the "user", it is generated in the Attachment uploade mechanism for
+    # questionnaires.
     submission_schema = {
         'type': 'object',
         'properties': {

--- a/api/app/signals/apps/questionnaires/fieldtypes/attachment.py
+++ b/api/app/signals/apps/questionnaires/fieldtypes/attachment.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2022 Gemeente Amsterdam
+from abc import ABC
+
 from signals.apps.questionnaires.fieldtypes.base import FieldType
 from signals.apps.services.domain.filescanner import UploadScannerService
 
 
-class Attachment(FieldType):
+class Attachment(ABC, FieldType):
+    """
+    The abstract Attachment class to be used as a base class for all attachment field types.
+    """
     submission_schema = {
         'type': 'object',
         'properties': {
@@ -25,7 +30,7 @@ class Attachment(FieldType):
         """
         Overwrite this function in the child class to validate the file.
         """
-        return False
+        raise NotImplementedError
 
 
 class Image(Attachment):

--- a/api/app/signals/apps/questionnaires/models/question.py
+++ b/api/app/signals/apps/questionnaires/models/question.py
@@ -4,7 +4,7 @@ import uuid
 
 from django.contrib.gis.db import models
 
-from signals.apps.questionnaires.fieldtypes import field_type_choices
+from signals.apps.questionnaires.fieldtypes import field_type_choices, get_field_type_class
 from signals.apps.questionnaires.managers import QuestionManager
 
 
@@ -41,3 +41,7 @@ class Question(models.Model):
         if self.analysis_key == 'PLACEHOLDER':
             self.analysis_key = f'PLACEHOLDER-{str(self.uuid)}'
         return super().save(*args, **kwargs)
+
+    @property
+    def field_type_class(self):
+        return get_field_type_class(self)

--- a/api/app/signals/apps/questionnaires/rest_framework/fields.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/fields.py
@@ -68,7 +68,11 @@ class SessionPublicHyperlinkedIdentityField(HyperlinkedRelatedFieldMixin, serial
             ('curies', dict(name='sia', href=self.reverse('signal-namespace', request=self.context.get('request')))),
             ('self', dict(href=self._get_url(value, 'public-session-detail'))),
             ('sia:questionnaire', dict(href=self._reverse('public-questionnaire-detail',
-                                                          kwargs={'uuid': value.questionnaire.uuid})))
+                                                          kwargs={'uuid': value.questionnaire.uuid}))),
+            ('sia:post-answers', dict(href=self._reverse('public-session-answers',
+                                                         kwargs={'uuid': value.uuid}))),
+            ('sia:post-attachments', dict(href=self._reverse('public-session-attachments',
+                                                             kwargs={'uuid': value.uuid}))),
         ])
 
         if value._signal:

--- a/api/app/signals/apps/questionnaires/rest_framework/fields.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/fields.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
+# Copyright (C) 2021 - 2022 Gemeente Amsterdam
 from collections import OrderedDict
 
 from django.core.exceptions import ObjectDoesNotExist

--- a/api/app/signals/apps/questionnaires/rest_framework/serializers/public/attachment.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/serializers/public/attachment.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+import uuid
+
+from django.core.files.storage import default_storage
+from PIL.Image import DecompressionBombError
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+
+from signals.apps.questionnaires.fieldtypes.attachment import Attachment
+from signals.apps.questionnaires.models import Question
+from signals.apps.services.domain.filescanner import FileRejectedError
+
+
+class PublicAttachmentSerializer(serializers.Serializer):
+    question_uuid = serializers.UUIDField()
+    file = serializers.FileField(required=True)
+
+    def validate_question_uuid(self, value):
+        try:
+            question = Question.objects.get(uuid=value)
+        except Question.DoesNotExist:
+            raise ValidationError('Question does not exist')
+
+        return question
+
+    def create(self, validated_data):
+        session_service = self.context['session_service']
+
+        # The question_uuid is transformed to a Question object in the validate_question_uuid method
+        question = validated_data.pop('question_uuid')
+        if not issubclass(question.field_type_class, Attachment):
+            raise ValidationError({'question': ['This question is not an attachment question']})
+
+        file = validated_data.pop('file')
+        try:
+            question.field_type_class().validate_file(file)
+        except (FileRejectedError, DecompressionBombError) as e:
+            raise ValidationError({'file': [str(e)]})
+
+        # Store the file in the default storage
+        session_uuid = session_service.session.uuid
+        random_uuid = uuid.uuid4()
+        extension = file.name.split('.')[-1]
+        path = f'{session_uuid.hex[:2]}/{session_uuid.hex[2:4]}/{session_uuid}/{random_uuid.hex}.{extension}'
+        file_path = default_storage.save(f'attachments/questionnaires/sessions/{path}', file.file)
+
+        payload = {'original_filename': file.name, 'file_path': file_path}
+        return session_service.create_answer(payload, question)

--- a/api/app/signals/apps/questionnaires/rest_framework/views/public/sessions.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public/sessions.py
@@ -86,7 +86,6 @@ class PublicSessionViewSet(HALViewSetRetrieve):
 
         answer_payloads = []
         questions = []
-
         retrieval_errors_by_uuid = {}
         for answer_data in serializer.data:
             uuid = answer_data['question_uuid']

--- a/api/app/signals/apps/questionnaires/rest_framework/views/public/sessions.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public/sessions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
+# Copyright (C) 2021 - 2022 Gemeente Amsterdam
 from rest_framework.decorators import action
 from rest_framework.exceptions import APIException
 from rest_framework.response import Response

--- a/api/app/signals/apps/questionnaires/rest_framework/views/public/sessions.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public/sessions.py
@@ -108,11 +108,11 @@ class PublicSessionViewSet(HALViewSetRetrieve):
         # TODO, consider status code - possibly return 400 if all answers were rejected
         return Response(serializer.data, status=200)
 
-    @action(detail=True, url_path=r'attachment/?$', methods=['POST', ], serializer_class=PublicAttachmentSerializer,
+    @action(detail=True, url_path=r'attachments/?$', methods=['POST', ], serializer_class=PublicAttachmentSerializer,
             serializer_detail_class=PublicAttachmentSerializer)
-    def attachment(self, request, *args, **kwargs):
+    def attachments(self, request, *args, **kwargs):
         """
-        Upload attachment for a specific session/question. The attachment will be validated and stored in the
+        Upload attachments for a specific session/question. The attachment will be validated and stored in the
         default_storage. The original name and location of the attachment will be stored in the payload of the answer.
         """
         session_service = get_session_service_or_404(self.get_object())

--- a/api/app/signals/apps/questionnaires/services/session.py
+++ b/api/app/signals/apps/questionnaires/services/session.py
@@ -19,6 +19,7 @@ class SessionService:
         self.session = session
         self.question_graph_service = QuestionGraphService(session.questionnaire.graph)
         self.answer_service = AnswerService
+        self._path_validation_errors_by_uuid = {}
 
     def is_publicly_accessible(self):
         """
@@ -256,7 +257,7 @@ class SessionService:
 
         # Cache our validation errors so that these can be accessed through the
         # path_validation_errors property.
-        self._path_validation_errors_by_uuid = errors_by_uuid
+        self._path_validation_errors_by_uuid.update(errors_by_uuid)
         return errors_by_uuid
 
     @property

--- a/api/app/signals/apps/questionnaires/services/session.py
+++ b/api/app/signals/apps/questionnaires/services/session.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
+# Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import logging
 from collections import OrderedDict
 

--- a/api/app/signals/apps/questionnaires/templates/questionnaires/swagger/public_openapi.yaml
+++ b/api/app/signals/apps/questionnaires/templates/questionnaires/swagger/public_openapi.yaml
@@ -152,33 +152,6 @@ paths:
         '404':
           description: Question not found
 
-  /public/qa/sessions/{UUID}/submit:
-    parameters:
-      - name: UUID
-        in: path
-        description: UUID of Question
-        required: true
-        schema:
-          type: string
-          pattern: '^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$'
-          example: '00000000-0000-0000-0000-000000000000'
-    post:
-      description: Submit a session (i.e. freeze it)
-
-      responses:
-        '200':
-          description: Detail of the frozen Session
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PublicSession'
-        '400':
-          description: Request invalid
-        '404':
-          description: Session not found
-        '410':
-          description: Session already used or expired.
-
   /public/qa/sessions/{UUID}:
     parameters:
       - name: UUID
@@ -192,11 +165,104 @@ paths:
     get:
       responses:
         '200':
-          description: Detail of the selected Session
+          description: Detail of the requested Session
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/PublicSession'
+
+  /public/qa/sessions/{UUID}/answers:
+    parameters:
+      - name: UUID
+        in: path
+        description: UUID of Session
+        required: true
+        schema:
+          type: string
+          pattern: '^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$'
+          example: '00000000-0000-0000-0000-000000000000'
+    post:
+      description: Submit a set of answers for a specific Session
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PublicSessionAnswerQuestionList'
+
+      responses:
+        '200':
+          description: Detail of the current state of the Session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicSession'
+        '400':
+          description: Request invalid
+        '404':
+          description: Session not found
+        '410':
+          description: Session already used or expired.
+
+  /public/qa/sessions/{UUID}/attachments:
+    parameters:
+      - name: UUID
+        in: path
+        description: UUID of Session
+        required: true
+        schema:
+          type: string
+          pattern: '^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$'
+          example: '00000000-0000-0000-0000-000000000000'
+    post:
+      description: Submit an attachment for a specific Session
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PublicSessionAnswerAttachmentQuestion'
+
+      responses:
+        '200':
+          description: Detail of the current state of the Session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicSession'
+        '400':
+          description: Request invalid
+        '404':
+          description: Session not found
+        '410':
+          description: Session already used or expired.
+
+  /public/qa/sessions/{UUID}/submit:
+    parameters:
+      - name: UUID
+        in: path
+        description: UUID of Session
+        required: true
+        schema:
+          type: string
+          pattern: '^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$'
+          example: '00000000-0000-0000-0000-000000000000'
+    post:
+      description: Submit a session (i.e. freeze it)
+
+      responses:
+        '200':
+          description: Detail of the current state of the Session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicSession'
+        '400':
+          description: Request invalid
+        '404':
+          description: Session not found
+        '410':
+          description: Session already used or expired.
 
 components:
   schemas:
@@ -506,6 +572,33 @@ components:
                 items:
                   type: string
           minItems: 0
+
+    PublicSessionAnswerQuestion:
+      type: object
+      properties:
+        payload:
+          type: string
+          example: 'This is an example of an answer to the question'
+        question_uuid:
+          type: string
+          pattern: '^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$'
+          example: '00000000-0000-0000-0000-000000000000'
+
+    PublicSessionAnswerQuestionList:
+      type: array
+      items:
+        $ref: '#/components/schemas/PublicSessionAnswerQuestion'
+
+    PublicSessionAnswerAttachmentQuestion:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+        question_uuid:
+          type: string
+          pattern: '^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$'
+          example: '00000000-0000-0000-0000-000000000000'
 
   securitySchemes:
     OAuth2:

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/views/public/test_public_sessions_endpoint.py
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/views/public/test_public_sessions_endpoint.py
@@ -302,8 +302,9 @@ class TestPublicSessionEndpointAnswerAttachmentFlow(ValidateJsonSchemaMixin, API
         #    q1 <- first question (PlainText)
         #    |
         #    q2 <- second question (Image)
-        self.q1 = QuestionFactory.create(analysis_key='q1', label='q1', short_label='q1')
-        self.q2 = QuestionFactory.create(analysis_key='q2', label='q2', short_label='q2', field_type='image')
+        self.q1 = QuestionFactory.create(analysis_key='q1', label='q1', short_label='q1', required=True)
+        self.q2 = QuestionFactory.create(analysis_key='q2', label='q2', short_label='q2', field_type='image',
+                                         required=True)
         graph = QuestionGraphFactory.create(name='testgraph', first_question=self.q1)
         EdgeFactory.create(graph=graph, question=self.q1, next_question=self.q2)
 

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/views/public/test_public_sessions_endpoint.py
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/views/public/test_public_sessions_endpoint.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
+# Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import os
 import uuid
 


### PR DESCRIPTION
## Description

To allow the Questionnaire to ask for an attachment a field type is added. An attachment can only be uploaded for an active Session containing a question that allows for an attachment upload.

This PR also contains and is depending on changes in PR https://github.com/Amsterdam/signals/pull/961

TODO:

- [X] Add fieldtypes for Attachment and Image (derived from Attachment)
- [X] Add checks (UploadScannerService) to the Image fieldtype
- [X] Add endpoint to upload attachments to a specific Session/Question
- [X] Add check that the question we are posting an attachment for is an "Attachment" or an "Image" question
- [X] Add check to the answer endpoint of a Session and do not allow POST of Attachments here
- [x] Add unit tests
- [x] Test locally
- [x] Document the change (swagger and documentation)

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
