### PR TITLE
Update Django 3.2.12 -> 3.2.13 (SQL injection vulnerabilities found in the Django ORM)

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,7 +24,7 @@ datapunt-authorization-django==1.3.0
 debtcollector==2.2.0
 defusedxml==0.7.1
 distlib==0.3.1
-Django==3.2.12
+Django==3.2.13
 django-appconf==1.0.4
 django-celery-beat==2.2.0
 django-celery-email==3.0.0


### PR DESCRIPTION
SQL Injection vulnerabilities found in the Django ORM explain, annotate, aggregate and extra methods. See the following URLs for more information:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28346
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28347

## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
