### PR TITLE
Fix CORS_ALLOWED_ORIGINS default (System check framework was failing)

### DIFF
--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -17,7 +17,7 @@ ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', DEFAULT_ALLOWED_HOSTS).split(',')
 
 INTERNAL_IPS = ('127.0.0.1', '0.0.0.0')
 
-CORS_ALLOWED_ORIGINS = [origin.strip() for origin in os.getenv('CORS_ALLOWED_ORIGINS', '').split(',')]
+CORS_ALLOWED_ORIGINS = [origin.strip() for origin in os.getenv('CORS_ALLOWED_ORIGINS', 'null').split(',')]
 CORS_ALLOW_ALL_ORIGINS = os.getenv('CORS_ALLOW_ALL_ORIGINS', True) in TRUE_VALUES
 
 SITE_ID = 1


### PR DESCRIPTION
## Description

Making new migrations was impossible because the System check framework identified issues in the `django-cors-headers`  configuration. The specific problem if identified can be solved by setting `'null'` as a default in case no allowed origins are configured in the `CORS_ALLOWED_ORIGINS` setting (as described in https://github.com/adamchainz/django-cors-headers/issues/404).


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
