### PR TITLE
Feature/extra properties on mail context for reporters

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/signal_created.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_created.py
@@ -51,4 +51,42 @@ class SignalCreatedAction(AbstractAction):
             reporter_email = f'{local}@{sd}{tld}'.replace('*', '\\*')  # noqa escape the * because it is used in markdown
             context.update({'reporter_email': reporter_email})
 
+        # Add the extra properties to the context of the email template
+        context.update({'extra_properties': self._extra_properties_context(signal.extra_properties)})
+
         return context
+
+    def _extra_properties_context(self, extra_properties):
+        """
+        Renders the extra properties of the signals as a dict of key-value pairs so that they can be rendered in the
+        email template.
+        """
+        context = {}
+        for extra_property in extra_properties:
+            context[extra_property['label']] = []
+            if isinstance(extra_property['answer'], (list, tuple)):
+                for answer in extra_property['answer']:
+                    context[extra_property['label']].append(self._get_answer_from_extra_property(answer))
+            else:
+                context[extra_property['label']].append(self._get_answer_from_extra_property(extra_property['answer']))
+        return context
+
+    def _get_answer_from_extra_property(self, extra_property):
+        """
+        Returns the first option that is available in the extra property and not empty as the answer.
+        Defaults to '-' if no option is available.
+        """
+        if 'label' in extra_property and extra_property['label']:
+            return extra_property['label']
+        elif 'value' in extra_property and extra_property['value']:
+            return extra_property['value']
+        elif 'answer' in extra_property and extra_property['answer']:
+            return extra_property['answer']
+        elif 'id' in extra_property and extra_property['id']:
+            return extra_property['id']
+        elif 'type' in extra_property and extra_property['type']:
+            return extra_property['type']
+        elif extra_property:
+            return extra_property
+        else:
+            return '-'

--- a/api/app/signals/apps/email_integrations/admin.py
+++ b/api/app/signals/apps/email_integrations/admin.py
@@ -35,6 +35,7 @@ class EmailTemplate(admin.ModelAdmin):
         models.TextField: {'widget': AdminMarkdownxWidget},
     }
 
+    save_on_top = True
     list_display = ('key', 'title', )
     readonly_fields = ('created_by', )
     form = EmailTemplateAdminForm

--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -69,11 +69,29 @@
             <li>sub_category_public_name</li>
         </ul>
         <h3>Variabelen welke in bepaalde templates beschikbaar zijn</h3>
+        <h4>Send mail signal created</h4>
         <ul>
-            <li>positive_feedback_url (alleen beschikbaar in de "afgehandeld" template)</li>
-            <li>negative_feedback_url (alleen beschikbaar in de "afgehandeld" template)</li>
-            <li>reaction_url (alleen beschikbaar in de "reactie gevraagd" template)</li>
-            <li>reaction_request_answer (alleen beschikbaar in de "reactie ontvangen" template)</li>
+            <li>extra_properties, vraag => lijst met antwoorden</li>
+            <li>reporter_phone (Alleen beschikbaar als er een telefoonnummer is opgegeven)</li>
+            <li>reporter_email (Alleen beschikbaar als er een email adres is opgegeven)</li>
+        </ul>
+        <h4>Send mail signal handeld</h4>
+        <ul>
+            <li>positive_feedback_url</li>
+            <li>negative_feedback_url</li>
+        </ul>
+        <h4>Send mail signal optional</h4>
+        <ul>
+            <li>afhandelings_text</li>
+        </ul>
+        <h4>Send mail signal reaction requested</h4>
+        <ul>
+            <li>reaction_url</li>
+            <li>reaction_request_answer</li>
+        </ul>
+        <h4>Send mail signal reaction requested received</h4>
+        <ul>
+            <li>reaction_request_answer</li>
         </ul>
     </div>
 

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -298,6 +298,53 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
         self.assertEqual(Note.objects.count(), 1)
         self.assertTrue(Note.objects.filter(text=self.action.note).exists())
 
+    def test_signal_created_with_extra_properties(self):
+        email_template = EmailTemplate.objects.get(key=EmailTemplate.SIGNAL_CREATED)
+        email_template.body = '{% for label, answers in extra_properties.items %}{{ label }} {% for answer in answers %}{{ answer}}{% if not forloop.last %}, {% endif %}{% endfor %} {% endfor %}'  # noqa
+        email_template.save()
+
+        self.assertEqual(len(mail.outbox), 0)
+
+        extra_properties = [
+            {
+                "id": "test-1",
+                "label": "Is dit de eerste vraag?",
+                "answer": "Ja, en dit is het antwoord op de eerste vraag",
+                "category_url": "/signals/v1/public/terms/categories/overig/sub_categories/overig"
+            }, {
+                "id": "test-2",
+                "label": "Is dit de tweede vraag en selecteren wij hier een of meerdere objecten?",
+                "answer": [{
+                    "id": 12345,
+                    "type": "type-1",
+                    "description": "Overig lichtpunt",
+                    "label": "Overig lichtpunt",
+                }, {
+                    "id": 67890,
+                    "type": "not-on-map",
+                    "label": "Lichtpunt niet op de kaart"
+                }, {
+                    "type": "not-on-map"
+                }],
+                "category_url": "/signals/v1/public/terms/categories/overig/sub_categories/overig"
+            }
+        ]
+
+        signal = SignalFactory.create(status__state=self.state, reporter__email='test@example.com',
+                                      extra_properties=extra_properties)
+
+        self.assertTrue(self.action(signal, dry_run=False))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
+        self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
+
+        self.assertIn('Is dit de eerste vraag?', mail.outbox[0].body)
+        self.assertIn('Ja, en dit is het antwoord op de eerste vraag', mail.outbox[0].body)
+        self.assertIn('Overig lichtpunt, Lichtpunt niet op de kaart, not-on-map', mail.outbox[0].body)
+        self.assertEqual(Note.objects.count(), 1)
+        self.assertTrue(Note.objects.filter(text=self.action.note).exists())
+
 
 class TestSignalHandledAction(ActionTestMixin, TestCase):
     """

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -327,6 +327,25 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
                     "type": "not-on-map"
                 }],
                 "category_url": "/signals/v1/public/terms/categories/overig/sub_categories/overig"
+            }, {
+                "id": "extra_straatverlichting_probleem",
+                "label": "Probleem",
+                "category_url": "/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/lantaarnpaal-straatverlichting",  # noqa
+                "answer": {
+                    "id": "lamp_doet_het_niet",
+                    "label": "Lamp doet het niet",
+                    "info": ""
+                }
+            },
+            {
+                "id": "extra_straatverlichting",
+                "label": "Denkt u dat de situatie gevaarlijk is?",
+                "category_url": "/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/lantaarnpaal-straatverlichting",  # noqa
+                "answer": {
+                    "id": "niet_gevaarlijk",
+                    "label": "Nee, niet gevaarlijk",
+                    "info": ""
+                }
             }
         ]
 
@@ -342,6 +361,10 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
         self.assertIn('Is dit de eerste vraag?', mail.outbox[0].body)
         self.assertIn('Ja, en dit is het antwoord op de eerste vraag', mail.outbox[0].body)
         self.assertIn('Overig lichtpunt, Lichtpunt niet op de kaart, not-on-map', mail.outbox[0].body)
+        self.assertIn('Probleem', mail.outbox[0].body)
+        self.assertIn('Lamp doet het niet', mail.outbox[0].body)
+        self.assertIn('Denkt u dat de situatie gevaarlijk is?', mail.outbox[0].body)
+        self.assertIn('Nee, niet gevaarlijk', mail.outbox[0].body)
         self.assertEqual(Note.objects.count(), 1)
         self.assertTrue(Note.objects.filter(text=self.action.note).exists())
 


### PR DESCRIPTION
## Description

When a Signal is created an email is sent to the reporter (if he/she leaves an email address). When contacting the municipality (and vica versa) it was confusing for the reporter which questions where asked and what the given answers where. Therefore the functionality to confirm this information to the reporter was requested.

In this PR the extra_properties "uitvraag" are added to the email template context for the signal created email.

The additional information in the signal created email could look something like:
![Screenshot from 2022-04-20 13-52-35](https://user-images.githubusercontent.com/23056530/164224707-62224f2c-0368-4475-a75f-e8c94a27c1e9.png)

For this example the template looks like:
![Screenshot from 2022-04-20 13-58-17](https://user-images.githubusercontent.com/23056530/164225579-1ecb0a9d-85fb-4b7a-8574-dbaf9c477991.png)

Also the Django admin page for editing the email template is updated to provide all template specific context variables in the help text.

![Screenshot from 2022-04-20 13-56-49](https://user-images.githubusercontent.com/23056530/164225239-3b651eef-0e06-425d-b43e-341c273dec23.png)

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
