### PR TITLE
Fixed 'NoneType' object is not iterable

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/signal_created.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_created.py
@@ -61,6 +61,9 @@ class SignalCreatedAction(AbstractAction):
         Renders the extra properties of the signals as a dict of key-value pairs so that they can be rendered in the
         email template.
         """
+        if not extra_properties:
+            return {}
+
         context = {}
         for extra_property in extra_properties:
             context[extra_property['label']] = []

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -368,6 +368,25 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
         self.assertEqual(Note.objects.count(), 1)
         self.assertTrue(Note.objects.filter(text=self.action.note).exists())
 
+    def test_signal_created_with_extra_properties_set_to_none(self):
+        email_template = EmailTemplate.objects.get(key=EmailTemplate.SIGNAL_CREATED)
+        email_template.body = '{% for label, answers in extra_properties.items %}{{ label }} {% for answer in answers %}{{ answer}}{% if not forloop.last %}, {% endif %}{% endfor %} {% endfor %}'  # noqa
+        email_template.save()
+
+        self.assertEqual(len(mail.outbox), 0)
+
+        signal = SignalFactory.create(status__state=self.state, reporter__email='test@example.com',
+                                      extra_properties=None)
+
+        self.assertTrue(self.action(signal, dry_run=False))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
+        self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
+
+        self.assertEqual(Note.objects.count(), 1)
+        self.assertTrue(Note.objects.filter(text=self.action.note).exists())
+
 
 class TestSignalHandledAction(ActionTestMixin, TestCase):
     """


### PR DESCRIPTION
## Description

Fixed 'NoneType' object is not iterable when looping over extra_properties that are none

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
