### PR TITLE
Increase UWSGI buffer size to match Signalen production deployments.

### DIFF
--- a/scripts/initialize.sh
+++ b/scripts/initialize.sh
@@ -50,6 +50,7 @@ uwsgi --master \
   --static-index=index.html \
   --static-map=/signals/static=/static \
   --static-map=/signals/media=/media \
+  --buffer-size=8192 \
   --harakiri=15 \
   --py-auto-reload=1 \
   --die-on-term


### PR DESCRIPTION
## Description

Change UWSGI buffer size setting used for local development to match that of production deployments.

