### PR TITLE
HTTP 400 response for forbidden status transition in email preview

### DIFF
--- a/api/app/signals/apps/api/tests/test_private_signal_email_preview_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_private_signal_email_preview_endpoint.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2022 Gemeente Amsterdam
+from unittest.mock import patch
+
 from django.contrib.auth.models import Permission
 
 from signals.apps.email_integrations.models import EmailTemplate
@@ -161,13 +163,43 @@ class TestPrivateSignalEmailPreview(SIAReadUserMixin, SIAReadWriteUserMixin, Sig
         # no new notes are added to the signal
         self.assertEqual(self.signal.statuses.count(), status_count)
 
-    def test_no_email_preview_available(self):
-        # From GEMELD to REACTIE_ONTVANGEN is not allowed therefore we expect a 404 not found
-        text = f'Lorem ipsum {workflow.REACTIE_ONTVANGEN} ...'
+    @patch('signals.apps.email_integrations.services.MailService')
+    def test_no_email_preview_missing_email_actions(self, patched):
+        # Test handling of missing email rules.
+        patched.actions = []
+
+        text = f'Lorem ipsum {workflow.BEHANDELING} ...'
         endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
 
-        response = self.client.post(endpoint, data={'status': workflow.REACTIE_ONTVANGEN, 'text': text}, format='json')
+        response = self.client.post(endpoint, data={'status': workflow.BEHANDELING, 'text': text}, format='json')
         self.assertEqual(response.status_code, 404)
+
+    def test_no_email_preview_for_forbidden_state_transition(self):
+        # For a forbidden state transition (see workflow.py) we want the same
+        # error message for email previews and (failed) state transitions.
+        text = f'Lorem ipsum {workflow.REACTIE_ONTVANGEN} ...'
+        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
+        signals_endpoint = f'/signals/v1/private/signals/{self.signal.id}'
+
+        response = self.client.post(endpoint, data={'status': workflow.REACTIE_ONTVANGEN, 'text': text}, format='json')
+        self.assertEqual(response.status_code, 400)
+        preview_response_json = response.json()
+
+        response = self.client.patch(
+            signals_endpoint, data={'status': {'state': workflow.REACTIE_ONTVANGEN, 'text': text}}, format='json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), preview_response_json)  # matching error message
+
+    def test_no_email_preview_state_te_verzenden(self):
+        # Test documenting edge case. The workflow.TE_VERZENDEN state has no
+        # email rule and requires the `target_api` property that cannot be set
+        # through the email preview viewset/serializer. In this case we want
+        # an HTTP 400.
+        text = f'Lorem ipsum {workflow.TE_VERZENDEN} ...'
+        endpoint = f'/signals/v1/private/signals/{self.signal.id}/email/preview/'
+
+        response = self.client.post(endpoint, data={'status': workflow.TE_VERZENDEN, 'text': text}, format='json')
+        self.assertEqual(response.status_code, 400)
 
     def test_missing_required_query_parameter(self):
         # The status query parameter is required

--- a/api/app/signals/apps/api/views/signals/private/signals.py
+++ b/api/app/signals/apps/api/views/signals/private/signals.py
@@ -4,7 +4,6 @@ import logging
 
 from datapunt_api.rest import DatapuntViewSet, HALPagination
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.db.models import CharField, Value
 from django.db.models.functions import JSONObject
 from django_filters.rest_framework import DjangoFilterBackend
@@ -269,10 +268,7 @@ class PrivateSignalViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, Dat
         text = post_serializer.validated_data.pop('text', None)
 
         status_data = {'state': status, 'text': text, 'send_email': True}
-        try:
-            subject, _, html_message = trigger_mail_action_for_email_preview(signal, status_data)
-        except ValidationError:
-            raise NotFound('No email preview available for given status transition')
+        subject, _, html_message = trigger_mail_action_for_email_preview(signal, status_data)
 
         context = self.get_serializer_context()
         context.update({'email_preview': {'subject': subject, 'html_message': html_message}})


### PR DESCRIPTION
## Description

We were getting inconsistent error messages in the backoffice frontend UI when using the email preview. An email preview could be attempted for a forbidden state transition and that would lead to a no email template present error. The actual problem was that the state transition was not allowed.

This PR matches the  error message for a forbidden state transition in email preview to the normal error message one would get for a forbidden state transition.

(proposed fix for: https://github.com/Signalen/product-steering/issues/139)

TODO:
* [X] ~check whether the frontend can handle this HTTP 400 in stead of HTTP 404~ Checked with @kiruys 

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
