### PR TITLE
Fix parsing extra_properties for email context when sending the signal_created email

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/signal_created.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_created.py
@@ -79,7 +79,9 @@ class SignalCreatedAction(AbstractAction):
         Returns the first option that is available in the extra property and not empty as the answer.
         Defaults to '-' if no option is available.
         """
-        if 'label' in extra_property and extra_property['label']:
+        if isinstance(extra_property, str):
+            return extra_property
+        elif 'label' in extra_property and extra_property['label']:
             return extra_property['label']
         elif 'value' in extra_property and extra_property['value']:
             return extra_property['value']

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -346,6 +346,12 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
                     "label": "Nee, niet gevaarlijk",
                     "info": ""
                 }
+            },
+            {
+                "id": "extra_fietswrak",
+                "label": "Extra informatie",
+                "answer": "2 wrakken met hele oude gemeentelijke labels en 2 tegen een lantaarnpaal in het gras en nog een losse zwarte met zachte band",  # noqa
+                "category_url": "/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/fietswrak"  # noqa
             }
         ]
 


### PR DESCRIPTION
## Description

Fixed a bug when parsing the extra_properties for the signal_created email context. An answer in the extra_properties can also be just a string

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
