### PR TITLE
Add Location question field type to VNG style Question model

### DIFF
--- a/api/app/signals/apps/signals/migrations/0158_alter_question_field_type.py
+++ b/api/app/signals/apps/signals/migrations/0158_alter_question_field_type.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0157_new_subcategories'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='question',
+            name='field_type',
+            field=models.CharField(
+                choices=[
+                    ('plain_text', 'PlainText'),
+                    ('text_input', 'TextInput'),
+                    ('multi_text_input', 'MultiTextInput'),
+                    ('checkbox_input', 'CheckboxInput'),
+                    ('radio_input', 'RadioInput'),
+                    ('select_input', 'SelectInput'),
+                    ('text_area_input', 'TextareaInput'),
+                    ('asset_select', 'AssetSelect'),
+                    ('location_select', 'LocationSelect')
+                ],
+                default='plain_text',
+                max_length=32
+            ),
+        ),
+    ]

--- a/api/app/signals/apps/signals/models/question.py
+++ b/api/app/signals/apps/signals/models/question.py
@@ -12,6 +12,7 @@ class Question(models.Model):
     SELECT_INPUT = 'select_input'
     TEXT_AREA_INPUT = 'text_area_input'
     ASSET_SELECT = 'asset_select'
+    LOCATION = 'location'
 
     FIELD_TYPE_CHOICES = (
         (PLAIN_TEXT, 'PlainText'),
@@ -22,6 +23,7 @@ class Question(models.Model):
         (SELECT_INPUT, 'SelectInput'),
         (TEXT_AREA_INPUT, 'TextareaInput'),
         (ASSET_SELECT, 'AssetSelect'),
+        (LOCATION, 'Location')
     )
 
     key = models.CharField(max_length=255)

--- a/api/app/signals/apps/signals/models/question.py
+++ b/api/app/signals/apps/signals/models/question.py
@@ -12,7 +12,7 @@ class Question(models.Model):
     SELECT_INPUT = 'select_input'
     TEXT_AREA_INPUT = 'text_area_input'
     ASSET_SELECT = 'asset_select'
-    LOCATION = 'location'
+    LOCATION_SELECT = 'location_select'
 
     FIELD_TYPE_CHOICES = (
         (PLAIN_TEXT, 'PlainText'),
@@ -23,7 +23,7 @@ class Question(models.Model):
         (SELECT_INPUT, 'SelectInput'),
         (TEXT_AREA_INPUT, 'TextareaInput'),
         (ASSET_SELECT, 'AssetSelect'),
-        (LOCATION, 'Location')
+        (LOCATION_SELECT, 'LocationSelect')
     )
 
     key = models.CharField(max_length=255)


### PR DESCRIPTION
## Description

To be able to apply special case logic to the location question (where is the nuisance complaint) we create a special field type. This way we do not have to apply too much fuzzy logic to the AssetSelect questions.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
