### PR TITLE
Sig 4556

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/__init__.py
+++ b/api/app/signals/apps/email_integrations/actions/__init__.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2021 - 2022 Gemeente Amsterdam
 from signals.apps.email_integrations.actions.signal_created import SignalCreatedAction
 from signals.apps.email_integrations.actions.signal_handeld import SignalHandledAction
+from signals.apps.email_integrations.actions.signal_handeld_negative_contact import (
+    SignalHandledNegativeAction
+)
 from signals.apps.email_integrations.actions.signal_optional import SignalOptionalAction
 from signals.apps.email_integrations.actions.signal_reaction_request import (
     SignalReactionRequestAction
@@ -15,6 +18,7 @@ from signals.apps.email_integrations.actions.signal_scheduled import SignalSched
 __all__ = [
     'SignalCreatedAction',
     'SignalHandledAction',
+    'SignalHandledNegativeAction',
     'SignalScheduledAction',
     'SignalReopenedAction',
     'SignalOptionalAction',

--- a/api/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+import logging
+
+from signals.apps.email_integrations.actions.abstract import AbstractAction
+from signals.apps.email_integrations.models import EmailTemplate
+from signals.apps.email_integrations.rules import SignalHandledNegativeRule
+
+logger = logging.getLogger(__name__)
+
+
+class SignalHandledNegativeAction(AbstractAction):
+    rule = SignalHandledNegativeRule()
+
+    key = EmailTemplate.Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT
+    subject = 'Meer over uw melding {signal_id}'
+
+    note = 'Automatische e-mail bij afhandelen heropenen negatieve feedback'

--- a/api/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class SignalHandledNegativeAction(AbstractAction):
     rule = SignalHandledNegativeRule()
 
-    key = EmailTemplate.Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT
+    key = EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT
     subject = 'Meer over uw melding {signal_id}'
 
     note = 'Automatische e-mail bij afhandelen heropenen negatieve feedback'

--- a/api/app/signals/apps/email_integrations/migrations/0005_alter_emailtemplate_key.py
+++ b/api/app/signals/apps/email_integrations/migrations/0005_alter_emailtemplate_key.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam
+# Copyright (C) 2022 Gemeente Amsterdam
 from django.db import migrations, models
 
 

--- a/api/app/signals/apps/email_integrations/models.py
+++ b/api/app/signals/apps/email_integrations/models.py
@@ -25,7 +25,7 @@ class EmailTemplate(CreatedUpdatedModel):
         (SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD, 'Send mail signal reaction requested'),
         (SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN, 'Send mail signal reaction requested received'),
         (SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN, 'Send mail signal reaction requested received'),
-        (SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT, 'Send mail signal '),
+        (SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT, 'Send mail signal'),
         (SIGNAL_FEEDBACK_RECEIVED, 'Send mail signal feedback received'),
     ]
 

--- a/api/app/signals/apps/email_integrations/models.py
+++ b/api/app/signals/apps/email_integrations/models.py
@@ -13,6 +13,7 @@ class EmailTemplate(CreatedUpdatedModel):
     SIGNAL_STATUS_CHANGED_OPTIONAL = 'signal_status_changed_optional'
     SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD = 'signal_status_changed_reactie_gevraagd'
     SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN = 'signal_status_changed_reactie_ontvangen'
+    Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT = 'signal_status_changed_afgehandeld_kto_negative_contact'
 
     KEYS_CHOICES = [
         (SIGNAL_CREATED, 'Send mail signal created'),
@@ -21,7 +22,8 @@ class EmailTemplate(CreatedUpdatedModel):
         (SIGNAL_STATUS_CHANGED_HEROPEND, 'Send mail signal reopened'),
         (SIGNAL_STATUS_CHANGED_OPTIONAL, 'Send mail optional'),
         (SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD, 'Send mail signal reaction requested'),
-        (SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN, 'Send mail signal reaction requested received')
+        (SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN, 'Send mail signal reaction requested received'),
+        (Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT, 'Send mail signal '),
     ]
 
     key = models.CharField(max_length=100, choices=KEYS_CHOICES, db_index=True)

--- a/api/app/signals/apps/email_integrations/models.py
+++ b/api/app/signals/apps/email_integrations/models.py
@@ -13,7 +13,7 @@ class EmailTemplate(CreatedUpdatedModel):
     SIGNAL_STATUS_CHANGED_OPTIONAL = 'signal_status_changed_optional'
     SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD = 'signal_status_changed_reactie_gevraagd'
     SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN = 'signal_status_changed_reactie_ontvangen'
-    Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT = 'signal_status_changed_afgehandeld_kto_negative_contact'
+    SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT = 'signal_status_changed_afgehandeld_kto_negative_contact'
     SIGNAL_FEEDBACK_RECEIVED = 'signal_feedback_received'
 
     KEYS_CHOICES = [
@@ -25,7 +25,7 @@ class EmailTemplate(CreatedUpdatedModel):
         (SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD, 'Send mail signal reaction requested'),
         (SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN, 'Send mail signal reaction requested received'),
         (SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN, 'Send mail signal reaction requested received'),
-        (Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT, 'Send mail signal '),
+        (SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT, 'Send mail signal '),
         (SIGNAL_FEEDBACK_RECEIVED, 'Send mail signal feedback received'),
     ]
 

--- a/api/app/signals/apps/email_integrations/rules/__init__.py
+++ b/api/app/signals/apps/email_integrations/rules/__init__.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2021 - 2022 Gemeente Amsterdam
 from signals.apps.email_integrations.rules.signal_created import SignalCreatedRule
 from signals.apps.email_integrations.rules.signal_handeld import SignalHandledRule
+from signals.apps.email_integrations.rules.signal_handeld_negative_contact import (
+    SignalHandledNegativeRule
+)
 from signals.apps.email_integrations.rules.signal_optional import SignalOptionalRule
 from signals.apps.email_integrations.rules.signal_reaction_request import SignalReactionRequestRule
 from signals.apps.email_integrations.rules.signal_reaction_request_received import (
@@ -18,4 +21,5 @@ __all__ = [
     'SignalOptionalRule',
     'SignalReactionRequestRule',
     'SignalReactionRequestReceivedRule',
+    'SignalHandledNegativeRule',
 ]

--- a/api/app/signals/apps/email_integrations/rules/signal_handeld_negative_contact.py
+++ b/api/app/signals/apps/email_integrations/rules/signal_handeld_negative_contact.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+from signals.apps.email_integrations.rules.abstract import AbstractRule
+from signals.apps.signals.models import Status
+from signals.apps.signals.workflow import AFGEHANDELD, VERZOEK_TOT_HEROPENEN
+
+
+class SignalHandledNegativeRule(AbstractRule):
+
+    def _validate_status(self, status):
+        """
+        Run status validations for the Rule
+
+        - The status is AFGEHANDELD
+        - The previous state is VERZOEK_TOT_HEROPENEN
+        - latest feed has allows_contact set True
+        """
+
+        return self._validate_status_state(status) and \
+            self._validate_previous_state_VERZOEK_TOT_HEROPENEN(status) and \
+            self._is_allows_contact(status)
+
+    def _validate_status_state(self, status):
+        """
+        Validate that the status is AFGEHANDELD
+        """
+        return status.state == AFGEHANDELD
+
+    def _validate_previous_state_VERZOEK_TOT_HEROPENEN(self, status) -> bool:
+        """
+        Validate that the previous state is VERZOEK_TOT_HEROPENEN
+        """
+
+        return Status.objects.filter(
+            _signal_id=status._signal_id
+        ).exclude(
+            id=status.id
+        ).order_by('-created_at').values_list(
+            'state',
+            flat=True
+        ).first() == VERZOEK_TOT_HEROPENEN
+
+    def _is_allows_contact(self, status) -> bool:
+        """
+        check if the feedback from the signal is to allow contact with the user.
+        """
+        try:
+            return status._signal.feedback.last().allows_contact
+        except AttributeError:
+            # if no feedback exists return False
+            return False

--- a/api/app/signals/apps/email_integrations/rules/signal_handeld_negative_contact.py
+++ b/api/app/signals/apps/email_integrations/rules/signal_handeld_negative_contact.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2022 Gemeente Amsterdam
+from django.conf import settings
+
 from signals.apps.email_integrations.rules.abstract import AbstractRule
 from signals.apps.signals.models import Status
 from signals.apps.signals.workflow import AFGEHANDELD, VERZOEK_TOT_HEROPENEN
@@ -49,3 +51,6 @@ class SignalHandledNegativeRule(AbstractRule):
         except AttributeError:
             # if no feedback exists return False
             return False
+
+    def _validate(self, signal):
+        return settings.FEATURE_FLAGS.get('REPORTER_MAIL_HANDLED_NEGATIVE_CONTACT_ENABLED', True)

--- a/api/app/signals/apps/email_integrations/services.py
+++ b/api/app/signals/apps/email_integrations/services.py
@@ -3,6 +3,7 @@
 from signals.apps.email_integrations.actions import (
     SignalCreatedAction,
     SignalHandledAction,
+    SignalHandledNegativeAction,
     SignalOptionalAction,
     SignalReactionRequestAction,
     SignalReactionRequestReceivedAction,
@@ -21,6 +22,7 @@ class MailService:
         SignalOptionalAction(),
         SignalReactionRequestAction(),
         SignalReactionRequestReceivedAction(),
+        SignalHandledNegativeAction()
     )
 
     @staticmethod

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -68,6 +68,12 @@ class ActionTestMixin:
                                      body='{{ text }} {{ created_at }} {{ reaction_request_answer }} '
                                           '{{ ORGANIZATION_NAME }}')
 
+        EmailTemplate.objects.create(key=EmailTemplate.Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT,
+                                     title='Uw melding {{ signal_id }}'
+                                           f' {EmailTemplate.Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT}',
+                                     body='{{ text }} {{ created_at }} {{ reaction_request_answer }} '
+                                          '{{ ORGANIZATION_NAME }}')
+
     def test_send_email(self):
         self.assertEqual(len(mail.outbox), 0)
 

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -71,9 +71,9 @@ class ActionTestMixin:
                                      body='{{ text }} {{ created_at }} {{ reaction_request_answer }} '
                                           '{{ ORGANIZATION_NAME }}')
 
-        EmailTemplate.objects.create(key=EmailTemplate.Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT,
+        EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT,
                                      title='Uw melding {{ signal_id }}'
-                                           f' {EmailTemplate.Signal_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT}',
+                                           f' {EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT}',
                                      body='{{ text }} {{ created_at }} {{ reaction_request_answer }} '
                                           '{{ ORGANIZATION_NAME }}')
 

--- a/api/app/signals/apps/email_integrations/tests/test_services.py
+++ b/api/app/signals/apps/email_integrations/tests/test_services.py
@@ -6,8 +6,9 @@ from django.test import TestCase
 
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.services import MailService
+from signals.apps.feedback.factories import FeedbackFactory
 from signals.apps.signals import workflow
-from signals.apps.signals.factories import SignalFactory
+from signals.apps.signals.factories import SignalFactory, StatusFactory
 from signals.apps.signals.models import Note
 
 
@@ -24,6 +25,30 @@ class TestMailActions(TestCase):
         self.assertTrue(MailService.mail(signal))
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id}')
+        self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
+        self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
+        self.assertEqual(Note.objects.count(), 1)
+
+    def test_only_send_feedback_negative_contact_mail(self):
+        """
+        Test to see if when a status is changed from VERZOEK_TOT_AFHANDELING to AFGEHANDELD and has allows_contact on
+        the feedback to only send one email
+        """
+        self.assertEqual(len(mail.outbox), 0)
+        signal = SignalFactory.create(status__state=workflow.VERZOEK_TOT_AFHANDELING,
+                                      reporter__email='test@example.com')
+        status = StatusFactory.create(_signal=signal, state=workflow.AFGEHANDELD)
+        feedback = FeedbackFactory.create(
+            allows_contact=True,
+            _signal=signal,
+        )
+        feedback.save()
+        signal.status = status  # change to new status AFGEHANDELD
+        signal.save()
+
+        self.assertTrue(MailService.mail(signal))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, f'Meer over uw melding {signal.id}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(Note.objects.count(), 1)

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -426,7 +426,7 @@ FEATURE_FLAGS = {
     # Enabled the history_log based response, disables the signal_history_view based response
     'SIGNAL_HISTORY_LOG_ENABLED': os.getenv('SIGNAL_HISTORY_LOG_ENABLED', False) in TRUE_VALUES,
     'API_USE_QUESTIONNAIRES_APP_FOR_FEEDBACK': os.getenv('API_USE_QUESTIONNAIRES_APP_FOR_FEEDBACK', False) in TRUE_VALUES,  # noqa
-
+    'REPORTER_MAIL_HANDLED_NEGATIVE_CONTACT_ENABLED': os.getenv('REPORTER_MAIL_HANDLED_NEGATIVE_CONTACT_ENABLED', True) in TRUE_VALUES, # noqa
     # Temporary added to exclude permissions in the signals/v1/permissions endpoint that are not yet implemented in
     # the frontend
     # TODO: Remove this when the frontend is updated


### PR DESCRIPTION
## Description

Add a new mail status action that triggers when changing from "VERZOEK_TOT_HEROPENEN " to "AFGEHANDELD" and where the feedback allows for contact to the user. 

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
