### PR TITLE
add extra feedback parameters for the email template

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/feedback_received_action.py
+++ b/api/app/signals/apps/email_integrations/actions/feedback_received_action.py
@@ -17,6 +17,8 @@ class FeedbackReceivedAction(AbstractSystemAction):
 
     def get_additional_context(self, signal, dry_run=False):
         return {
+            'feedback_allows_contact': self.kwargs['feedback'].allows_contact,
+            'feedback_is_satisfied': self.kwargs['feedback'].is_satisfied,
             'feedback_text': self.kwargs['feedback'].text,
             'feedback_text_extra': self.kwargs['feedback'].text_extra
         }

--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -93,6 +93,13 @@
         <ul>
             <li>reaction_request_answer</li>
         </ul>
+        <h4>Send mail signal feedback received</h4>
+        <ul>
+            <li>feedback_allows_contact</li>
+            <li>feedback_is_satisfied</li>
+            <li>feedback_text</li>
+            <li>feedback_text_extra</li>
+        </ul>
     </div>
 
     {{ block.super }}

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -661,7 +661,8 @@ class TestSignalSystemActions(TestCase):
 
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_FEEDBACK_RECEIVED,
                                      title='Uw feedback is ontvangen',
-                                     body='{{ feedback_text }} {{ feedback_text_extra }}')
+                                     body='{{ feedback_text }} {{ feedback_text_extra }} '
+                                          '{{ feedback_allows_contact }} {{ feedback_is_satisfied }}')
 
     def test_system_action_rule(self):
         """
@@ -708,6 +709,8 @@ class TestSignalSystemActions(TestCase):
         feedback = FeedbackFactory.create(
             text=text,
             text_extra=text_extra,
+            allows_contact=True,
+            is_satisfied=False,
             token=uuid.uuid4(),
             _signal=signal
         )
@@ -718,5 +721,9 @@ class TestSignalSystemActions(TestCase):
 
         self.assertIn('feedback_text', result)
         self.assertIn('feedback_text_extra', result)
+        self.assertIn('feedback_allows_contact', result)
+        self.assertIn('feedback_is_satisfied', result)
         self.assertEqual(result['feedback_text'], text)
         self.assertEqual(result['feedback_text_extra'], text_extra)
+        self.assertTrue(result['feedback_allows_contact'])
+        self.assertFalse(result['feedback_is_satisfied'])


### PR DESCRIPTION
## Description
Add extra feedback parameters for the email template

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
