### PR TITLE
Added a feature flag to enable/disable the system mail action for FeedbackReceived

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/feedback_received_action.py
+++ b/api/app/signals/apps/email_integrations/actions/feedback_received_action.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import logging
 
+from django.conf import settings
+
 from signals.apps.email_integrations.actions.abstract import AbstractSystemAction
 from signals.apps.email_integrations.models import EmailTemplate
 
@@ -10,6 +12,9 @@ logger = logging.getLogger(__name__)
 
 class FeedbackReceivedAction(AbstractSystemAction):
     _required_call_kwargs = ('feedback',)
+
+    # Rule must check if the feature flag for this system mail is enabled
+    rule = lambda self, signal: settings.FEATURE_FLAGS.get('SYSTEM_MAIL_FEEDBACK_RECEIVED_ENABLED', True)  # noqa: E731
 
     key = EmailTemplate.SIGNAL_FEEDBACK_RECEIVED
     subject = 'Bedankt voor uw feedback'

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -435,6 +435,9 @@ FEATURE_FLAGS = {
                                                   'sia_delete_attachment_of_parent_signal,'
                                                   'sia_delete_attachment_of_child_signal,'
                                                   'sia_delete_attachment_of_other_user').split(','),
+
+    # Enable system mail for Feedback Received
+    'SYSTEM_MAIL_FEEDBACK_RECEIVED_ENABLED': os.getenv('SYSTEM_MAIL_FEEDBACK_RECEIVED_ENABLED', True) in TRUE_VALUES,  # noqa
 }
 
 API_DETERMINE_STADSDEEL_ENABLED_AREA_TYPE = 'sia-stadsdeel'


### PR DESCRIPTION
## Description

Added a feature flag to enable/disable the system mail action for FeedbackReceived

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
