### PR TITLE
add feedback context to the new email rule + unit tests

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
@@ -16,3 +16,19 @@ class SignalHandledNegativeAction(AbstractAction):
     subject = 'Meer over uw melding {signal_id}'
 
     note = 'Automatische e-mail bij afhandelen heropenen negatieve feedback'
+
+    def get_additional_context(self, signal, dry_run=False):
+        """
+        Add the extra feedback essences to the email template
+        """
+        feedback = signal.feedback.last()
+
+        if not feedback:
+            return {}
+
+        return {
+            'feedback_allows_contact': feedback.allows_contact,
+            'feedback_is_satisfied': feedback.is_satisfied,
+            'feedback_text': feedback.text,
+            'feedback_text_extra': feedback.text_extra
+        }

--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -93,7 +93,7 @@
         <ul>
             <li>reaction_request_answer</li>
         </ul>
-        <h4>Send mail signal feedback received</h4>
+        <h4>Send mail signal feedback received & Send mail signal negative KTO contact</h4>
         <ul>
             <li>feedback_allows_contact</li>
             <li>feedback_is_satisfied</li>


### PR DESCRIPTION
## Description

add the feedback context to the new mail action for the email template

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
