### PR TITLE
Add note to history on upload of attachment.

### DIFF
--- a/api/app/signals/apps/api/serializers/attachment.py
+++ b/api/app/signals/apps/api/serializers/attachment.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
+import os
 from datetime import timedelta
 
 from datapunt_api.rest import DisplayField, HALSerializer
@@ -24,11 +25,21 @@ PUBLIC_UPLOAD_ALLOWED_STATES = (AFGEHANDELD, GEMELD, REACTIE_GEVRAAGD)
 
 class SignalAttachmentSerializerMixin:
     def create(self, validated_data):
-        attachment = Signal.actions.add_attachment(validated_data['file'], self.context['view'].get_signal())
+        user = self.context['request'].user
+        signal = self.context['view'].get_signal()
 
-        if self.context['request'].user:
-            attachment.created_by = self.context['request'].user.email
+        # save our attachment
+        attachment = Signal.actions.add_attachment(validated_data['file'], signal)
+        if user:
+            attachment.created_by = user.email
             attachment.save()
+
+        # add a note that an attachment (currently only images allowed) was uploaded
+        filename = os.path.basename(attachment.file.name)
+        msg = f'Foto toegevoegd door melder: {filename}'
+        if user:
+            msg = f'Foto toegevoegd door {user.email}: {filename}'
+        Signal.actions.create_note({'text': msg}, self.context['view'].get_signal())
 
         return attachment
 

--- a/api/app/signals/apps/api/tests/test_private_signal_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_private_signal_endpoint.py
@@ -36,7 +36,7 @@ from signals.apps.signals.factories import (
     SourceFactory
 )
 from signals.apps.signals.factories.category_departments import CategoryDepartmentFactory
-from signals.apps.signals.models import STADSDEEL_CENTRUM, Attachment, Signal
+from signals.apps.signals.models import STADSDEEL_CENTRUM, Attachment, Note, Signal
 from signals.apps.signals.tests.attachment_helpers import (
     add_image_attachments,
     add_non_image_attachments,
@@ -530,6 +530,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
     def test_create_initial_and_upload_image(self, validate_address):
         attachment_count = Attachment.objects.count()
         attachments_url = self.detail_endpoint.format(pk=self.signal_no_image.pk) + '/attachments/'
+        note_count = Note.objects.count()
 
         image = SimpleUploadedFile('image.gif', small_gif, content_type='image/gif')
         response = self.client.post(attachments_url, data={'file': image})
@@ -544,6 +545,16 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         self.assertEqual(Attachment.objects.count(), attachment_count + 2)
         for attachment in Attachment.objects.all().order_by('created_at')[attachment_count:]:
             self.assertEqual(self.sia_read_write_user.email, attachment.created_by)
+
+        # Check that history contains notes that show photo's were uploaded.
+        self.assertEqual(Note.objects.count(), note_count + 2)
+
+        note_qs = Note.objects.filter(_signal=self.signal_no_image).order_by('created_at')
+        attachment_qs = Attachment.objects.filter(_signal=self.signal_no_image).order_by('created_at')
+
+        for note, attachment in zip(note_qs, attachment_qs):
+            filename = os.path.basename(attachment.file.name)
+            self.assertIn(f'Foto toegevoegd door {self.sia_read_write_user}: {filename}', note.text)
 
     @patch("signals.apps.api.validation.address.base.BaseAddressValidation.validate_address",
            side_effect=AddressValidationUnavailableException)  # Skip address validation


### PR DESCRIPTION
## Description

The UX design for managing attachments contained history entries for uploaded images. This PR implements these history entries as notes in the history for a Signal.

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
