### PR TITLE
chore/SIG-3643

### DIFF
--- a/api/app/signals/apps/api/pdf/mixins.py
+++ b/api/app/signals/apps/api/pdf/mixins.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam
 from django.views.generic.base import TemplateResponseMixin
 
 from signals.apps.api.pdf.response import PDFTemplateResponse

--- a/api/app/signals/apps/api/pdf/mixins.py
+++ b/api/app/signals/apps/api/pdf/mixins.py
@@ -12,7 +12,7 @@ class PDFTemplateResponseMixin(TemplateResponseMixin):
 
     def get_pdf_filename(self):
         if not self.pdf_filename:
-            self.pdf_filename = 'Signalen-{}.pdf'.format(self.object.pk)
+            self.pdf_filename = f'{self.object.get_id_display()}.pdf'
         return self.pdf_filename
 
     def render_to_response(self, context, **response_kwargs):

--- a/api/app/signals/apps/api/serializers/signal.py
+++ b/api/app/signals/apps/api/serializers/signal.py
@@ -178,6 +178,7 @@ class PrivateSignalSerializerDetail(HALSerializer, AddressValidationMixin):
         ]
     )
 
+    id_display = serializers.CharField(source='get_id_display', read_only=True)
     attachments = PrivateSignalAttachmentRelatedField(view_name='private-signals-attachments-detail', many=True,
                                                       required=False, read_only=True)
 
@@ -188,6 +189,7 @@ class PrivateSignalSerializerDetail(HALSerializer, AddressValidationMixin):
             '_display',
             'category',
             'id',
+            'id_display',
             'has_attachments',
             'location',
             'status',
@@ -347,6 +349,8 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
     # The Session containing the given answers of a Questionnaire
     session = serializers.UUIDField(default=None, write_only=True, required=False)
 
+    id_display = serializers.CharField(source='get_id_display', read_only=True)
+
     class Meta:
         model = Signal
         list_serializer_class = _SignalListSerializer
@@ -354,6 +358,7 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
             '_links',
             '_display',
             'id',
+            'id_display',
             'signal_id',
             'source',
             'text',

--- a/api/app/signals/apps/api/serializers/signal.py
+++ b/api/app/signals/apps/api/serializers/signal.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2022 Gemeente Amsterdam
 import os
 
 from datapunt_api.rest import DisplayField, HALSerializer

--- a/api/app/signals/apps/api/templates/api/pdf/print_signal.html
+++ b/api/app/signals/apps/api/templates/api/pdf/print_signal.html
@@ -2,7 +2,7 @@
 <html>
 <head lang="en">
     <meta charset="UTF-8">
-    <title>Melding Signalen-{{ signal.id }} </title>
+    <title>Melding {{ signal.get_id_display }} </title>
     <style type="text/css">
         * {
             font-family: Avenir Next LT W01 Demi,arial,sans-serif;
@@ -99,7 +99,7 @@
         </table>
     </div>
 
-    <h1>Signalen-{{ signal.id }}</h1>
+    <h1>{{ signal.get_id_display }}</h1>
     <div style="width: 680px; height: 250px; background-color: lightgray; margin-bottom: 25px; position:relative; top:0px; left:0px;">
         {% if img_data_uri %}
         <img src="{{img_data_uri}}" style="position:relative; top:0px; left:0px;"/>
@@ -114,7 +114,7 @@
         {% if signal.is_child %}
         <tr>
             <td>Hoofdmelding</td>
-            <td>: Signalen-{{ signal.parent.id }}</td>
+            <td>: {{ signal.parent.get_id_display }}</td>
         </tr>
         {% endif %}
         <tr>

--- a/api/app/signals/apps/api/tests/test_pdf.py
+++ b/api/app/signals/apps/api/tests/test_pdf.py
@@ -21,7 +21,7 @@ class TestPDFView(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(response.get('Content-Type'), 'application/pdf')
         self.assertEqual(
             response.get('Content-Disposition'),
-            'attachment;filename="Signalen-{}.pdf"'.format(self.signal.pk)
+            f'attachment;filename="{self.signal.get_id_display()}.pdf"'
         )
 
     def test_get_pdf_signal_does_not_exists(self):

--- a/api/app/signals/apps/api/tests/test_pdf.py
+++ b/api/app/signals/apps/api/tests/test_pdf.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam
 
 from django.contrib.auth.models import Permission
 

--- a/api/app/signals/apps/api/tests/test_private_signal_email_preview_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_private_signal_email_preview_endpoint.py
@@ -116,7 +116,7 @@ class TestPrivateSignalEmailPreview(SIAReadUserMixin, SIAReadWriteUserMixin, Sig
             self.assertEqual(response.status_code, 200)
 
             response_data = response.json()
-            self.assertEqual(f'Meer over uw melding {self.signal.id}', response_data['subject'])
+            self.assertEqual(f'Meer over uw melding {self.signal.get_id_display()}', response_data['subject'])
             self.assertIn(text, response_data['html'])
 
             # Refresh the Signal
@@ -148,7 +148,7 @@ class TestPrivateSignalEmailPreview(SIAReadUserMixin, SIAReadWriteUserMixin, Sig
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
-        self.assertEqual(f'Meer over uw melding {self.signal.id}', response_data['subject'])
+        self.assertEqual(f'Meer over uw melding {self.signal.get_id_display()}', response_data['subject'])
         self.assertIn(text, response_data['html'])
 
         # Refresh the Signal

--- a/api/app/signals/apps/email_integrations/actions/abstract.py
+++ b/api/app/signals/apps/email_integrations/actions/abstract.py
@@ -82,7 +82,7 @@ class AbstractAction(ABC):
         except EmailTemplate.DoesNotExist:
             logger.warning(f'EmailTemplate {self.key} does not exists')
 
-            subject = self.subject.format(signal_id=context['signal_id'])
+            subject = self.subject.format(formatted_signal_id=context['formatted_signal_id'])
             message = loader.get_template('email/signal_default.txt').render(context)
             html_message = loader.get_template('email/signal_default.html').render(context)
 

--- a/api/app/signals/apps/email_integrations/actions/signal_created.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_created.py
@@ -13,7 +13,7 @@ class SignalCreatedAction(AbstractAction):
     rule = SignalCreatedRule()
 
     key = EmailTemplate.SIGNAL_CREATED
-    subject = 'Bedankt voor uw melding {signal_id}'
+    subject = 'Bedankt voor uw melding {formatted_signal_id}'
 
     note = 'Automatische e-mail bij registratie van de melding is verzonden aan de melder.'
 

--- a/api/app/signals/apps/email_integrations/actions/signal_handeld.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_handeld.py
@@ -14,7 +14,7 @@ class SignalHandledAction(AbstractAction):
     rule = SignalHandledRule()
 
     key = EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD
-    subject = 'Meer over uw melding {signal_id}'
+    subject = 'Meer over uw melding {formatted_signal_id}'
 
     note = 'Automatische e-mail bij afhandelen is verzonden aan de melder.'
 

--- a/api/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
@@ -13,7 +13,7 @@ class SignalHandledNegativeAction(AbstractAction):
     rule = SignalHandledNegativeRule()
 
     key = EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT
-    subject = 'Meer over uw melding {signal_id}'
+    subject = 'Meer over uw melding {formatted_signal_id}'
 
     note = 'Automatische e-mail bij afhandelen heropenen negatieve feedback'
 

--- a/api/app/signals/apps/email_integrations/actions/signal_optional.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_optional.py
@@ -13,7 +13,7 @@ class SignalOptionalAction(AbstractAction):
     rule = SignalOptionalRule()
 
     key = EmailTemplate.SIGNAL_STATUS_CHANGED_OPTIONAL
-    subject = 'Meer over uw melding {signal_id}'
+    subject = 'Meer over uw melding {formatted_signal_id}'
 
     note = 'De statusupdate is per e-mail verzonden aan de melder'
 

--- a/api/app/signals/apps/email_integrations/actions/signal_reaction_request.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_reaction_request.py
@@ -14,7 +14,7 @@ class SignalReactionRequestAction(AbstractAction):
     rule = SignalReactionRequestRule()
 
     key = EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD
-    subject = 'Meer over uw melding {signal_id}'
+    subject = 'Meer over uw melding {formatted_signal_id}'
 
     note = 'E-mail met vraag verstuurd aan melder'
 

--- a/api/app/signals/apps/email_integrations/actions/signal_reaction_request_received.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_reaction_request_received.py
@@ -13,7 +13,7 @@ class SignalReactionRequestReceivedAction(AbstractAction):
     rule = SignalReactionRequestReceivedRule()
 
     key = EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN
-    subject = 'Meer over uw melding {signal_id}'
+    subject = 'Meer over uw melding {formatted_signal_id}'
 
     note = 'Automatische e-mail bij Reactie ontvangen is verzonden aan de melder.'
 

--- a/api/app/signals/apps/email_integrations/actions/signal_reopened.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_reopened.py
@@ -13,6 +13,6 @@ class SignalReopenedAction(AbstractAction):
     rule = SignalReopenedRule()
 
     key = EmailTemplate.SIGNAL_STATUS_CHANGED_HEROPEND
-    subject = 'Meer over uw melding {signal_id}'
+    subject = 'Meer over uw melding {formatted_signal_id}'
 
     note = 'Automatische e-mail bij heropenen is verzonden aan de melder.'

--- a/api/app/signals/apps/email_integrations/actions/signal_scheduled.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_scheduled.py
@@ -13,6 +13,6 @@ class SignalScheduledAction(AbstractAction):
     rule = SignalScheduledRule()
 
     key = EmailTemplate.SIGNAL_STATUS_CHANGED_INGEPLAND
-    subject = 'Meer over uw melding {signal_id}'
+    subject = 'Meer over uw melding {formatted_signal_id}'
 
     note = 'Automatische e-mail bij inplannen is verzonden aan de melder.'

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -35,45 +35,45 @@ class ActionTestMixin:
 
     def setUp(self):
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_CREATED,
-                                     title='Uw melding {{ signal_id }}'
+                                     title='Uw melding {{ formatted_signal_id }}'
                                            f' {EmailTemplate.SIGNAL_CREATED}',
                                      body='{{ text }} {{ created_at }} {{ handling_message }} {{ ORGANIZATION_NAME }}')
 
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD,
-                                     title='Uw melding {{ signal_id }}'
+                                     title='Uw melding {{ formatted_signal_id }}'
                                            f' {EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD}',
                                      body='{{ text }} {{ created_at }} {{ positive_feedback_url }} '
                                           '{{ negative_feedback_url }}{{ ORGANIZATION_NAME }}')
 
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_INGEPLAND,
-                                     title='Uw melding {{ signal_id }}'
+                                     title='Uw melding {{ formatted_signal_id }}'
                                            f' {EmailTemplate.SIGNAL_STATUS_CHANGED_INGEPLAND}',
                                      body='{{ text }} {{ created_at }} {{ ORGANIZATION_NAME }}')
 
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_HEROPEND,
-                                     title='Uw melding {{ signal_id }}'
+                                     title='Uw melding {{ formatted_signal_id }}'
                                            f' {EmailTemplate.SIGNAL_STATUS_CHANGED_HEROPEND}',
                                      body='{{ text }} {{ created_at }} {{ ORGANIZATION_NAME }}')
 
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_OPTIONAL,
-                                     title='Uw melding {{ signal_id }}'
+                                     title='Uw melding {{ formatted_signal_id }}'
                                            f' {EmailTemplate.SIGNAL_STATUS_CHANGED_OPTIONAL}',
                                      body='{{ text }} {{ created_at }} {{ status_text }} {{ ORGANIZATION_NAME }}')
 
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD,
-                                     title='Uw melding {{ signal_id }}'
+                                     title='Uw melding {{ formatted_signal_id }}'
                                            f' {EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD}',
                                      body='{{ text }} {{ created_at }} {{ status_text }} {{ reaction_url }} '
                                           '{{ ORGANIZATION_NAME }}')
 
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN,
-                                     title='Uw melding {{ signal_id }}'
+                                     title='Uw melding {{ formatted_signal_id }}'
                                            f' {EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN}',
                                      body='{{ text }} {{ created_at }} {{ reaction_request_answer }} '
                                           '{{ ORGANIZATION_NAME }}')
 
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT,
-                                     title='Uw melding {{ signal_id }}'
+                                     title='Uw melding {{ formatted_signal_id }}'
                                            f' {EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT}',
                                      body='{{ text }} {{ created_at }} {{ reaction_request_answer }} '
                                           '{{ ORGANIZATION_NAME }} {{ feedback_text }} {{ feedback_text_extra }} ')
@@ -86,7 +86,7 @@ class ActionTestMixin:
                                       status__send_email=self.send_email, reporter__email='test@example.com')
         self.assertTrue(self.action(signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(Note.objects.count(), 1)
@@ -261,7 +261,7 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
 
         self.assertTrue(self.action(signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertIn('t**t@******e.com', mail.outbox[0].body)
@@ -279,7 +279,7 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
 
         self.assertTrue(self.action(signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertIn('tt@**.com', mail.outbox[0].body)
@@ -299,7 +299,7 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
 
         self.assertTrue(self.action(signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
 
@@ -370,7 +370,7 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
 
         self.assertTrue(self.action(signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
 
@@ -396,7 +396,7 @@ class TestSignalCreatedAction(ActionTestMixin, TestCase):
 
         self.assertTrue(self.action(signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
 
@@ -505,7 +505,7 @@ class TestSignalHandledNegativeAction(ActionTestMixin, TestCase):
         self.assertEqual(len(mail.outbox), 0)
         self.assertTrue(self.action(self.signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Uw melding {self.signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {self.signal.get_id_display()} {self.action.key}')
         self.assertEqual(mail.outbox[0].to, [self.signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(Note.objects.count(), 1)
@@ -666,7 +666,7 @@ class TestSignalReactionRequestReceivedAction(ActionTestMixin, TestCase):
                                       status__send_email=self.send_email, reporter__email='test@example.com')
         self.assertTrue(self.action(signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id} {self.action.key}')
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(Note.objects.count(), 1)
@@ -766,7 +766,7 @@ class TestSignalCreatedActionNoTemplate(TestCase):
         signal = SignalFactory.create(status__state=self.state, reporter__email='test@example.com')
         self.assertTrue(self.action(signal, dry_run=False))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Bedankt voor uw melding {signal.id}')
+        self.assertEqual(mail.outbox[0].subject, f'Bedankt voor uw melding {signal.get_id_display()}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(Note.objects.count(), 1)

--- a/api/app/signals/apps/email_integrations/tests/test_services.py
+++ b/api/app/signals/apps/email_integrations/tests/test_services.py
@@ -15,7 +15,7 @@ from signals.apps.signals.models import Note
 class TestMailActions(TestCase):
     def setUp(self):
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_CREATED,
-                                     title='Uw melding {{ signal_id }}',
+                                     title='Uw melding {{ formatted_signal_id }}',
                                      body='{{ text }} {{ created_at }} {{ handling_message }} {{ ORGANIZATION_NAME }}')
 
     def test_send_status_email(self):
@@ -24,7 +24,7 @@ class TestMailActions(TestCase):
         signal = SignalFactory.create(status__state=workflow.GEMELD, reporter__email='test@example.com')
         self.assertTrue(MailService.status_mail(signal))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.id}')
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(Note.objects.count(), 1)
@@ -78,7 +78,7 @@ class TestMailActions(TestCase):
 
         self.assertTrue(MailService.status_mail(signal))
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, f'Meer over uw melding {signal.id}')
+        self.assertEqual(mail.outbox[0].subject, f'Meer over uw melding {signal.get_id_display()}')
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(Note.objects.count(), 1)

--- a/api/app/signals/apps/email_integrations/tests/test_utils.py
+++ b/api/app/signals/apps/email_integrations/tests/test_utils.py
@@ -124,7 +124,7 @@ class TestUtils(TestCase):
         context = make_email_context(signal=signal)
 
         self.assertEqual(context['signal_id'], signal.id)
-        self.assertEqual(context['formatted_signal_id'], signal.sia_id)
+        self.assertEqual(context['formatted_signal_id'], signal.get_id_display())
         self.assertEqual(context['created_at'], signal.created_at)
         self.assertEqual(context['text'], signal.text)
         self.assertEqual(context['text_extra'], signal.text_extra)
@@ -161,7 +161,7 @@ class TestUtils(TestCase):
         context = make_email_context(signal=signal, additional_context={'extra': 'context'})
 
         self.assertEqual(context['signal_id'], signal.id)
-        self.assertEqual(context['formatted_signal_id'], signal.sia_id)
+        self.assertEqual(context['formatted_signal_id'], signal.get_id_display())
         self.assertEqual(context['created_at'], signal.created_at)
         self.assertEqual(context['text'], signal.text)
         self.assertEqual(context['text_extra'], signal.text_extra)

--- a/api/app/signals/apps/email_integrations/utils.py
+++ b/api/app/signals/apps/email_integrations/utils.py
@@ -131,7 +131,7 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
 
     context = {
         'signal_id': signal.id,
-        'formatted_signal_id': signal.sia_id,
+        'formatted_signal_id': signal.get_id_display(),
         'created_at': signal.created_at,
         'text': text,
         'text_extra': text_extra,

--- a/api/app/signals/apps/sigmax/stuf_protocol/outgoing/voegZaakdocumentToe_Lk01.py
+++ b/api/app/signals/apps/sigmax/stuf_protocol/outgoing/voegZaakdocumentToe_Lk01.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2022 Gemeente Amsterdam
 """
 Support for voegZaakdocumentToe_Lk01 messages to send to CityControl.
 

--- a/api/app/signals/apps/sigmax/stuf_protocol/outgoing/voegZaakdocumentToe_Lk01.py
+++ b/api/app/signals/apps/sigmax/stuf_protocol/outgoing/voegZaakdocumentToe_Lk01.py
@@ -31,7 +31,7 @@ def _generate_voegZaakdocumentToe_Lk01(signal, seq_no):
         'DOC_UUID': str(uuid.uuid4()),
         'DATA': encoded_pdf.decode('utf-8'),
         'DOC_TYPE': 'PDF',
-        'FILE_NAME': f'{signal.sia_id}.pdf'
+        'FILE_NAME': f'{signal.get_id_display()}.pdf'
     })
 
 

--- a/api/app/signals/apps/sigmax/tests/stuf_protocol/outgoing/test_pdf.py
+++ b/api/app/signals/apps/sigmax/tests/stuf_protocol/outgoing/test_pdf.py
@@ -42,12 +42,12 @@ class TestPDF(TestCase):
 
         # General information about the `Signal` object.
         current_tz = timezone.get_current_timezone()
-        self.assertIn(f'Signalen-{signal.id}', html)
+        self.assertIn(signal.get_id_display(), html)
         self.assertIn(signal.created_at.astimezone(current_tz).strftime('%d-%m-%Y'), html)
         self.assertIn(signal.created_at.astimezone(current_tz).strftime('%H:%M:%S'), html)
         self.assertIn(signal.incident_date_start.astimezone(current_tz).strftime('%d-%m-%Y'), html)
         self.assertIn(signal.incident_date_start.astimezone(current_tz).strftime('%H:%M:%S'), html)
-        self.assertIn(f'Signalen-{signal.id}', html)
+        self.assertIn(signal.get_id_display(), html)
         self.assertIn(signal.category_assignment.category.parent.name, html)
         self.assertIn(signal.category_assignment.category.name, html)
         self.assertIn(signal.priority.get_priority_display(), html)

--- a/api/app/signals/apps/sigmax/tests/stuf_protocol/outgoing/test_pdf.py
+++ b/api/app/signals/apps/sigmax/tests/stuf_protocol/outgoing/test_pdf.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam
 from unittest import mock
 
 from django.test import TestCase

--- a/api/app/signals/apps/signals/models/signal.py
+++ b/api/app/signals/apps/signals/models/signal.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2022 Gemeente Amsterdam
 import uuid
 
 from django.conf import settings

--- a/api/app/signals/apps/signals/models/signal.py
+++ b/api/app/signals/apps/signals/models/signal.py
@@ -107,9 +107,22 @@ class Signal(CreatedUpdatedModel):
     def is_child(self):
         return self.parent is not None
 
+    def get_id_display(self):
+        """
+        Signals Identifier used for external communication.
+        Can be configured in the settings, defaults to 'SIG-' + id.
+        """
+        return f'{settings.SIGNAL_ID_DISPLAY_PREFIX or ""}{self.id}'
+
     @property
     def sia_id(self):
         """
+        Deprecated in favour of `id_display`. Will be removed a.s.a.p.
+
+        TODO:
+        - Check if this can be changed in the SIGMAX communication
+        - Remove this property
+
         SIA identifier used for external communication.
         """
         return f'SIA-{self.id}'

--- a/api/app/signals/apps/signals/tests/test_models.py
+++ b/api/app/signals/apps/signals/tests/test_models.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import os
 from unittest import mock
 

--- a/api/app/signals/apps/signals/tests/test_models.py
+++ b/api/app/signals/apps/signals/tests/test_models.py
@@ -247,6 +247,19 @@ class TestSignalManager(TransactionTestCase):
 
 class TestSignalModel(TestCase):
 
+    def test_get_id_display(self):
+        signal = factories.SignalFactory.create(id=999)
+        self.assertEqual('SIG-999', signal.get_id_display())
+
+        with override_settings(SIGNAL_ID_DISPLAY_PREFIX='SIGNALS-'):
+            self.assertEqual('SIGNALS-999', signal.get_id_display())
+
+        with override_settings(SIGNAL_ID_DISPLAY_PREFIX=''):
+            self.assertEqual('999', signal.get_id_display())
+
+        with override_settings(SIGNAL_ID_DISPLAY_PREFIX=None):
+            self.assertEqual('999', signal.get_id_display())
+
     def test_sia_id(self):
         signal = factories.SignalFactory.create(id=999)
 

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -26,6 +26,10 @@ SITE_DOMAIN = os.getenv('SITE_DOMAIN', 'api.data.amsterdam.nl')
 
 ORGANIZATION_NAME = os.getenv('ORGANIZATION_NAME', 'Gemeente Amsterdam')
 
+# The prefix of the display value of the signal ID. Defaults to 'SIG-'. This wil generate an id like SIG-123456 when
+# using the `signal.get_id_display()` class method.
+SIGNAL_ID_DISPLAY_PREFIX = os.getenv('SIGNAL_ID_DISPLAY_PREFIX', 'SIG-')
+
 # Accept signals within this geographic bounding box in
 # format: <lon_min>,<lat_min>,<lon_max>,<lat_max> (WS84)
 # default value covers The Netherlands


### PR DESCRIPTION
## Description

The display ID that is used in Signalen is currently a mix of 2, `SIA-{ID}` and `Signalen-{ID}`. In this PR this is changed to 1 new display ID, default this is `SIG-{ID}`. It is possible to change the prefix `SIG-` in the settings by changing the `SIGNAL_ID_DISPLAY_PREFIX` to the prefix, it defaults to `SIG-`.

The API now also returns a `id_display` in the responses of the private/signals endpoints. Example:

```
"_links": {
    "self": {
        "href": "http://127.0.0.1:8000/signals/v1/private/signals/123"
    }
},
"_display": "123 - m - None - 2022-01-01T00:00:00.000000+01:00",
"id": 123,
"id_display": "SIG-123",
"signal_id": "00000000-0000-0000-0000-000000000000",
```

The configured email (example):
![Screenshot from 2022-05-16 15-20-40](https://user-images.githubusercontent.com/23056530/168602062-eeb0a441-9f53-4971-b6d9-f2109eed8672.png)

The PDF (example):
![Screenshot from 2022-05-16 15-17-45](https://user-images.githubusercontent.com/23056530/168601476-4d3abc82-9294-4512-ba86-ed18040239d6.png)

Configurable in the settings (Defaults to `SIG-`):
![Screenshot from 2022-05-16 15-36-40](https://user-images.githubusercontent.com/23056530/168605248-7d7ac9a7-79ca-4511-920e-91b82e99f4e3.png)

TODO:
- ~[ ] Check Sigmax implementation. The `SIA-{ID}.{ROUNDTRIP}` (example: `SIA-123.001`) is communicated to Sigmax and we need to double check if we can change this to `SIG-{ID}.{ROUNDTRIP}` (example: `SIG-123.001`)~ It was decided to leave this out of this PR. A new PR will be made changing this.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
