### PR TITLE
Add allows_contact validation to abstractrule

### DIFF
--- a/api/app/signals/apps/feedback/managers.py
+++ b/api/app/signals/apps/feedback/managers.py
@@ -9,4 +9,4 @@ logger = logging.getLogger(__name__)
 
 class FeedbackManager(models.Manager):
     def request_feedback(self, signal):
-        return self.create(**{'_signal': signal})
+        return self.create(**{'_signal': signal, 'allows_contact': True})

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -427,6 +427,7 @@ FEATURE_FLAGS = {
     'SIGNAL_HISTORY_LOG_ENABLED': os.getenv('SIGNAL_HISTORY_LOG_ENABLED', False) in TRUE_VALUES,
     'API_USE_QUESTIONNAIRES_APP_FOR_FEEDBACK': os.getenv('API_USE_QUESTIONNAIRES_APP_FOR_FEEDBACK', False) in TRUE_VALUES,  # noqa
     'REPORTER_MAIL_HANDLED_NEGATIVE_CONTACT_ENABLED': os.getenv('REPORTER_MAIL_HANDLED_NEGATIVE_CONTACT_ENABLED', True) in TRUE_VALUES, # noqa
+    'REPORTER_MAIL_DISABLE_CONTACT_FEEDBACK_ALLOWS_CONTACT': os.getenv('REPORTER_MAIL_DISABLE_CONTACT_FEEDBACK_ALLOWS_CONTACT', True) in TRUE_VALUES, # noqa
     # Temporary added to exclude permissions in the signals/v1/permissions endpoint that are not yet implemented in
     # the frontend
     # TODO: Remove this when the frontend is updated


### PR DESCRIPTION
…ows_contact validation to every mail action

## Description
Add an allows_contact valication to the abstract mail validation to check if the latest feedback from allows for contact.
If not feedback froms exists it will still allow for contact.

Change the feedback default creation to allows_contact=True to still be able to mail users if the feedback form is not yet filled in.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
