### PR TITLE
disabled the mail when the user feedback is_satisfied is True

### DIFF
--- a/api/app/signals/apps/api/tests/test_history_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_history_endpoint.py
@@ -311,7 +311,7 @@ class TestHistoryForFeedback(SignalsBaseApiTestCase, SIAReadUserMixin):
         self.assertEqual(response.status_code, 200)
 
         response_data = response.json()
-        self.assertEqual(len(response_data), 8)
+        self.assertEqual(len(response_data), 7)
 
         # check that filtering by RECEIVE_FEEDBACK works
         response = self.client.get(history_url + '?what=RECEIVE_FEEDBACK')

--- a/api/app/signals/apps/feedback/serializers.py
+++ b/api/app/signals/apps/feedback/serializers.py
@@ -65,7 +65,8 @@ class FeedbackSerializer(serializers.ModelSerializer):
 
         instance = super().update(instance, validated_data)
         # trigger the mail to be after the instance update to have the new data
-        MailService.system_mail(signal=instance._signal,
-                                action_name='feedback_received',
-                                feedback=instance)
+        if not is_satisfied:
+            MailService.system_mail(signal=instance._signal,
+                                    action_name='feedback_received',
+                                    feedback=instance)
         return instance


### PR DESCRIPTION
## Description
Disable the mail when feedback has been received only when the user is satisfied

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
