### PR TITLE
fix category public name fallback

### DIFF
--- a/api/app/signals/apps/api/views/signals/public/signals.py
+++ b/api/app/signals/apps/api/views/signals/public/signals.py
@@ -3,7 +3,8 @@
 import logging
 
 from django.db.models import CharField, Min, Value
-from django.db.models.functions import Coalesce, JSONObject
+from django.db.models.expressions import Case, When
+from django.db.models.functions import JSONObject
 from django.http import Http404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
@@ -92,8 +93,16 @@ class PublicSignalViewSet(GenericViewSet):
                     properties=JSONObject(
                         category=JSONObject(
                             # Return the category public_name. If the public_name is empty, return the category name
-                            name=Coalesce('category_assignment__category__public_name',
-                                          'category_assignment__category__name'),
+                            # name=Coalesce('category_assignment__category__public_name',
+                            #               'category_assignment__category__name'),
+                            name=Case(
+                                When(category_assignment__category__public_name__exact='',
+                                     then='category_assignment__category__name'),
+                                When(category_assignment__category__public_name__isnull=True,
+                                     then='category_assignment__category__name'),
+                                default='category_assignment__category__public_name',
+                                output_field=CharField(),
+                            )
                         ),
                         # Creation date of the Signal
                         created_at='created_at',


### PR DESCRIPTION
## Description

Category public_name must be returned in the public signals geography endpoint. When empty or null the Category name must be used as a fallback

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
