### PR TITLE
Correctly set created_by property of Notes for attachment deletes

### DIFF
--- a/api/app/signals/apps/api/serializers/attachment.py
+++ b/api/app/signals/apps/api/serializers/attachment.py
@@ -37,9 +37,9 @@ class SignalAttachmentSerializerMixin:
         # add a note that an attachment (currently only images allowed) was uploaded
         filename = os.path.basename(attachment.file.name)
         if user:
-            Signal.actions.create_note({'text': f'Foto toegevoegd: {filename}', 'created_by': user}, signal)
+            Signal.actions.create_note({'text': f'Bijlage toegevoegd: {filename}', 'created_by': user}, signal)
         else:
-            Signal.actions.create_note({'text': f'Foto toegevoegd door melder: {filename}'}, signal)
+            Signal.actions.create_note({'text': f'Bijlage toegevoegd door melder: {filename}'}, signal)
 
         return attachment
 

--- a/api/app/signals/apps/api/serializers/attachment.py
+++ b/api/app/signals/apps/api/serializers/attachment.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import os
 from datetime import timedelta
 
@@ -36,10 +36,10 @@ class SignalAttachmentSerializerMixin:
 
         # add a note that an attachment (currently only images allowed) was uploaded
         filename = os.path.basename(attachment.file.name)
-        msg = f'Foto toegevoegd door melder: {filename}'
         if user:
-            msg = f'Foto toegevoegd door {user.email}: {filename}'
-        Signal.actions.create_note({'text': msg}, signal)
+            Signal.actions.create_note({'text': f'Foto toegevoegd: {filename}', 'created_by': user}, signal)
+        else:
+            Signal.actions.create_note({'text': f'Foto toegevoegd door melder: {filename}'}, signal)
 
         return attachment
 

--- a/api/app/signals/apps/api/serializers/signal.py
+++ b/api/app/signals/apps/api/serializers/signal.py
@@ -522,7 +522,7 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
             # Add history entries for every attachment that was copied. Only photos allowed for now.
             for attachment in Attachment.objects.filter(_signal=signal).order_by('created_at'):
                 filename = os.path.basename(attachment.file.name)
-                msg = f'Foto gekopieerd van hoofdmelding: {filename}'
+                msg = f'Bijlage gekopieerd van hoofdmelding: {filename}'
                 Signal.actions.create_note(data={'text': msg}, signal=signal)
 
         signal.refresh_from_db()

--- a/api/app/signals/apps/api/tests/test_attachment_permissions.py
+++ b/api/app/signals/apps/api/tests/test_attachment_permissions.py
@@ -136,7 +136,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
 
         n = Note.objects.all().first()
-        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.text, f'Bijlage {att_filename} is verwijderd.')
         self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_others_attachments_with_proper_department_i(self):
@@ -170,7 +170,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
 
         n = Note.objects.all().first()
-        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.text, f'Bijlage {att_filename} is verwijderd.')
         self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_others_attachments_with_proper_department_ii(self):
@@ -208,7 +208,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
 
         n = Note.objects.all().first()
-        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.text, f'Bijlage {att_filename} is verwijderd.')
         self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_others_attachments_with_proper_department_iii(self):
@@ -246,7 +246,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
 
         n = Note.objects.all().first()
-        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.text, f'Bijlage {att_filename} is verwijderd.')
         self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_normal_signals_attachments(self):
@@ -282,7 +282,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
 
         n = Note.objects.all().first()
-        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.text, f'Bijlage {att_filename} is verwijderd.')
         self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_parent_signal_attachments(self):
@@ -325,7 +325,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Note.objects.filter(_signal=parent_signal).count(), 1)
 
         n = Note.objects.all().first()
-        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.text, f'Bijlage {att_filename} is verwijderd.')
         self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_child_signal_attachments(self):

--- a/api/app/signals/apps/api/tests/test_attachment_permissions.py
+++ b/api/app/signals/apps/api/tests/test_attachment_permissions.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
+# Copyright (C) 2021 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+import os
+
 from django.contrib.auth.models import Permission
 
 from signals.apps.signals.factories import (
@@ -110,6 +112,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
         self.client.force_authenticate(user=self.sia_read_write_user)
         self.sia_read_write_user.profile.departments.add(self.department)
+        att_filename = os.path.basename(self.attachment.file.name)
 
         # hand out all of normal, parent, child signal's attachment delete permissions
         self.sia_read_write_user.user_permissions.set([
@@ -132,6 +135,10 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
 
+        n = Note.objects.all().first()
+        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.created_by, self.sia_read_write_user.email)
+
     def test_delete_others_attachments_with_proper_department_i(self):
         """
         Test that user with "sia_delete_attachment_of_other_user" permission
@@ -140,6 +147,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 1)
         self.client.force_authenticate(user=self.sia_read_write_user)
         self.sia_read_write_user.profile.departments.add(self.department)
+        att_filename = os.path.basename(self.attachment.file.name)
 
         # hand out all of normal, parent, child signal's attachment delete permissions
         # and permission to delete other's attachments
@@ -160,6 +168,10 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
+
+        n = Note.objects.all().first()
+        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_others_attachments_with_proper_department_ii(self):
         """
@@ -185,6 +197,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         # let's pretend a reporter (i.e. never logged-in) uploaded the attachment
         self.attachment.created_by = None
         self.attachment.save()
+        att_filename = os.path.basename(self.attachment.file.name)
 
         # should be able to delete a reporter's attachment
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 0)
@@ -193,6 +206,10 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
+
+        n = Note.objects.all().first()
+        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_others_attachments_with_proper_department_iii(self):
         """
@@ -218,6 +235,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         # let's pretend our test user uploaded the attachment
         self.attachment.created_by = self.sia_read_write_user.email
         self.attachment.save()
+        att_filename = os.path.basename(self.attachment.file.name)
 
         # should be able to delete a reporter's attachment
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 0)
@@ -226,6 +244,10 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
+
+        n = Note.objects.all().first()
+        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_normal_signals_attachments(self):
         """
@@ -239,6 +261,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         # let's pretend our test user uploaded the attachment (no "sia_delete_attachment_of_other_user" needed)
         self.attachment.created_by = self.sia_read_write_user.email
         self.attachment.save()
+        att_filename = os.path.basename(self.attachment.file.name)
 
         # Try to delete without "sia_delete_attachment_of_normal_signal"
         url = self.attachments_endpoint_detail.format(self.signal.pk, self.attachment.pk)
@@ -258,6 +281,10 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(Attachment.objects.filter(_signal=self.signal).count(), 0)
         self.assertEqual(Note.objects.filter(_signal=self.signal).count(), 1)
 
+        n = Note.objects.all().first()
+        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.created_by, self.sia_read_write_user.email)
+
     def test_delete_parent_signal_attachments(self):
         """
         Check that "sia_delete_attachment_of_parent_signal" is needed to delete a
@@ -273,6 +300,7 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         ImageAttachmentFactory.create(_signal=child_signal)
         self.attachment.created_by = self.sia_read_write_user.email
         self.attachment.save()
+        att_filename = os.path.basename(self.attachment.file.name)
 
         # Try to delete without "sia_delete_attachment_of_parent_signal"
         parent_signal = self.signal
@@ -295,6 +323,10 @@ class TestAttachmentPermissions(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(Attachment.objects.filter(_signal=parent_signal).count(), 0)
         self.assertEqual(Note.objects.filter(_signal=parent_signal).count(), 1)
+
+        n = Note.objects.all().first()
+        self.assertEqual(n.text, f'Foto {att_filename} is verwijderd.')
+        self.assertEqual(n.created_by, self.sia_read_write_user.email)
 
     def test_delete_child_signal_attachments(self):
         """

--- a/api/app/signals/apps/api/tests/test_private_signal_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_private_signal_endpoint.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import copy
 import json
 import os
@@ -554,7 +554,8 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
 
         for note, attachment in zip(note_qs, attachment_qs):
             filename = os.path.basename(attachment.file.name)
-            self.assertEqual(f'Foto toegevoegd door {self.sia_read_write_user}: {filename}', note.text)
+            self.assertEqual(f'Foto toegevoegd: {filename}', note.text)
+            self.assertEqual(self.sia_read_write_user.email, note.created_by)
 
     @patch("signals.apps.api.validation.address.base.BaseAddressValidation.validate_address",
            side_effect=AddressValidationUnavailableException)  # Skip address validation

--- a/api/app/signals/apps/api/tests/test_private_signal_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_private_signal_endpoint.py
@@ -554,7 +554,7 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
 
         for note, attachment in zip(note_qs, attachment_qs):
             filename = os.path.basename(attachment.file.name)
-            self.assertEqual(f'Foto toegevoegd: {filename}', note.text)
+            self.assertEqual(f'Bijlage toegevoegd: {filename}', note.text)
             self.assertEqual(self.sia_read_write_user.email, note.created_by)
 
     @patch("signals.apps.api.validation.address.base.BaseAddressValidation.validate_address",

--- a/api/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
+++ b/api/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
@@ -330,7 +330,7 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
 
         for note, attachment in zip(note_qs, attachment_qs):
             filename = os.path.basename(attachment.file.name)
-            self.assertEqual(f'Foto gekopieerd van hoofdmelding: {filename}', note.text)
+            self.assertEqual(f'Bijlage gekopieerd van hoofdmelding: {filename}', note.text)
             self.assertEqual(None, note.created_by)
 
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',

--- a/api/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
+++ b/api/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import copy
 import os
 from unittest import expectedFailure, skip
@@ -331,6 +331,7 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
         for note, attachment in zip(note_qs, attachment_qs):
             filename = os.path.basename(attachment.file.name)
             self.assertEqual(f'Foto gekopieerd van hoofdmelding: {filename}', note.text)
+            self.assertEqual(None, note.created_by)
 
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation

--- a/api/app/signals/apps/api/tests/test_public_signal_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_public_signal_endpoint.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import copy
 import json
 import os

--- a/api/app/signals/apps/api/tests/test_public_signal_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_public_signal_endpoint.py
@@ -243,7 +243,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         note = Note.objects.last()
 
         filename = os.path.basename(attachment.file.name)
-        self.assertEqual(f'Foto toegevoegd door melder: {filename}', note.text)
+        self.assertEqual(f'Bijlage toegevoegd door melder: {filename}', note.text)
 
     def test_add_attachment_extension_not_allowed(self):
         signal = SignalFactory.create(status__state=GEMELD)

--- a/api/app/signals/apps/api/views/attachment.py
+++ b/api/app/signals/apps/api/views/attachment.py
@@ -91,5 +91,7 @@ class PrivateSignalAttachmentsViewSet(
         self.perform_destroy(attachment)
 
         att_filename = os.path.split(attachment.file.name)[1]
-        Signal.actions.create_note({'text': f'Attachment {att_filename} is verwijderd door {user}.'}, signal=signal)
+        Signal.actions.create_note({
+            'text': f'Foto {att_filename} is verwijderd.', 'created_by': user
+        }, signal=signal)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/api/app/signals/apps/api/views/attachment.py
+++ b/api/app/signals/apps/api/views/attachment.py
@@ -92,6 +92,6 @@ class PrivateSignalAttachmentsViewSet(
 
         att_filename = os.path.split(attachment.file.name)[1]
         Signal.actions.create_note({
-            'text': f'Foto {att_filename} is verwijderd.', 'created_by': user
+            'text': f'Bijlage {att_filename} is verwijderd.', 'created_by': user
         }, signal=signal)
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Description

The Notes added tot history of a Signal (nuisance complaint) when attachments are deleted must correctly show the active user (and not as part of the notes' text).

see: https://github.com/Signalen/product-steering/issues/176


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
