### PR TITLE
Add caption to images in PDF (upload timestamp, user and filename)

### DIFF
--- a/api/app/signals/apps/api/templates/api/pdf/print_signal.html
+++ b/api/app/signals/apps/api/templates/api/pdf/print_signal.html
@@ -180,10 +180,14 @@
 
     <div class="divider">&nbsp;</div>
     <h2>Foto's</h2>
-    {% if jpg_data_uris %}
-        {% for data_uri in jpg_data_uris %}
+    {% if attachment_images %}
+        {% for data_uri, att_filename, user_email, created_at in attachment_images %}
             {% if data_uri %}
-                <p><img src="{{ data_uri|safe }}" style="width:680px" alt=""></p>
+                <p>
+                    <img src="{{ data_uri|safe }}" style="width:680px" alt="">
+                    {{ att_filename}} op {{ created_at | date:"d-m-Y" }} {{ created_at | date:"H:i" }} door
+                    {% if user_email %}{{ user_email }}{% else %}melder{% endif %}
+                </p>
             {% else %}
                 <p>Image not available</p>
             {% endif %}
@@ -192,6 +196,7 @@
     {% else %}
         <p>Er zijn geen foto's beschikbaar omdat de melder in Signalen geen foto's heeft meegeleverd.</p>
     {% endif %}
+
 
     <div class="divider">&nbsp;</div>
     <h2>Geschiedenis</h2>

--- a/api/app/signals/apps/api/views/signals/private/pdf.py
+++ b/api/app/signals/apps/api/views/signals/private/pdf.py
@@ -109,12 +109,13 @@ class GeneratePdfView(SingleObjectMixin, PDFTemplateView):
                 rd_coordinates.x + 340.00,
                 rd_coordinates.y + 125.00,
             )
-        jpg_data_uris = DataUriImageEncodeService.get_context_data_images(self.object, self.max_size)
+        jpg_data_uris, att_filenames, user_emails, att_created_ats = \
+            DataUriImageEncodeService.get_context_data_images(self.object, self.max_size)
 
         return super().get_context_data(
             bbox=bbox,
             img_data_uri=img_data_uri,
-            jpg_data_uris=jpg_data_uris,
+            attachment_images=zip(jpg_data_uris, att_filenames, user_emails, att_created_ats),
             user=self.request.user,
             logo_src=logo_src,
         )

--- a/api/app/signals/apps/services/domain/images.py
+++ b/api/app/signals/apps/services/domain/images.py
@@ -29,6 +29,10 @@ class DataUriImageEncodeService:
     @staticmethod
     def get_context_data_images(signal, max_size):
         jpg_data_uris = []
+        att_filenames = []
+        user_emails = []
+        att_created_ats = []
+
         for att in signal.attachments.all():
             # Attachment is_image property is currently not reliable
             _, ext = os.path.splitext(att.file.name)
@@ -62,6 +66,11 @@ class DataUriImageEncodeService:
                     image.save(new_buffer, format='JPEG')
                     encoded = f'data:image/jpg;base64,{base64.b64encode(new_buffer.getvalue()).decode("utf-8")}'
 
-            jpg_data_uris.append(encoded)
+            att_filename = os.path.basename(att.file.name)
 
-        return jpg_data_uris
+            jpg_data_uris.append(encoded)
+            att_filenames.append(att_filename)
+            user_emails.append(att.created_by)
+            att_created_ats.append(att.created_at)
+
+        return jpg_data_uris, att_filenames, user_emails, att_created_ats

--- a/api/app/signals/apps/services/tests/domain/test_images.py
+++ b/api/app/signals/apps/services/tests/domain/test_images.py
@@ -30,13 +30,21 @@ class TestImagesService(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
 
     def test_get_context_data_no_images(self):
         AttachmentFactory(_signal=self.signal, file__filename='blah.txt', file__data=b'blah', is_image=False)
-        jpg_data_uris = DataUriImageEncodeService.get_context_data_images(self.signal, 800)
+        jpg_data_uris, att_filenames, user_emails, att_created_ats = \
+            DataUriImageEncodeService.get_context_data_images(self.signal, 800)
         self.assertEqual(len(jpg_data_uris), 0)
+        self.assertEqual(len(att_filenames), 0)
+        self.assertEqual(len(user_emails), 0)
+        self.assertEqual(len(att_created_ats), 0)
 
     def test_get_context_data_invalid_images(self):
         AttachmentFactory.create(_signal=self.signal, file__filename='blah.jpg', file__data=b'blah', is_image=True)
-        jpg_data_uris = DataUriImageEncodeService.get_context_data_images(self.signal, 800)
+        jpg_data_uris, att_filenames, user_emails, att_created_ats = \
+            DataUriImageEncodeService.get_context_data_images(self.signal, 800)
         self.assertEqual(len(jpg_data_uris), 0)
+        self.assertEqual(len(att_filenames), 0)
+        self.assertEqual(len(user_emails), 0)
+        self.assertEqual(len(att_created_ats), 0)
 
     def test_get_context_data_valid_image(self):
         image = Image.new("RGB", (100, 100), (0, 0, 0))
@@ -44,8 +52,12 @@ class TestImagesService(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         image.save(buffer, format='JPEG')
 
         AttachmentFactory.create(_signal=self.signal, file__filename='blah.jpg', file__data=buffer.getvalue())
-        jpg_data_uris = DataUriImageEncodeService.get_context_data_images(self.signal, 80)
+        jpg_data_uris, att_filenames, user_emails, att_created_ats = \
+            DataUriImageEncodeService.get_context_data_images(self.signal, 800)
         self.assertEqual(len(jpg_data_uris), 1)
+        self.assertEqual(len(att_filenames), 1)
+        self.assertEqual(len(user_emails), 1)
+        self.assertEqual(len(att_created_ats), 1)
         self.assertEqual(jpg_data_uris[0][:22], 'data:image/jpg;base64,')
         self.assertGreater(len(jpg_data_uris[0]), 22)
 
@@ -56,7 +68,11 @@ class TestImagesService(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         image.save(buffer, format='PNG')
 
         AttachmentFactory.create(_signal=self.signal, file__filename='blah.png', file__data=buffer.getvalue())
-        jpg_data_uris = DataUriImageEncodeService.get_context_data_images(self.signal, 200)
+        jpg_data_uris, att_filenames, user_emails, att_created_ats = \
+            DataUriImageEncodeService.get_context_data_images(self.signal, 800)
         self.assertEqual(len(jpg_data_uris), 1)
+        self.assertEqual(len(att_filenames), 1)
+        self.assertEqual(len(user_emails), 1)
+        self.assertEqual(len(att_created_ats), 1)
         self.assertEqual(jpg_data_uris[0][:22], 'data:image/jpg;base64,')
         self.assertGreater(len(jpg_data_uris[0]), 22)

--- a/api/app/signals/apps/sigmax/stuf_protocol/outgoing/pdf.py
+++ b/api/app/signals/apps/sigmax/stuf_protocol/outgoing/pdf.py
@@ -33,14 +33,15 @@ def _render_html(signal: Signal):
         rd_coordinates.y + 125.00,
     )
     # HOTFIX for SIG-1473
-    jpg_data_uris = DataUriImageEncodeService.get_context_data_images(signal, 800)
+    jpg_data_uris, att_filenames, user_emails, att_created_ats = \
+        DataUriImageEncodeService.get_context_data_images(signal, 800)
 
     context = {
         'signal': signal,
         'now': timezone.datetime.now(),
         'bbox': bbox,
         'user': None,
-        'jpg_data_uris': jpg_data_uris,
+        'attachment_images': zip(jpg_data_uris, att_filenames, user_emails, att_created_ats),
     }
     return render_to_string('api/pdf/print_signal.html', context=context)
 


### PR DESCRIPTION
## Description

The PDFs generated by Signalen do not contain information about the attached images. This PR addresses that and adds a caption to each image with the upload timestamp, the uploader (whether the original reporter or a Signalen user) and the filename.


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
