### PR TITLE
Sig 4251

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -1075,6 +1075,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/publicCategoryListResponse'
+  /signals/v1/public/feedback/forms/{feedback_token}/:
+    get:
+      description: Get the feedback details
+      parameters:
+        - name: feedback_token
+          in: path
+          description: Feedback token for fetching the form
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: details parameters is present if the form is already filled in.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  details:
+                    type: string
+                    example: filled out
+    patch:
+      description: Update the feedback form
+      parameters:
+        - name: feedback_token
+          in: path
+          description: Feedback token for fetching the form
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        description: JSON data to update signal
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/publicFeedbackForm'
+      responses:
+
+
 
   /signals/v1/public/terms/categories/{main_slug}:
     get:
@@ -4797,6 +4839,32 @@ components:
         show_on_overview:
           type: boolean
           default: False
+
+    publicFeedbackForm:
+      description: JSON data for category updates
+      type: object
+      properties:
+        is_satisfied:
+          type: boolean
+          description: Flag if the reporter is satisfied or not
+        allows_contact:
+          type: boolean
+          description: Flag if the reporter allows for contacting
+        text:
+          type: string
+          description: text giving by the reporter
+        text_list:
+          description: List of texts from the reporter
+          type: array
+          items:
+            type: string
+        text_extra:
+          type: string
+          description: Extra set of text from the reporter
+      required:
+        - is_satisfied
+        - allows_contact
+        - text_extra
 
   securitySchemes:
     OAuth2:

--- a/api/app/signals/apps/api/tests/test_history_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_history_endpoint.py
@@ -328,6 +328,7 @@ class TestHistoryForFeedback(SignalsBaseApiTestCase, SIAReadUserMixin):
         self.feedback.is_satisfied = True
         self.feedback.allows_contact = False
         self.feedback.text = text
+        self.feedback.text_list = None
         self.feedback.text_extra = text_extra
         self.feedback.submitted_at = self.feedback.created_at + timedelta(days=1)
         self.feedback.save()

--- a/api/app/signals/apps/feedback/factories.py
+++ b/api/app/signals/apps/feedback/factories.py
@@ -39,4 +39,5 @@ class FeedbackFactory(factory.django.DjangoModelFactory):
     is_satisfied = fuzzy.FuzzyChoice([True, False])
     allows_contact = fuzzy.FuzzyChoice([True, False])
     text = factory.Sequence(lambda n: 'Unieke klaag tekst nummer: {}'.format(n))
+    text_list = [fuzzy.FuzzyText(), fuzzy.FuzzyText(), fuzzy.FuzzyText()]
     text_extra = fuzzy.FuzzyChoice([None, 'Daarom is waarom.'])

--- a/api/app/signals/apps/feedback/migrations/0009_feedback_text_list.py
+++ b/api/app/signals/apps/feedback/migrations/0009_feedback_text_list.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('feedback', '0008_auto_20210402_1225'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='feedback',
+            name='text_list',
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.TextField(blank=True, max_length=1000), blank=True, null=True, size=None),
+        ),
+    ]

--- a/api/app/signals/apps/feedback/models.py
+++ b/api/app/signals/apps/feedback/models.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import timedelta
 
 from django.contrib.gis.db import models
+from django.contrib.postgres.fields import ArrayField
 from django.utils import timezone
 
 from signals.apps.feedback.app_settings import FEEDBACK_EXPECTED_WITHIN_N_DAYS
@@ -42,6 +43,7 @@ class Feedback(models.Model):
     is_satisfied = models.BooleanField(null=True)
     allows_contact = models.BooleanField(default=False)
     text = models.TextField(max_length=1000, null=True, blank=True)
+    text_list = ArrayField(models.TextField(max_length=1000, blank=True), null=True, blank=True)
     text_extra = models.TextField(max_length=1000, null=True, blank=True)
 
     objects = models.Manager()
@@ -52,25 +54,33 @@ class Feedback(models.Model):
 
     @property
     def is_too_late(self):
-        """Feedback still on time"""
+        """
+        Feedback still on time
+        """
         open_period = timedelta(days=FEEDBACK_EXPECTED_WITHIN_N_DAYS)
 
         return timezone.now() > self.created_at + open_period
 
     @property
     def is_filled_out(self):
-        """Feedback form already filled out and submitted."""
+        """
+        Feedback form already filled out and submitted.
+        """
         return self.submitted_at is not None
 
 
-def _get_description_of_receive_feedback(feedback_id):
-    """Given a history entry for submission of feedback create descriptive text."""
-    feedback = Feedback.objects.get(token=feedback_id)
+def _get_description_of_receive_feedback(feedback_token):
+    """
+    Given a history entry for submission of feedback create descriptive text.
+    """
+    feedback = Feedback.objects.get(token=feedback_token)
 
     # Craft a message for UI
     desc = 'Ja, de melder is tevreden\n' if feedback.is_satisfied else \
         'Nee, de melder is ontevreden\n'
-    desc += 'Waarom: {}'.format(feedback.text)
+
+    text = ",". join(feedback.text_list) if feedback.text_list else feedback.text or "Geen Feedback"
+    desc += 'Waarom: {}'.format(text)
 
     if feedback.text_extra:
         desc += '\nToelichting: {}'.format(feedback.text_extra)

--- a/api/app/signals/apps/feedback/serializers.py
+++ b/api/app/signals/apps/feedback/serializers.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import ValidationError
 
 from signals.apps.email_integrations.services import MailService
 from signals.apps.feedback.models import Feedback, StandardAnswer
-from signals.apps.feedback.utils import validate_answers
+from signals.apps.feedback.utils import validate_answers, merge_texts
 from signals.apps.signals import workflow
 from signals.apps.signals.models import Signal
 
@@ -31,8 +31,8 @@ class FeedbackSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             'is_satisfied': {'write_only': True, 'required': True},
             'allows_contact': {'write_only': True},
-            'text': {'write_only': True, "required": False},
-            'text_list': {'write_only': True, "required": False},
+            'text': {'write_only': True, 'required': False},
+            'text_list': {'write_only': True, 'required': False},
             'text_extra': {'write_only': True},
         }
 
@@ -58,6 +58,12 @@ class FeedbackSerializer(serializers.ModelSerializer):
         # Check whether the relevant Signal instance should possibly be
         # reopened (i.e. transition to VERZOEK_TOT_HEROPENEN state).
         is_satisfied = validated_data['is_satisfied']
+
+        # @TODO: When text field is depricated the following can be removed
+        validated_data = merge_texts(validated_data)
+        instance.text = None
+        instance.text_list = validated_data['text_list']
+
         reopen = False
         if not is_satisfied:
             reopen = validate_answers(validated_data)

--- a/api/app/signals/apps/feedback/serializers.py
+++ b/api/app/signals/apps/feedback/serializers.py
@@ -73,7 +73,7 @@ class FeedbackSerializer(serializers.ModelSerializer):
                     'state': workflow.VERZOEK_TOT_HEROPENEN,
                 }
                 Signal.actions.update_status(payload, signal)
-        instance.submitted_at = None
+
         instance = super().update(instance, validated_data)
         # trigger the mail to be after the instance update to have the new data
         if not is_satisfied:

--- a/api/app/signals/apps/feedback/serializers.py
+++ b/api/app/signals/apps/feedback/serializers.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import ValidationError
 
 from signals.apps.email_integrations.services import MailService
 from signals.apps.feedback.models import Feedback, StandardAnswer
-from signals.apps.feedback.utils import validate_answers, merge_texts
+from signals.apps.feedback.utils import merge_texts, validate_answers
 from signals.apps.signals import workflow
 from signals.apps.signals.models import Signal
 

--- a/api/app/signals/apps/feedback/tests/test_model.py
+++ b/api/app/signals/apps/feedback/tests/test_model.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from signals.apps.feedback.app_settings import FEEDBACK_EXPECTED_WITHIN_N_DAYS
+from signals.apps.feedback.factories import FeedbackFactory
+from signals.apps.feedback.models import _get_description_of_receive_feedback
+
+
+class TestFeedbackModel(TestCase):
+
+    def setUp(self):
+        self.feedback = FeedbackFactory.create()
+
+    def test_is_to_late(self):
+        """
+        Check if the created date is later then the FEEDBACK_EXPECTED_WITHIN_N_DAYS
+        """
+        timedelta(days=FEEDBACK_EXPECTED_WITHIN_N_DAYS + 1)
+        self.feedback.created_at = timezone.now() - timedelta(days=FEEDBACK_EXPECTED_WITHIN_N_DAYS + 1)
+        self.assertTrue(self.feedback.is_too_late)
+
+    def test_is_not_to_late(self):
+        """
+        Check if the created date is later then the FEEDBACK_EXPECTED_WITHIN_N_DAYS
+        """
+        self.assertFalse(self.feedback.is_too_late)
+
+    def test_is_filled_out(self):
+        self.feedback.submitted_at = timezone.now()
+        self.assertTrue(self.feedback.is_filled_out)
+
+    def test_is_not_filled_out(self):
+        self.assertFalse(self.feedback.is_filled_out)
+
+
+class TestDescriptionReceived(TestCase):
+
+    def test__get_description_of_receive_feedback(self):
+        feedback = FeedbackFactory.create(
+            is_satisfied=True,
+            text=None,
+            text_list=['my', 'test', 'list'],
+            text_extra='extra_text',
+            allows_contact=True,
+        )
+        response = _get_description_of_receive_feedback(feedback.token)
+        validate_text = "Ja, de melder is tevreden\nWaarom: my,test,list\nToelichting: extra_text\n" \
+                        "Toestemming contact opnemen: Ja"
+        self.assertEqual(response, validate_text)
+
+    def test__get_description_of_receive_feedback_no_satisfied(self):
+        feedback = FeedbackFactory.create(
+            is_satisfied=False,
+            text="My Text",
+            text_list=None,
+            text_extra=None,
+            allows_contact=False,
+        )
+        response = _get_description_of_receive_feedback(feedback.token)
+        validate_text = "Nee, de melder is ontevreden\nWaarom: My Text\n" \
+                        "Toestemming contact opnemen: Nee"
+        self.assertEqual(response, validate_text)

--- a/api/app/signals/apps/feedback/tests/test_serializer.py
+++ b/api/app/signals/apps/feedback/tests/test_serializer.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+
+
+from django.test import TestCase
+
+from signals.apps.feedback.serializers import FeedbackSerializer
+
+
+class TestFeedbackSerializer(TestCase):
+
+    def setUp(self):
+        self.data = {
+            'text': 'fake_text',
+            'is_satisfied': False,
+            'allows_contact': True,
+            'text_extra': 'fake_text_extra'
+        }
+
+    def test_validate_text(self):
+
+        self.data['text'] = 'fake_text'
+
+        serializer = FeedbackSerializer(data=self.data)
+        self.assertTrue(serializer.is_valid())
+
+    def test_validate_text_list(self):
+        self.data['text_list'] = ['fake_text']
+
+        serializer = FeedbackSerializer(data=self.data)
+        self.assertTrue(serializer.is_valid())
+
+    def test_validate_text_and_list(self):
+        self.data['text'] = 'fake_text'
+        self.data['text_list'] = ['fake_text']
+
+        serializer = FeedbackSerializer(data=self.data)
+        self.assertTrue(serializer.is_valid())
+
+    def test_validate_missing_both(self):
+        serializer = FeedbackSerializer(data=self.data)
+        self.assertFalse(serializer.is_valid())
+        print(serializer.errors)

--- a/api/app/signals/apps/feedback/tests/test_serializer.py
+++ b/api/app/signals/apps/feedback/tests/test_serializer.py
@@ -11,14 +11,12 @@ class TestFeedbackSerializer(TestCase):
 
     def setUp(self):
         self.data = {
-            'text': 'fake_text',
             'is_satisfied': False,
             'allows_contact': True,
             'text_extra': 'fake_text_extra'
         }
 
     def test_validate_text(self):
-
         self.data['text'] = 'fake_text'
 
         serializer = FeedbackSerializer(data=self.data)
@@ -40,4 +38,8 @@ class TestFeedbackSerializer(TestCase):
     def test_validate_missing_both(self):
         serializer = FeedbackSerializer(data=self.data)
         self.assertFalse(serializer.is_valid())
-        print(serializer.errors)
+        err = serializer.errors
+        self.assertIn('non_field_errors', err)
+        self.assertEqual(str(err['non_field_errors'][0]),
+                         'Either text or text_list must be filled in')
+        self.assertTrue(len(err['non_field_errors']) == 1)

--- a/api/app/signals/apps/feedback/tests/test_utils.py
+++ b/api/app/signals/apps/feedback/tests/test_utils.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+
+from django.test import TestCase
+
+from signals.apps.feedback.utils import validate_answers
+
+
+class TestFeedbackUtils(TestCase):
+
+    _REOPEN_TEXT = "Er is niets met mijn melding gedaan"
+    _REOPEN_TEXT_2 = "Ik voel mij niet serieus genomen door de gemeente"
+    _STAY_CLOSED_TEXT = "De behandeling duurde te lang"
+    _STAY_CLOSED_TEXT_2 = "Het contact over de afhandeling was slecht"
+
+    def test_validate_answers_text_only_reopen(self):
+        """
+        text only when an reopens when unhappy string
+        """
+        data = {'text': self._REOPEN_TEXT}
+
+        self.assertTrue(validate_answers(data))
+
+    def test_validate_answers_text_only_stay_closed(self):
+        """
+        text only when and stay closed
+        """
+        data = {'text': self._STAY_CLOSED_TEXT}
+
+        self.assertFalse(validate_answers(data))
+
+    def test_validate_answers_text_list_only_reopen(self):
+        """
+        text_list only when an reopens when unhappy string
+        """
+        data = {'text_list': [self._REOPEN_TEXT]}
+
+        self.assertTrue(validate_answers(data))
+
+    def test_validate_answers_text_list_only_stay_closed(self):
+        """
+        text_list only when and stay closed
+        """
+        data = {'text_list': [self._STAY_CLOSED_TEXT]}
+
+        self.assertFalse(validate_answers(data))
+
+    def test_validate_answers_text_list_reopen_and_close(self):
+        """
+        text_list with multiple anwsers and only triggers reopen it should true to reopen the signal
+        """
+        data = {'text_list': [self._REOPEN_TEXT, self._STAY_CLOSED_TEXT]}
+        self.assertTrue(validate_answers(data))
+
+    def test_validate_answers_text_list_custom_text(self):
+        """
+        text_list with a custom text should always return true to reopen the signal
+        """
+        data = {'text_list': ["SOME CUSTOMER TEXT"]}
+        self.assertTrue(validate_answers(data))
+
+    def test_validate_answers_text_list_and_text(self):
+        """
+        when text and text_list are send both
+        """
+        data = {
+            'text': self._STAY_CLOSED_TEXT,
+            'text_list': [self._STAY_CLOSED_TEXT_2]}
+        self.assertFalse(validate_answers(data))
+
+    def test_validate_answers_text_list_and_text_reopen(self):
+        """
+        when text and text_list are send both
+        """
+        data = {
+            'text': self._REOPEN_TEXT_2,
+            'text_list': [self._STAY_CLOSED_TEXT_2]
+        }
+        self.assertTrue(validate_answers(data))
+
+    def test_validate_answers_text_list_multiple_reopen(self):
+        """
+        if text_list has multiple reopen texts
+        """
+        data = {
+            'text_list': [self._REOPEN_TEXT, self._REOPEN_TEXT_2]}
+        self.assertTrue(validate_answers(data))
+
+    def test_validate_answers_text_list_multiple_stay_closed(self):
+        """
+        if text_list has multiple stay closed texts
+        """
+        data = {
+            'text_list': [self._STAY_CLOSED_TEXT, self._STAY_CLOSED_TEXT_2]}
+        self.assertFalse(validate_answers(data))
+
+    def test_validate_answers_text_list_multiple_stay_mixed(self):
+        """
+        if text_list has closed and reopen mixed
+        """
+        data = {'text_list': [self._STAY_CLOSED_TEXT, self._STAY_CLOSED_TEXT_2, self._REOPEN_TEXT_2]}
+        self.assertTrue(validate_answers(data))
+
+    def test_validate_answers_text_list_multiple_closed_with_custom(self):
+        """
+        if text_list has a custom text in it
+        """
+        data = {'text_list': [self._STAY_CLOSED_TEXT, self._STAY_CLOSED_TEXT_2, "some reporter text"]}
+        self.assertTrue(validate_answers(data))

--- a/api/app/signals/apps/feedback/tests/test_utils.py
+++ b/api/app/signals/apps/feedback/tests/test_utils.py
@@ -3,7 +3,7 @@
 
 from django.test import TestCase
 
-from signals.apps.feedback.utils import validate_answers, merge_texts
+from signals.apps.feedback.utils import merge_texts, validate_answers
 
 
 class TestFeedbackUtils(TestCase):

--- a/api/app/signals/apps/feedback/tests/test_utils.py
+++ b/api/app/signals/apps/feedback/tests/test_utils.py
@@ -3,7 +3,7 @@
 
 from django.test import TestCase
 
-from signals.apps.feedback.utils import validate_answers
+from signals.apps.feedback.utils import validate_answers, merge_texts
 
 
 class TestFeedbackUtils(TestCase):
@@ -12,22 +12,6 @@ class TestFeedbackUtils(TestCase):
     _REOPEN_TEXT_2 = "Ik voel mij niet serieus genomen door de gemeente"
     _STAY_CLOSED_TEXT = "De behandeling duurde te lang"
     _STAY_CLOSED_TEXT_2 = "Het contact over de afhandeling was slecht"
-
-    def test_validate_answers_text_only_reopen(self):
-        """
-        text only when an reopens when unhappy string
-        """
-        data = {'text': self._REOPEN_TEXT}
-
-        self.assertTrue(validate_answers(data))
-
-    def test_validate_answers_text_only_stay_closed(self):
-        """
-        text only when and stay closed
-        """
-        data = {'text': self._STAY_CLOSED_TEXT}
-
-        self.assertFalse(validate_answers(data))
 
     def test_validate_answers_text_list_only_reopen(self):
         """
@@ -59,25 +43,6 @@ class TestFeedbackUtils(TestCase):
         data = {'text_list': ["SOME CUSTOMER TEXT"]}
         self.assertTrue(validate_answers(data))
 
-    def test_validate_answers_text_list_and_text(self):
-        """
-        when text and text_list are send both
-        """
-        data = {
-            'text': self._STAY_CLOSED_TEXT,
-            'text_list': [self._STAY_CLOSED_TEXT_2]}
-        self.assertFalse(validate_answers(data))
-
-    def test_validate_answers_text_list_and_text_reopen(self):
-        """
-        when text and text_list are send both
-        """
-        data = {
-            'text': self._REOPEN_TEXT_2,
-            'text_list': [self._STAY_CLOSED_TEXT_2]
-        }
-        self.assertTrue(validate_answers(data))
-
     def test_validate_answers_text_list_multiple_reopen(self):
         """
         if text_list has multiple reopen texts
@@ -90,8 +55,7 @@ class TestFeedbackUtils(TestCase):
         """
         if text_list has multiple stay closed texts
         """
-        data = {
-            'text_list': [self._STAY_CLOSED_TEXT, self._STAY_CLOSED_TEXT_2]}
+        data = {'text_list': [self._STAY_CLOSED_TEXT, self._STAY_CLOSED_TEXT_2]}
         self.assertFalse(validate_answers(data))
 
     def test_validate_answers_text_list_multiple_stay_mixed(self):
@@ -107,3 +71,47 @@ class TestFeedbackUtils(TestCase):
         """
         data = {'text_list': [self._STAY_CLOSED_TEXT, self._STAY_CLOSED_TEXT_2, "some reporter text"]}
         self.assertTrue(validate_answers(data))
+
+    def test_validate_answers_duplicate(self):
+        """
+        Create a check to see that duplicate messages are not seen as custom texts because of a list diff.
+        and keep the signal Close with duplicate closed texts
+        """
+        data = {'text_list': [self._STAY_CLOSED_TEXT,
+                              self._STAY_CLOSED_TEXT,
+                              self._STAY_CLOSED_TEXT]}
+
+        self.assertFalse(validate_answers(data))
+
+    def test_merge_text_only_text(self):
+        """
+        Only text and convert it to text_list
+        """
+        data = {'text': 'test'}
+
+        data = merge_texts(data)
+        self.assertNotIn('text', data)
+        self.assertIn('test', data['text_list'])
+
+    def test_merge_text_only_text_list(self):
+        """
+        Only text and convert it to text_list
+        """
+        data = {'text_list': ['test', 'a', 'text']}
+
+        data = merge_texts(data)
+        self.assertNotIn('text', data)
+        self.assertEqual(['test', 'a', 'text'], data['text_list'])
+
+    def test_merge_text_text_and_list(self):
+        """
+        Only text and convert it to text_list
+        """
+        data = {
+            'text': 'my_text',
+            'text_list': ['test', 'a', 'text']
+        }
+
+        data = merge_texts(data)
+        self.assertNotIn('text', data)
+        self.assertEqual(['test', 'a', 'text', 'my_text'], data['text_list'])

--- a/api/app/signals/apps/feedback/utils.py
+++ b/api/app/signals/apps/feedback/utils.py
@@ -23,13 +23,7 @@ def validate_answers(data: Dict) -> bool:
     """
     Validate if the answers require the signal to be reopened or not
     """
-
-    text = data.get('text')
-    text_list = data.get('text_list') if data.get('text_list') else []
-
-    if text:
-        text_list.append(text)
-
+    text_list = set(data.get('text_list', []))
     query = Q()
     for t in text_list:
         query.add(Q(text=t), Q.OR)
@@ -40,3 +34,17 @@ def validate_answers(data: Dict) -> bool:
         return True
 
     return any(x for x in sa if x.reopens_when_unhappy)
+
+
+def merge_texts(data: Dict) -> Dict:
+    """
+    Merge the text and text_list to only text_list and return the new list
+    """
+    text_list = data.get('text_list') if data.get('text_list') else []
+
+    text = data.pop('text', None)
+    if text:
+        text_list.append(text)
+
+    data['text_list'] = text_list
+    return data

--- a/api/app/signals/apps/feedback/utils.py
+++ b/api/app/signals/apps/feedback/utils.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import logging
+from typing import Dict
 
 from django.conf import settings
+from django.db.models import Q
+
+from signals.apps.feedback.models import StandardAnswer
 
 logger = logging.getLogger(__name__)
 
@@ -13,3 +17,26 @@ def get_feedback_urls(feedback):
     negative_feedback_url = f'{settings.FRONTEND_URL}/kto/nee/{feedback.token}'
 
     return positive_feedback_url, negative_feedback_url
+
+
+def validate_answers(data: Dict) -> bool:
+    """
+    Validate if the answers require the signal to be reopened or not
+    """
+
+    text = data.get('text')
+    text_list = data.get('text_list') if data.get('text_list') else []
+
+    if text:
+        text_list.append(text)
+
+    query = Q()
+    for t in text_list:
+        query.add(Q(text=t), Q.OR)
+
+    sa = StandardAnswer.objects.filter(query)
+    if len(sa) != len(text_list):
+        # if the lists are not of equal length the list has custom texts and needs to be reopend
+        return True
+
+    return any(x for x in sa if x.reopens_when_unhappy)

--- a/api/app/signals/apps/reporting/csv/datawarehouse/kto_feedback.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/kto_feedback.py
@@ -36,8 +36,8 @@ def create_kto_feedback_csv(location: str) -> str:
 
     csv_file = queryset_to_csv_file(queryset, os.path.join(location, file_name))
 
-    ordered_field_names = ['_signal_id', 'is_satisfied', 'allows_contact', 'text', 'text_list',
-                           'text_extra', 'created_at', 'submitted_at', ]
+    ordered_field_names = ['_signal_id', 'is_satisfied', 'allows_contact', 'text',
+                           'text_extra', 'created_at', 'submitted_at', 'text_list']
     reorder_csv(csv_file.name, ordered_field_names)
 
     return csv_file.name

--- a/api/app/signals/apps/reporting/csv/datawarehouse/kto_feedback.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/kto_feedback.py
@@ -26,6 +26,7 @@ def create_kto_feedback_csv(location: str) -> str:
     queryset = Feedback.objects.values(
         '_signal_id',
         'text',
+        'text_list',
         'text_extra',
         'created_at',
         'submitted_at',
@@ -35,8 +36,8 @@ def create_kto_feedback_csv(location: str) -> str:
 
     csv_file = queryset_to_csv_file(queryset, os.path.join(location, file_name))
 
-    ordered_field_names = ['_signal_id', 'is_satisfied', 'allows_contact', 'text', 'text_extra', 'created_at',
-                           'submitted_at', ]
+    ordered_field_names = ['_signal_id', 'is_satisfied', 'allows_contact', 'text', 'text_list',
+                           'text_extra', 'created_at', 'submitted_at', ]
     reorder_csv(csv_file.name, ordered_field_names)
 
     return csv_file.name

--- a/api/app/tox.ini
+++ b/api/app/tox.ini
@@ -13,13 +13,11 @@ whitelist_externals =
     pytest
     flake8
     isort
-;commands =
-;    pytest: pytest -n 4 --cov=signals --cov-report=term --cov-report=html:{toxworkdir}/test/htmlcov --no-cov-on-fail {posargs:} --tb=short
-;    flake8: flake8 signals
-;    isort: isort --recursive --diff --check-only signals tests
-;    spdx: python check_spdx.py .
 commands =
-    pytest: pytest -s --reuse-db {posargs:}
+    pytest: pytest -n 4 --cov=signals --cov-report=term --cov-report=html:{toxworkdir}/test/htmlcov --no-cov-on-fail {posargs:} --tb=short
+    flake8: flake8 signals
+    isort: isort --recursive --diff --check-only signals tests
+    spdx: python check_spdx.py .
 
 [pytest]
 DJANGO_SETTINGS_MODULE = signals.settings.testing

--- a/api/app/tox.ini
+++ b/api/app/tox.ini
@@ -13,11 +13,13 @@ whitelist_externals =
     pytest
     flake8
     isort
+;commands =
+;    pytest: pytest -n 4 --cov=signals --cov-report=term --cov-report=html:{toxworkdir}/test/htmlcov --no-cov-on-fail {posargs:} --tb=short
+;    flake8: flake8 signals
+;    isort: isort --recursive --diff --check-only signals tests
+;    spdx: python check_spdx.py .
 commands =
-    pytest: pytest -n 4 --cov=signals --cov-report=term --cov-report=html:{toxworkdir}/test/htmlcov --no-cov-on-fail {posargs:} --tb=short
-    flake8: flake8 signals
-    isort: isort --recursive --diff --check-only signals tests
-    spdx: python check_spdx.py .
+    pytest: pytest -s --reuse-db {posargs:}
 
 [pytest]
 DJANGO_SETTINGS_MODULE = signals.settings.testing


### PR DESCRIPTION
## Description
Give the option to have multiple text submits on the feedback form.
Add a new field tot the database to store the text's separately  to allow for backwards compatibility
Adjust the CSV export to also add the text_list to the fields

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
