### PR TITLE
convert_validation_error can now handle a ValidationError with a message or messages

### DIFF
--- a/api/app/signals/apps/api/generics/mixins.py
+++ b/api/app/signals/apps/api/generics/mixins.py
@@ -11,8 +11,8 @@ def convert_validation_error(error):
     Convert a Django ValidationError to a DRF ValidationError.
     """
     # TODO: handle Django ValidationError properties other than message
-    if hasattr(error, 'message'):
-        return DRFValidationError(error.message)
+    if hasattr(error, 'messages'):
+        return DRFValidationError(error.messages)
     else:
         return DRFValidationError('Validation error on underlying data.')
 

--- a/api/app/signals/apps/api/generics/mixins.py
+++ b/api/app/signals/apps/api/generics/mixins.py
@@ -1,17 +1,19 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import mixins
 from rest_framework.exceptions import ValidationError as DRFValidationError
 
 
-def convert_validation_error(error):
+def convert_validation_error(error: DjangoValidationError) -> DRFValidationError:
     """
     Convert a Django ValidationError to a DRF ValidationError.
     """
     # TODO: handle Django ValidationError properties other than message
-    if hasattr(error, 'messages'):
+    if hasattr(error, 'message') and error.message:
+        return DRFValidationError(error.message)
+    elif hasattr(error, 'messages') and error.messages:
         return DRFValidationError(error.messages)
     else:
         return DRFValidationError('Validation error on underlying data.')

--- a/api/app/signals/apps/api/tests/generics/__init__.py
+++ b/api/app/signals/apps/api/tests/generics/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam

--- a/api/app/signals/apps/api/tests/generics/test_mixins.py
+++ b/api/app/signals/apps/api/tests/generics/test_mixins.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.test import TestCase
+
+from signals.apps.api.generics.mixins import convert_validation_error
+
+
+class TestConvertValidationErrorFunction(TestCase):
+    def test_error_with_message(self):
+        error = DjangoValidationError('A message')
+
+        self.assertTrue(hasattr(error, 'message'))
+        self.assertTrue(hasattr(error, 'messages'))
+        self.assertEqual(error.message, 'A message')
+        self.assertEqual(error.messages[0], 'A message')
+
+        converted_error = convert_validation_error(error)
+        self.assertEqual(converted_error.detail[0], 'A message')
+
+    def test_error_with_messages(self):
+        error = DjangoValidationError([DjangoValidationError('First message'), DjangoValidationError('Second message')])
+
+        self.assertFalse(hasattr(error, 'message'))
+        self.assertTrue(hasattr(error, 'messages'))
+        self.assertEqual(len(error.messages), 2)
+        self.assertEqual(error.messages[0], 'First message')
+        self.assertEqual(error.messages[1], 'Second message')
+
+        converted_error = convert_validation_error(error)
+
+        self.assertEqual(len(converted_error.detail), 2)
+        self.assertEqual(converted_error.detail[0], 'First message')
+        self.assertEqual(converted_error.detail[1], 'Second message')


### PR DESCRIPTION
## Description

The convert_validation_error function used to convert Django ValidationErrors into DRF ValidationErrors can now handle ValidationErrors with a message OR messages.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
