### PR TITLE
Move obscuring contact details to services app and add tests

### DIFF
--- a/api/app/signals/apps/services/domain/contact_details.py
+++ b/api/app/signals/apps/services/domain/contact_details.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2021 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+
+
+class ContactDetailsService:
+    @staticmethod
+    def obscure_email(email, escape_for_markdown):
+        """
+        Partially obscure a email address.
+
+        Examples:
+            - test@test.com         -> t**t@***t.com
+            - test.user@gmail.com   -> t*******r@****l.com
+            - test.user@amsterdam.nl-> t*******r@********m.nl
+            - test@tst.com          -> t**t@***.com
+            - tt@tst.com            -> tt@***.com
+        """
+        local, domain = email.split('@')
+        local = local[0].ljust(len(local)-1, '*') + local[-1]
+        sd, tld = domain[:domain.rfind('.')], domain[domain.rfind('.'):]
+        sd = sd[-1:].rjust(len(sd), '*') if len(sd) > 3 else ''.join(['*' for _ in range(len(sd))])
+        obscured_email = f'{local}@{sd}{tld}'
+
+        if escape_for_markdown:
+            obscured_email = obscured_email.replace('*', '\\*')  # noqa escape the * because it is used in markdown
+        return obscured_email
+
+    def obscure_phone(phone, escape_for_markdown):
+        """
+        Partially obscure a phone number.
+
+        Examples:
+            - +31 6 12 34 56 78 -> *******678
+            - +31612345678      -> *******678
+            - 06 12 34 56 78    -> *******678
+            - 0612345678        -> *******678
+        """
+        obscured_phone = phone.replace(' ', '')
+        obscured_phone = obscured_phone[-3:].rjust(10, '*')
+
+        if escape_for_markdown:
+            obscured_phone = obscured_phone.replace('*', '\\*')
+        return obscured_phone

--- a/api/app/signals/apps/services/tests/domain/test_contact_details.py
+++ b/api/app/signals/apps/services/tests/domain/test_contact_details.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2021 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+
+import mistune
+from django.test import TestCase
+
+from signals.apps.email_integrations.markdown.renderers import PlaintextRenderer
+from signals.apps.services.domain.contact_details import ContactDetailsService
+
+
+class TestContactDetailsService(TestCase):
+    email_cases = [
+        ('test@test.com', 't**t@***t.com'),
+        ('test.user@gmail.com', 't*******r@****l.com'),
+        ('test.user@amsterdam.nl', 't*******r@********m.nl'),
+        ('test@tst.com', 't**t@***.com'),
+        ('tt@tst.com', 'tt@***.com'),
+    ]
+    phone_cases = [
+        ('+31 6 12 34 56 78', '*******678'),
+        ('+31612345678', '*******678'),
+        ('06 12 34 56 78', '*******678'),
+        ('0612345678', '*******678'),
+    ]
+
+    def setUp(self):
+        self.render_plaintext = mistune.create_markdown(renderer=PlaintextRenderer())
+
+    def test_obscure_email(self):
+        for email, obscured_email in self.email_cases:
+            self.assertEqual(ContactDetailsService.obscure_email(email, False), obscured_email)
+
+    def test_obscure_email_for_markdown(self):
+        for email, obscured_email in self.email_cases:
+            encoded = ContactDetailsService.obscure_email(email, True)
+            # paragraphs get \n\n appended, hence the slice below
+            self.assertEqual(self.render_plaintext(encoded)[:-2], obscured_email)
+
+    def test_obscure_phone(self):
+        for phone, obscured_phone in self.phone_cases:
+            self.assertEqual(ContactDetailsService.obscure_phone(phone, False), obscured_phone)
+
+    def test_obscure_phone_for_markdown(self):
+        for phone, obscured_phone in self.phone_cases:
+            encoded = ContactDetailsService.obscure_phone(phone, True)
+            # paragraphs get \n\n appended, hence the slice below
+            self.assertEqual(self.render_plaintext(encoded)[:-2], obscured_phone)


### PR DESCRIPTION
## Description

Move the contact detail obfuscation code to the services app and add tests.


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
