### PR TITLE
Add Signal source to e-mail template context

### DIFF
--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -67,6 +67,7 @@
             <li>ORGANIZATION_NAME</li>
             <li>main_category_public_name</li>
             <li>sub_category_public_name</li>
+            <li>source</li>
         </ul>
         <h3>Variabelen welke in bepaalde templates beschikbaar zijn</h3>
         <h4>Send mail signal created</h4>

--- a/api/app/signals/apps/email_integrations/tests/test_utils.py
+++ b/api/app/signals/apps/email_integrations/tests/test_utils.py
@@ -133,6 +133,7 @@ class TestUtils(TestCase):
         self.assertEqual(context['status_state'], signal.status.state)
         self.assertEqual(context['handling_message'], signal.category_assignment.stored_handling_message)
         self.assertEqual(context['ORGANIZATION_NAME'], settings.ORGANIZATION_NAME)
+        self.assertEqual(context['source'], signal.source)
 
     def test_make_email_context_for_category_with_or_without_public_name(self):
         # Check categories with public names.

--- a/api/app/signals/apps/email_integrations/utils.py
+++ b/api/app/signals/apps/email_integrations/utils.py
@@ -142,6 +142,7 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
         'ORGANIZATION_NAME': settings.ORGANIZATION_NAME,
         'main_category_public_name': parent_public_name,
         'sub_category_public_name': category.public_name if category.public_name else category.name,
+        'source': signal.source,
     }
 
     if additional_context:


### PR DESCRIPTION
## Description

Add signal source to e-mail template context, so we can conditionally add some text based on the source.

Requested by municipality Bergen op Zoom.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
