### PR TITLE
Fixed where clause for the forward and reverse query that will move d…

### DIFF
--- a/api/app/signals/apps/history/migrations/0004_migrate_change_log_to_history_log.py
+++ b/api/app/signals/apps/history/migrations/0004_migrate_change_log_to_history_log.py
@@ -19,10 +19,9 @@ INSERT INTO history_log
     LEFT JOIN history_log hl on (
         hl.content_type_id = cl.content_type_id and
         hl.object_pk = CAST(cl.object_id AS TEXT) and
-        hl.created_at = cl.when and
-        hl._signal_id = null
+        hl.created_at = cl.when
     )
-    WHERE hl.object_pk = null;
+    WHERE hl.object_pk IS NULL AND hl._signal_id IS NULL;
 """
 
 reverse_sql_migrate = """
@@ -44,7 +43,7 @@ INSERT INTO change_log
         CAST(hl.object_pk AS INTEGER) = cl.object_id and
         hl.created_at = cl."when"
     )
-    WHERE cl.object_id IS NULL;
+    WHERE cl.object_id IS NULL AND hl._signal_id IS NULL;
 """
 
 


### PR DESCRIPTION
## Description

Fixed where clause for the forward and reverse query that will move data between the change_log and the history_log tables

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
