### PR TITLE
Prefer signal.location.area_name over ...area_code in PDF

### DIFF
--- a/api/app/signals/apps/api/templates/api/pdf/print_signal.html
+++ b/api/app/signals/apps/api/templates/api/pdf/print_signal.html
@@ -130,7 +130,7 @@
             {% if signal.location.stadsdeel %}
             <td>: {{ signal.location.get_stadsdeel_display }}</td>
             {% else %}
-            <td>: {{ signal.location.area_code }}</td>
+            <td>: {% if signal.location.area_name %}{{ signal.location.area_name }}{% else %}{{ signal.location.area_code }}{% endif %}</td>
             {% endif %}
         </tr>
         <tr>


### PR DESCRIPTION
## Description
See [product steering #185](https://github.com/Signalen/product-steering/issues/185)

The PDF summaries generated by Signalen for a nuisance complaint contain information about the location of the complaint. It can be assigned to an area upon creation. For VNG installations that area is identified by a user unfriendly code, the preference is that the area is identified by name. If available this PR uses name of the area that a nuisance complaint lies in. If the area name is not available it will use the area code as a fallback.

Note: this does not change the heading, that still reads "Stadsdeel" in any case.

_Regarding tests; this concerns the content of the summary PDFs which is hard to test currently. If we agree on an approach for these tests in the PR associated with [product steering 184](https://github.com/Signalen/product-steering/issues/184), I will implement that method here as well._

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
