### PR TITLE
CVE-2022-34749: Updated mistune to 2.0.3

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -66,7 +66,7 @@ kombu==5.2.3
 lxml==4.6.5
 MarkupSafe==1.1.1
 mccabe==0.6.1
-mistune==2.0.1
+mistune==2.0.3
 msgpack==1.0.2
 netaddr==0.8.0
 netifaces==0.11.0


### PR DESCRIPTION
## Description

CVE-2022-34749 Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) in the ASTERISK_EMPHASIS regex.

Updated mistune to 2.0.3

More info on:

- https://security.snyk.io/vuln/SNYK-PYTHON-MISTUNE-2940625

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
