### PR TITLE
CVE-2022-2309: Updated lxml to version 4.9.1

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -63,7 +63,7 @@ jsonschema==3.2.0
 jwcrypto==0.8
 keystoneauth1==4.3.1
 kombu==5.2.3
-lxml==4.6.5
+lxml==4.9.1
 MarkupSafe==1.1.1
 mccabe==0.6.1
 mistune==2.0.3


### PR DESCRIPTION
## Description

CVE-2022-2309

Affected versions of this package are vulnerable to NULL Pointer Dereference in the iterwalk() function (used by canonicalize) that can be triggered by malicious input.CVE-2022-2309

Updated lxml to version 4.9.1

More info on:

- https://security.snyk.io/vuln/SNYK-PYTHON-LXML-2940874
- https://www.cve.org/CVERecord?id=CVE-2022-2309

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
