### PR TITLE
SIG-4683 Added status "GESPLITST" as an option to the "delete_signals" script

### DIFF
--- a/api/app/signals/apps/signals/management/commands/delete_signals.py
+++ b/api/app/signals/apps/signals/management/commands/delete_signals.py
@@ -10,11 +10,11 @@ from django.utils import timezone
 
 from signals.apps.search.tasks import delete_from_elastic
 from signals.apps.signals.models import DeletedSignal, Signal
-from signals.apps.signals.workflow import AFGEHANDELD, GEANNULEERD
+from signals.apps.signals.workflow import AFGEHANDELD, GEANNULEERD, GESPLITST
 
 
 class Command(BaseCommand):
-    STATE_CHOICES = (AFGEHANDELD, GEANNULEERD, )
+    STATE_CHOICES = (AFGEHANDELD, GEANNULEERD, GESPLITST, )
     _dry_run = False
 
     def add_arguments(self, parser):

--- a/api/app/signals/apps/signals/tests/management/commands/delete_signals/test_delete_signals_base.py
+++ b/api/app/signals/apps/signals/tests/management/commands/delete_signals/test_delete_signals_base.py
@@ -48,7 +48,7 @@ class TestDeleteSignalsBase(TestCase):
         err_output = err_buffer.getvalue()
 
         self.assertEqual(output, '')
-        self.assertIn('Invalid state(s) provided must be one of "o, a"', err_output)
+        self.assertIn('Invalid state(s) provided must be one of "o, a, s"', err_output)
 
         buffer = StringIO()
         err_buffer = StringIO()


### PR DESCRIPTION
## Description

The end status "GESPLITST" has been used in Amsterdam for a small period. Signals that have the status "GESPLITS" are basically parent and child Signals so they also should be deleted after X time.

In this PR the option to delete Signals in the state "GESPLITST" has been added as an option to the "delete_signals" management command.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
