### PR TITLE
SIG-4678 Added "is_public_accessible" flag to the responses of the public category endpoints

### DIFF
--- a/api/app/signals/apps/api/serializers/category.py
+++ b/api/app/signals/apps/api/serializers/category.py
@@ -32,6 +32,7 @@ class CategoryHALSerializer(HALSerializer):
             'handling_message',
             'questionnaire',
             'public_name',
+            'is_public_accessible',
         )
 
     def get_departments(self, obj):
@@ -45,6 +46,7 @@ class ParentCategoryHALSerializer(HALSerializer):
     serializer_url_field = CategoryHyperlinkedIdentityField
     _display = DisplayField()
     sub_categories = CategoryHALSerializer(many=True, source='children')
+    is_public_accessible = serializers.SerializerMethodField(method_name='get_is_public_accessible')
 
     class Meta:
         model = Category
@@ -54,8 +56,19 @@ class ParentCategoryHALSerializer(HALSerializer):
             'name',
             'slug',
             'public_name',
+            'is_public_accessible',
             'sub_categories',
         )
+
+    def get_is_public_accessible(self, obj):
+        """
+        If there are child categories that are public accessible this should return True OR return the value of
+        'is_public_accessible' of the ParentCategory
+        """
+        return any([
+            child_is_public_accessible
+            for child_is_public_accessible in obj.children.values_list('is_public_accessible', flat=True)
+        ]) or obj.is_public_accessible
 
 
 class PrivateCategorySLASerializer(serializers.ModelSerializer):

--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -3264,6 +3264,14 @@ components:
           type: string
           description: The public name
           nullable: True
+        is_public_accessible:
+          type: boolean
+          description: >-
+            Returns True if there are child signals that have been marked as public accessible OR True if the parent
+            category has been marked public accessible. If the value is True than the categories contains Signals that
+            can be shown on for example a public map containing Signals in the city (Only certain properties of the 
+            Signal will be exposed).
+          example: True
         sub_categories:
           type: array
           description: A list of child categories
@@ -3342,6 +3350,13 @@ components:
           description: The public name
           nullable: True
           example: Asbest / accu (Publieke naam)
+        is_public_accessible:
+          type: boolean
+          description: >-
+            Returns True if the category has been marked public accessible. If the value is True than the category 
+            contains Signals that can be shown on for example a public map containing Signals in the city (Only certain 
+            properties of the Signal will be exposed).
+          example: True
 
     privateCategoryResponse:
       description: JSON data describing the category response

--- a/api/app/signals/apps/api/tests/json_schema/get_signals_v1_public_terms_categories.json
+++ b/api/app/signals/apps/api/tests/json_schema/get_signals_v1_public_terms_categories.json
@@ -123,6 +123,19 @@
 						"slug": {
 							"type": "string"
 						},
+						"public_name": {
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"type": "null"
+								}
+							]
+						},
+						"is_public_accessible": {
+							"type": "boolean"
+						},
 						"sub_categories": {
 							"type": "array",
 							"items": [
@@ -268,6 +281,19 @@
 										"questionnaire": {
 											"type": "string",
 											"pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+										},
+										"public_name": {
+											"oneOf": [
+												{
+													"type": "string"
+												},
+												{
+													"type": "null"
+												}
+											]
+										},
+										"is_public_accessible": {
+											"type": "boolean"
 										}
 									},
 									"required": [
@@ -277,7 +303,9 @@
 										"slug",
 										"handling",
 										"departments",
-										"is_active"
+										"is_active",
+										"public_name",
+										"is_public_accessible"
 									]
 								}
 							]
@@ -288,6 +316,8 @@
 						"_display",
 						"name",
 						"slug",
+						"public_name",
+						"is_public_accessible",
 						"sub_categories"
 					]
 				}

--- a/api/app/signals/apps/api/tests/json_schema/get_signals_v1_public_terms_categories_{slug}.json
+++ b/api/app/signals/apps/api/tests/json_schema/get_signals_v1_public_terms_categories_{slug}.json
@@ -57,6 +57,19 @@
 		"slug": {
 			"type": "string"
 		},
+		"public_name": {
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
+		"is_public_accessible": {
+			"type": "boolean"
+		},
 		"sub_categories": {
 			"type": "array",
 			"items": [
@@ -202,6 +215,19 @@
 						"questionnaire": {
 							"type": "string",
 							"pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+						},
+						"public_name": {
+							"oneOf": [
+								{
+									"type": "string"
+								},
+								{
+									"type": "null"
+								}
+							]
+						},
+						"is_public_accessible": {
+							"type": "boolean"
 						}
 					},
 					"required": [
@@ -211,7 +237,9 @@
 						"slug",
 						"handling",
 						"departments",
-						"is_active"
+						"is_active",
+						"public_name",
+						"is_public_accessible"
 					]
 				}
 			]
@@ -222,6 +250,8 @@
 		"_display",
 		"name",
 		"slug",
+		"public_name",
+		"is_public_accessible",
 		"sub_categories"
 	]
 }

--- a/api/app/signals/apps/api/tests/json_schema/get_signals_v1_public_terms_categories_{slug}_sub_categories_{sub_slug}.json
+++ b/api/app/signals/apps/api/tests/json_schema/get_signals_v1_public_terms_categories_{slug}_sub_categories_{sub_slug}.json
@@ -103,6 +103,19 @@
 		"questionnaire": {
 			"type": "string",
 			"pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+		},
+		"public_name": {
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "null"
+				}
+			]
+		},
+		"is_public_accessible": {
+			"type": "boolean"
 		}
 	},
 	"required": [
@@ -112,6 +125,8 @@
 		"slug",
 		"handling",
 		"departments",
-		"is_active"
+		"is_active",
+		"public_name",
+		"is_public_accessible"
 	]
 }


### PR DESCRIPTION
## Description

Added the "is_public_accessible" flag of a category to the response of the public category endpoints.

For a parent category the "is_public_accessible" can be set to True or False. However when there are child categories that have a "is_public_accessible" set to True this will also apply to the parent category.

Examples:

Category list:
```
{
    "_links": {
        "self": {
            "href": "http://127.0.0.1:8000/signals/v1/public/terms/categories"
        },
        "next": {
            "href": null
        },
        "previous": {
            "href": null
        }
    },
    "count": 13,
    "results": [
        {
            "_links": {
                "curies": {
                    "name": "sia",
                    "href": "http://127.0.0.1:8000/signals/v1/relations"
                },
                "self": {
                    "href": "http://127.0.0.1:8000/signals/v1/public/terms/categories/afval"
                }
            },
            "_display": "Afval",
            "name": "Afval",
            "slug": "afval",
            "public_name": null,
            "is_public_accessible": false,
            "sub_categories": [
```

Parent category:
```
{
    "_links": {
        "curies": {
            "name": "sia",
            "href": "http://127.0.0.1:8000/signals/v1/relations"
        },
        "self": {
            "href": "http://127.0.0.1:8000/signals/v1/public/terms/categories/afval"
        }
    },
    "_display": "Afval",
    "name": "Afval",
    "slug": "afval",
    "public_name": "Afval (Publieke naam)",
    "is_public_accessible": true,
    "sub_categories": [
        {
```

Child category:
```
{
    "_links": {
        "curies": {
            "name": "sia",
            "href": "http://127.0.0.1:8000/signals/v1/relations"
        },
        "self": {
            "href": "http://127.0.0.1:8000/signals/v1/public/terms/categories/afval/sub_categories/bedrijfsafval"
        }
    },
    "_display": "Bedrijfsafval (Afval)",
    "name": "Bedrijfsafval",
    "slug": "bedrijfsafval",
    "handling": "A3DMC",
    "departments": [],
    "is_active": false,
    "description": "",
    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail.",
    "public_name": null,
    "is_public_accessible": true
}
```

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
