### PR TITLE
make maincategory_slug and category_slug optinal when filtering for s…

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -1023,7 +1023,7 @@ paths:
           description: Filter returns only signals with matching main category
             slug.
           in: query
-          required: true
+          required: false
           schema:
             type: string
             example: afval
@@ -1031,7 +1031,7 @@ paths:
           description: >-
             Filter returns only signals with matching sub category slug.
           in: query
-          required: true
+          required: false
           schema:
             type: string
             example: overig-afval

--- a/api/app/signals/apps/api/views/signals/public/signals.py
+++ b/api/app/signals/apps/api/views/signals/public/signals.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2022 Gemeente Amsterdam
-import logging
-
 from django.db.models import CharField, Min, Value
 from django.db.models.expressions import Case, When
 from django.db.models.functions import JSONObject
@@ -28,8 +26,6 @@ from signals.apps.signals.workflow import (
     VERZOEK_TOT_HEROPENEN
 )
 from signals.throttling import PostOnlyNoUserRateThrottle
-
-logger = logging.getLogger(__name__)
 
 
 class PublicSignalViewSet(GenericViewSet):
@@ -76,7 +72,6 @@ class PublicSignalViewSet(GenericViewSet):
         Returns a GeoJSON of all Signal's that are in an "Open" state and in a publicly available category.
         Additional filtering can be done by adding query parameters.
         """
-
         qs = self.get_queryset()
 
         if request.query_params.get('group_by', '').lower() == 'category':


### PR DESCRIPTION
…ignals in the geo endpoint

## Description
Make the geon endpoint have the parameters maincategory_slug and category_slug optional and make them indepented from each other. Without the category parameters all signals will be returned regardless of category

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
