### PR TITLE
add reporter allowed sharing variable to the create signal template

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/signal_created.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_created.py
@@ -21,17 +21,20 @@ class SignalCreatedAction(AbstractAction):
     def get_additional_context(self, signal, dry_run=False):
         context = {'afhandelings_text': signal.category_assignment.category.handling_message, }
 
-        if signal.reporter and signal.reporter.phone:
-            """
-            If a reporter has given his/hers phone number it is added to the email context in a specific format.
-            """
-            context.update({'reporter_phone': ContactDetailsService.obscure_phone(signal.reporter.phone, True)})
+        if signal.reporter:
+            if signal.reporter.phone:
+                """
+                If a reporter has given his/hers phone number it is added to the email context in a specific format.
+                """
+                context.update({'reporter_phone': ContactDetailsService.obscure_phone(signal.reporter.phone, True)})
 
-        if signal.reporter and signal.reporter.email:
-            """
-            If a reporter has given his/hers email address it is added to the email context in a specific format.
-            """
-            context.update({'reporter_email': ContactDetailsService.obscure_email(signal.reporter.email, True)})
+            if signal.reporter.email:
+                """
+                If a reporter has given his/hers email address it is added to the email context in a specific format.
+                """
+                context.update({'reporter_email': ContactDetailsService.obscure_email(signal.reporter.email, True)})
+
+            context.update({'reporter_sharing_allowed': signal.reporter.sharing_allowed})
 
         # Add the extra properties to the context of the email template
         context.update({'extra_properties': self._extra_properties_context(signal.extra_properties)})

--- a/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/api/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -75,6 +75,7 @@
             <li>extra_properties, vraag => lijst met antwoorden</li>
             <li>reporter_phone (Alleen beschikbaar als er een telefoonnummer is opgegeven)</li>
             <li>reporter_email (Alleen beschikbaar als er een email adres is opgegeven)</li>
+            <li>reporter_sharing_allowed</li>
         </ul>
         <h4>Send mail signal handeld</h4>
         <ul>

--- a/api/app/signals/apps/services/domain/contact_details.py
+++ b/api/app/signals/apps/services/domain/contact_details.py
@@ -25,6 +25,7 @@ class ContactDetailsService:
             obscured_email = obscured_email.replace('*', '\\*')  # noqa escape the * because it is used in markdown
         return obscured_email
 
+    @staticmethod
     def obscure_phone(phone, escape_for_markdown):
         """
         Partially obscure a phone number.


### PR DESCRIPTION
## Description

Add the variable reporter allowed sharing to the create signal context to be used in the email templates
Also a small quickfix where @staticmethod was missing for the obscure_phone method

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
