### PR TITLE
Add ability to configure SSL required mode for database connection

### DIFF
--- a/api/app/signals/settings/__init__.py
+++ b/api/app/signals/settings/__init__.py
@@ -33,3 +33,6 @@ DATABASES = {
         'PORT': DATABASE_PORT # noqa
     },
 } # noqa
+
+if DATABASE_REQUIRE_SSL: # noqa
+    DATABASES['default']['OPTIONS'] = {'sslmode': 'require'}

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -129,7 +129,7 @@ DATABASE_USER = os.getenv('DATABASE_USER', 'signals')
 DATABASE_PASSWORD = os.getenv('DATABASE_PASSWORD', 'insecure')
 DATABASE_HOST = os.getenv('DATABASE_HOST_OVERRIDE')
 DATABASE_PORT = os.getenv('DATABASE_PORT_OVERRIDE')
-
+DATABASE_REQUIRE_SSL = os.getenv('DATABASE_REQUIRE_SSL', False) in TRUE_VALUES
 
 # Django cache settings
 CACHES = {


### PR DESCRIPTION
## Description

This adds a new environment variable setting `DATABASE_REQUIRE_SSL` that configures sslmode require on the database connection. This is required for Azure Database for Postgresql Single Server.

## Checklist

- [*] Keep the PR, and the amount of commits to a minimum
- [*] The commit messages are meaningful and descriptive
- [*] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [*] Check that the branch is based on `master` and is up to date with `master`
- [*] Check that the PR targets `master`
- [*] There are no merge conflicts and no conflicting Django migrations
- [*] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

Tested this by running it locally with a test database in Azure.