### PR TITLE
Use object-fit to include thin and tall images in PDFs

### DIFF
--- a/api/app/signals/apps/api/templates/api/pdf/print_signal.html
+++ b/api/app/signals/apps/api/templates/api/pdf/print_signal.html
@@ -184,7 +184,7 @@
         {% for data_uri, att_filename, user_email, created_at in attachment_images %}
             {% if data_uri %}
                 <p>
-                    <img src="{{ data_uri|safe }}" style="object-fit: contain; width:680px; height:500px; background-color: lightgray;" alt=""><br>
+                    <img src="{{ data_uri|safe }}" style="object-fit: contain; width:680px; max-height:500px;" alt=""><br>
                     {{ att_filename}} op {{ created_at | date:"d-m-Y" }} {{ created_at | date:"H:i" }} door
                     {% if user_email %}{{ user_email }}{% else %}melder{% endif %}
                 </p>

--- a/api/app/signals/apps/api/templates/api/pdf/print_signal.html
+++ b/api/app/signals/apps/api/templates/api/pdf/print_signal.html
@@ -184,7 +184,7 @@
         {% for data_uri, att_filename, user_email, created_at in attachment_images %}
             {% if data_uri %}
                 <p>
-                    <div style="background-color:lightgray; margin:0px; line-height: 0px;"><img src="{{ data_uri|safe }}" style="object-fit: contain; object-position: 50% 50%; width:680px; height:500px;" alt=""></div><br>
+                    <img src="{{ data_uri|safe }}" style="object-fit: contain; width:680px; height:500px; background-color: lightgray;" alt=""><br>
                     {{ att_filename}} op {{ created_at | date:"d-m-Y" }} {{ created_at | date:"H:i" }} door
                     {% if user_email %}{{ user_email }}{% else %}melder{% endif %}
                 </p>

--- a/api/app/signals/apps/api/templates/api/pdf/print_signal.html
+++ b/api/app/signals/apps/api/templates/api/pdf/print_signal.html
@@ -184,7 +184,7 @@
         {% for data_uri, att_filename, user_email, created_at in attachment_images %}
             {% if data_uri %}
                 <p>
-                    <img src="{{ data_uri|safe }}" style="width:680px" alt="">
+                    <div style="background-color:lightgray; margin:0px; line-height: 0px;"><img src="{{ data_uri|safe }}" style="object-fit: contain; object-position: 50% 50%; width:680px; height:500px;" alt=""></div><br>
                     {{ att_filename}} op {{ created_at | date:"d-m-Y" }} {{ created_at | date:"H:i" }} door
                     {% if user_email %}{{ user_email }}{% else %}melder{% endif %}
                 </p>


### PR DESCRIPTION
## Description

Images in PDFs created from Signals (nuisance complaints) are at times truncated. This was caused by thin and tall images overflowing the page. Proposed fix is a CSS tweak in the intermediate HTML templates used for PDF rendering that resizes images to always fit.

**TODO:**
- ~Check new layout with business representatives of Amsterdam.~


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
