### PR TITLE
Rename STuF organisation and application to SIG

### DIFF
--- a/api/app/signals/apps/sigmax/templates/sigmax/actualiseerZaakstatus_Bv03.xml
+++ b/api/app/signals/apps/sigmax/templates/sigmax/actualiseerZaakstatus_Bv03.xml
@@ -5,8 +5,8 @@
         <stuurgegevens>
            <berichtcode>Bv03</berichtcode>
            <zender>
-              <organisatie>AMS</organisatie>
-              <applicatie>SIA</applicatie>
+              <organisatie>SIG</organisatie>
+              <applicatie>SIG</applicatie>
            </zender>
            <ontvanger>
               <organisatie>SMX</organisatie>

--- a/api/app/signals/apps/sigmax/templates/sigmax/actualiseerZaakstatus_Fo03.xml
+++ b/api/app/signals/apps/sigmax/templates/sigmax/actualiseerZaakstatus_Fo03.xml
@@ -8,8 +8,8 @@
          <stuurgegevens>
             <berichtcode>Fo03</berichtcode>
             <zender>
-               <organisatie>AMS</organisatie>
-               <applicatie>SIA</applicatie>
+               <organisatie>SIG</organisatie>
+               <applicatie>SIG</applicatie>
             </zender>
             <ontvanger>
                <organisatie>SMX</organisatie>

--- a/api/app/signals/apps/sigmax/templates/sigmax/actualiseerZaakstatus_Lk01.xml
+++ b/api/app/signals/apps/sigmax/templates/sigmax/actualiseerZaakstatus_Lk01.xml
@@ -4,8 +4,8 @@
             <stuurgegevens>
                 <berichtcode xmlns="http://www.egem.nl/StUF/StUF0301">Lk01</berichtcode>
                 <zender xmlns="http://www.egem.nl/StUF/StUF0301">
-                    <organisatie>AMS</organisatie>
-                    <applicatie>SIA</applicatie>
+                    <organisatie>SIG</organisatie>
+                    <applicatie>SIG</applicatie>
                 </zender>
                 <ontvanger xmlns="http://www.egem.nl/StUF/StUF0301">
                     <organisatie>SMX</organisatie>

--- a/api/app/signals/apps/sigmax/templates/sigmax/creeerZaak_Lk01.xml
+++ b/api/app/signals/apps/sigmax/templates/sigmax/creeerZaak_Lk01.xml
@@ -4,8 +4,8 @@
             <ZKN:stuurgegevens>
                 <StUF:berichtcode>Lk01</StUF:berichtcode>
                 <StUF:zender>
-                    <StUF:organisatie>AMS</StUF:organisatie>
-                    <StUF:applicatie>SIA</StUF:applicatie>
+                    <StUF:organisatie>SIG</StUF:organisatie>
+                    <StUF:applicatie>SIG</StUF:applicatie>
                 </StUF:zender>
                 <StUF:ontvanger>
                     <StUF:organisatie>SMX</StUF:organisatie>

--- a/api/app/signals/apps/sigmax/templates/sigmax/voegZaakdocumentToe_Lk01.xml
+++ b/api/app/signals/apps/sigmax/templates/sigmax/voegZaakdocumentToe_Lk01.xml
@@ -5,8 +5,8 @@
          <ZKN:stuurgegevens>
             <StUF:berichtcode>Lk01</StUF:berichtcode>
             <StUF:zender>
-               <StUF:organisatie>AMS</StUF:organisatie>
-               <StUF:applicatie>SIA</StUF:applicatie>
+               <StUF:organisatie>SIG</StUF:organisatie>
+               <StUF:applicatie>SIG</StUF:applicatie>
             </StUF:zender>
             <StUF:ontvanger>
                <StUF:organisatie>SMX</StUF:organisatie>


### PR DESCRIPTION
## Description

This is a proposal from Sigmax. We should check if this is going to work for the Amsterdam integration as well.

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
