### PR TITLE
Bumped Django from 3.2.14 to 3.2.15

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,7 +24,7 @@ datapunt-authorization-django==1.3.0
 debtcollector==2.2.0
 defusedxml==0.7.1
 distlib==0.3.1
-Django==3.2.14
+Django==3.2.15
 django-appconf==1.0.4
 django-celery-beat==2.2.0
 django-celery-email==3.0.0


### PR DESCRIPTION
## Description

Bumps 
- [Django](https://github.com/django/django) from 3.2.14 to 3.2.15.

Fixes

CVE-2022-36359: Potential reflected file download vulnerability in FileResponse
An application may have been vulnerable to a reflected file download (RFD) attack that sets the Content-Disposition header of a FileResponse when the filename was derived from user-supplied input. The filename is now escaped to avoid this possibility.

This issue has high severity, according to the Django security policy.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
