### PR TITLE
add enters after each list option in the history

### DIFF
--- a/api/app/signals/apps/feedback/models.py
+++ b/api/app/signals/apps/feedback/models.py
@@ -82,7 +82,7 @@ def _get_description_of_receive_feedback(feedback_token):
     desc = 'Ja, de melder is tevreden\n' if feedback.is_satisfied else \
         'Nee, de melder is ontevreden\n'
 
-    text = ",". join(feedback.text_list) if feedback.text_list else feedback.text or "Geen Feedback"
+    text = ",\n". join(feedback.text_list) if feedback.text_list else feedback.text or "Geen Feedback"
     desc += 'Waarom: {}'.format(text)
 
     if feedback.text_extra:

--- a/api/app/signals/apps/feedback/tests/test_model.py
+++ b/api/app/signals/apps/feedback/tests/test_model.py
@@ -49,7 +49,7 @@ class TestDescriptionReceived(TestCase):
             allows_contact=True,
         )
         response = _get_description_of_receive_feedback(feedback.token)
-        validate_text = "Ja, de melder is tevreden\nWaarom: my,test,list\nToelichting: extra_text\n" \
+        validate_text = "Ja, de melder is tevreden\nWaarom: my,\ntest,\nlist\nToelichting: extra_text\n" \
                         "Toestemming contact opnemen: Ja"
         self.assertEqual(response, validate_text)
 


### PR DESCRIPTION
## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
