### PR TITLE
Add extra authorization check to Sigmax/CityControl flow

### DIFF
--- a/api/app/signals/apps/sigmax/views.py
+++ b/api/app/signals/apps/sigmax/views.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 """
 This module contains a minimal implementation of the StUF standard as it
 applies to communication between the SIA system and Sigmax CityControl.
@@ -7,6 +7,7 @@ applies to communication between the SIA system and Sigmax CityControl.
 import logging
 
 from django.shortcuts import render
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.views import APIView
 
 from signals.apps.sigmax.stuf_protocol.incoming import (
@@ -29,6 +30,9 @@ class CityControlReceiver(APIView):
         """
         Handle SOAP requests, dispatch on SOAPAction header.
         """
+        if not request.user.has_perm('signals.perform_sigmax_updates'):
+            raise PermissionDenied(detail='Not authorized to perform updates on behalf of CityControl!')
+
         # https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383528
         if 'HTTP_SOAPACTION' not in request.META:
             error_msg = 'SOAPAction header not set'

--- a/api/app/signals/apps/signals/migrations/0163_alter_signal_options.py
+++ b/api/app/signals/apps/signals/migrations/0163_alter_signal_options.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0162_signal_user_HISTORY'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='signal',
+            options={
+                'ordering': ('created_at',),
+                'permissions': (
+                    ('sia_read', 'Leesrechten algemeen'),
+                    ('sia_write', 'Schrijfrechten algemeen'),
+                    ('sia_split', 'Splitsen van een melding'),
+                    ('sia_signal_create_initial', 'Melding aanmaken'),
+                    ('sia_signal_create_note', 'Notitie toevoegen bij een melding'),
+                    ('sia_signal_change_status', 'Wijzigen van status van een melding'),
+                    ('sia_signal_change_category', 'Wijzigen van categorie van een melding'),
+                    ('sia_signal_export', 'Meldingen exporteren'), ('sia_signal_report', 'Rapportage beheren'),
+                    ('perform_sigmax_updates', 'Updates door CityControl uitvoeren')
+                )
+            },
+        ),
+    ]

--- a/api/app/signals/apps/signals/models/signal.py
+++ b/api/app/signals/apps/signals/models/signal.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
+# Copyright (C) 2019 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+
 import uuid
 
 from django.conf import settings
@@ -69,6 +70,9 @@ class Signal(CreatedUpdatedModel):
             ('sia_signal_change_category', 'Wijzigen van categorie van een melding'),  # SIG-2192
             ('sia_signal_export', 'Meldingen exporteren'),  # SIG-2192
             ('sia_signal_report', 'Rapportage beheren'),  # SIG-2192
+            # Following permission has no sia prefix, so cannot be set through
+            # backoffice/frontend (product-steering/241):
+            ('perform_sigmax_updates', 'Updates door CityControl uitvoeren'),
         )
         ordering = ('created_at',)
         indexes = [


### PR DESCRIPTION
## Description

Current implementation of Sigmax/CityControl SOAP endpoint is to not require specific permissions. This PR adds that requirement.

Note: **not** for inclusion in 2.7.1 release as this requires some coordination with our users.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
