### PR TITLE
Add celery task for cleaning up too-long outstanding reaction requests

### DIFF
--- a/api/app/signals/apps/questionnaires/tasks.py
+++ b/api/app/signals/apps/questionnaires/tasks.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+from signals.apps.questionnaires.services.reaction_request import clean_up_reaction_request
+from signals.celery import app
+
+
+@app.task
+def clean_up_reaction_request_task():
+    clean_up_reaction_request()

--- a/api/app/signals/apps/questionnaires/tests/test_tasks.py
+++ b/api/app/signals/apps/questionnaires/tests/test_tasks.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils.timezone import now
+from freezegun import freeze_time
+
+from signals.apps.questionnaires.services.reaction_request import REACTION_REQUEST_DAYS_OPEN
+from signals.apps.questionnaires.tasks import clean_up_reaction_request_task
+from signals.apps.signals import workflow
+from signals.apps.signals.factories import SignalFactory
+from signals.apps.signals.models.signal import Signal
+
+
+class TestCleanUpReactionRequested(TestCase):
+    def setUp(self):
+        with freeze_time(now() - timedelta(days=2 * REACTION_REQUEST_DAYS_OPEN)):
+            # Five signals that were in state REACTIE_GEVRAAGD and too old to
+            # still receive an update.
+            SignalFactory.create_batch(5, status__state=workflow.REACTIE_GEVRAAGD)
+
+        with freeze_time(now() - timedelta(days=REACTION_REQUEST_DAYS_OPEN // 2)):
+            # Five signals that were in state REACTIE_GEVRAAGD and may still
+            # get an update.
+            SignalFactory.create_batch(5, status__state=workflow.REACTIE_GEVRAAGD)
+
+    def test_task(self):
+        clean_up_reaction_request_task()
+        reactie_gevraagd = Signal.objects.filter(status__state=workflow.REACTIE_GEVRAAGD)
+        reactie_ontvangen = Signal.objects.filter(status__state=workflow.REACTIE_ONTVANGEN)
+        self.assertEqual(reactie_gevraagd.count(), 5)
+        self.assertEqual(reactie_ontvangen.count(), 5)


### PR DESCRIPTION
## Description

It was not possible to schedule the cleaning up of outstanding reaction requests that were open for too long via Django Celery Beat. This was the case because the original Signalen instance in Amsterdam was using an external scheduler (Jenkins calling management commands).

This PR addresses that by adding a Celery task to do the cleaning up. Behind the scenes this test calls the same service as the management command.


## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
