### PR TITLE
Add feature flag to show/hide reporter details in PDF export

### DIFF
--- a/api/app/signals/apps/api/templates/api/pdf/print_signal.html
+++ b/api/app/signals/apps/api/templates/api/pdf/print_signal.html
@@ -161,22 +161,24 @@
 
     {% include 'api/pdf/extra_properties.html' with signal=signal %}
 
-    <div class="divider">&nbsp;</div>
-    <h2>Melder</h2>
-    <table class="results" style="page-break-after: avoid; page-break-before: avoid; -pdf-page-break: avoid; margin: 30px 0 30px 0;">
-        <tr>
-            <td style="width: 200px;">E-mail</td>
-            <td>: {{ reporter_email|default:"Onbekend" }}</td>
-        </tr>
-        <tr>
-            <td>Telefoonnummer</td>
-            <td>: {{ reporter_phone|default:"Onbekend" }}</td>
-        </tr>
-        <tr>
-            <td>Verklaring contactgegevens delen</td>
-            <td>: {{ signal.reporter.sharing_allowed|yesno:"Toegestaan,Niet toegestaan" }}</td>
-        </tr>
-    </table>
+    {% if FEATURE_FLAGS.SHOW_REPORTER_CONTACT_DETAILS_IN_PDF %}
+        <div class="divider">&nbsp;</div>
+        <h2>Melder</h2>
+        <table class="results" style="page-break-after: avoid; page-break-before: avoid; -pdf-page-break: avoid; margin: 30px 0 30px 0;">
+            <tr>
+                <td style="width: 200px;">E-mail</td>
+                <td>: {{ reporter_email|default:"Onbekend" }}</td>
+            </tr>
+            <tr>
+                <td>Telefoonnummer</td>
+                <td>: {{ reporter_phone|default:"Onbekend" }}</td>
+            </tr>
+            <tr>
+                <td>Verklaring contactgegevens delen</td>
+                <td>: {{ signal.reporter.sharing_allowed|yesno:"Toegestaan,Niet toegestaan" }}</td>
+            </tr>
+        </table>
+    {% endif %}
 
     <div class="divider">&nbsp;</div>
     <h2>Foto's</h2>

--- a/api/app/signals/apps/services/domain/pdf_summary.py
+++ b/api/app/signals/apps/services/domain/pdf_summary.py
@@ -161,6 +161,7 @@ class PDFSummaryService:
             'now': timezone.now(),
             'reporter_email': reporter_email,
             'reporter_phone': reporter_phone,
+            'FEATURE_FLAGS': settings.FEATURE_FLAGS
         }
 
     @staticmethod

--- a/api/app/signals/settings/feature_flags.py
+++ b/api/app/signals/settings/feature_flags.py
@@ -34,4 +34,7 @@ FEATURE_FLAGS = {
 
     # Enable/disable the deletion of signals in a certain state for a certain amount of time
     'DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED': os.getenv('DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED', False) in TRUE_VALUES,  # noqa
+
+    # Show/hide reporter contact details in PDF export
+    'SHOW_REPORTER_CONTACT_DETAILS_IN_PDF': os.getenv('SHOW_REPORTER_CONTACT_DETAILS_IN_PDF', True) in TRUE_VALUES,
 }


### PR DESCRIPTION
## Description

This PR adds a feature flag `SHOW_REPORTER_CONTACT_DETAILS_IN_PDF` that can be used to show or hide contact details in the PDF export.

See https://github.com/Signalen/product-steering/issues/245


## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `master` and is up to date with `master`
- [ ] Check that the PR targets `master`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
