### PR TITLE
Add deadline and deadline_factor_3 to categories CSV export

### DIFF
--- a/api/app/signals/apps/reporting/csv/datawarehouse/categories.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/categories.py
@@ -21,6 +21,8 @@ def create_category_assignments_csv(location: str) -> str:
         'id',
         'created_at',
         'updated_at',
+        'deadline',
+        'deadline_factor_3',
         '_signal_id',
         main=F('category__parent__name'),
         sub=F('category__name'),
@@ -35,7 +37,7 @@ def create_category_assignments_csv(location: str) -> str:
     csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'categories.csv'))
 
     ordered_field_names = ['id', 'main', 'sub', 'departments', 'created_at', 'updated_at', 'extra_properties',
-                           '_signal_id', ]
+                           '_signal_id', 'deadline', 'deadline_factor_3', ]
     reorder_csv(csv_file.name, ordered_field_names)
 
     return csv_file.name

--- a/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
+++ b/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
@@ -10,6 +10,7 @@ from glob import glob
 from os import path
 from unittest import mock
 
+import dateutil
 import pytz
 from django.core.files.storage import FileSystemStorage
 from django.test import override_settings, testcases
@@ -18,7 +19,13 @@ from freezegun import freeze_time
 from signals.apps.feedback.factories import FeedbackFactory
 from signals.apps.reporting.csv import datawarehouse
 from signals.apps.reporting.utils import _get_storage_backend
-from signals.apps.signals.factories import DepartmentFactory, NoteFactory, SignalFactory
+from signals.apps.signals.factories import (
+    CategoryFactory,
+    DepartmentFactory,
+    NoteFactory,
+    ServiceLevelObjectiveFactory,
+    SignalFactory
+)
 from signals.apps.signals.models import SignalDepartments
 
 
@@ -269,7 +276,10 @@ class TestDatawarehouse(testcases.TestCase):
                 # self.assertIn(row['updated_at'], str(reporter.updated_at))
 
     def test_create_category_assignments_csv(self):
-        signal = SignalFactory.create()
+        category = CategoryFactory.create()
+        ServiceLevelObjectiveFactory.create(n_days=1, use_calendar_days=False, category=category)
+
+        signal = SignalFactory.create(category_assignment__category=category)
         category_assignment = signal.category_assignment
 
         csv_file = datawarehouse.create_category_assignments_csv(self.csv_tmp_dir)
@@ -286,6 +296,11 @@ class TestDatawarehouse(testcases.TestCase):
                 self.assertEqual(row['sub'], str(category_assignment.category.name))
                 self.assertEqual(row['departments'],
                                  ', '.join(category_assignment.category.departments.values_list('name', flat=True)))
+
+                deadline = dateutil.parser.parse(row['deadline'])
+                deadline_factor_3 = dateutil.parser.parse(row['deadline_factor_3'])
+                self.assertEqual(deadline, category_assignment.deadline)
+                self.assertEqual(deadline_factor_3, category_assignment.deadline_factor_3)
 
                 # noqa Disabled because the Postgres format is slightly different than the Python format, so we decided to comment these checks for now
                 # self.assertEqual(row['created_at'], str(category_assignment.created_at))


### PR DESCRIPTION
## Description

This PR adds the field deadline and deadline_factor_3 to the categories.csv export.

Closes https://github.com/Signalen/backend/issues/176