### PR TITLE
Chore: silence test suite warnings (assertEquals, timezone problems)

### DIFF
--- a/api/app/signals/apps/api/tests/test_serializers.py
+++ b/api/app/signals/apps/api/tests/test_serializers.py
@@ -34,7 +34,7 @@ class TestReporterSerializer(TestCase):
 
         feedback = FeedbackFactory.create(
             _signal=self.signal,
-            submitted_at='2022-01-01',
+            submitted_at='2022-01-01 00:00:00+00:00',
             allows_contact=False
         )
         feedback.save()

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -182,7 +182,7 @@ class ActionTestMixin:
         feedback = FeedbackFactory.create(
             _signal=signal,
             allows_contact=False,
-            submitted_at='2022-01-01'
+            submitted_at='2022-01-01 00:00:00+00:00'
         )
         feedback.save()
         signal.save()
@@ -202,7 +202,7 @@ class ActionTestMixin:
         feedback = FeedbackFactory.create(
             _signal=signal,
             allows_contact=False,
-            submitted_at='2022-01-01'
+            submitted_at='2022-01-01 00:00:00+00:00'
         )
         feedback.save()
         signal.save()
@@ -236,8 +236,8 @@ class ActionTestMixin:
 
         signal.refresh_from_db()
         self.assertEqual(signal.notes.count(), 1)
-        self.assertEquals(signal.notes.first().text,
-                          'E-mail is niet verzonden omdat er verdachte tekens in de meldtekst staan.')
+        self.assertEqual(signal.notes.first().text,
+                         'E-mail is niet verzonden omdat er verdachte tekens in de meldtekst staan.')
 
 
 class TestSignalCreatedAction(ActionTestMixin, TestCase):
@@ -650,8 +650,8 @@ class TestSignalHandledNegativeAction(ActionTestMixin, TestCase):
 
         self.signal.refresh_from_db()
         self.assertEqual(self.signal.notes.count(), 1)
-        self.assertEquals(self.signal.notes.first().text,
-                          'E-mail is niet verzonden omdat er verdachte tekens in de meldtekst staan.')
+        self.assertEqual(self.signal.notes.first().text,
+                         'E-mail is niet verzonden omdat er verdachte tekens in de meldtekst staan.')
 
     @override_settings(FEATURE_FLAGS={
         'REPORTER_MAIL_HANDLED_NEGATIVE_CONTACT_ENABLED': False,

--- a/api/app/signals/apps/questionnaires/rest_framework/views/public/questionnaires.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public/questionnaires.py
@@ -19,7 +19,7 @@ class PublicQuestionnaireViewSet(DatapuntViewSet):
     lookup_field = 'uuid'
     lookup_url_kwarg = 'uuid'
 
-    queryset = Questionnaire.objects.active()
+    queryset = Questionnaire.objects.active().order_by('-created_at')
     queryset_detail = Questionnaire.objects.active()
 
     serializer_class = PublicQuestionnaireSerializer

--- a/api/app/signals/apps/questionnaires/rest_framework/views/public/questions.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/views/public/questions.py
@@ -20,7 +20,7 @@ class PublicQuestionViewSet(DatapuntViewSet):
     lookup_field = 'retrieval_key'
     lookup_url_kwarg = 'retrieval_key'
 
-    queryset = Question.objects.all()
+    queryset = Question.objects.all().order_by('-created_at')
     queryset_detail = Question.objects.all()
 
     serializer_class = PublicQuestionSerializer

--- a/api/app/signals/apps/questionnaires/tests/services/test_questionnaires.py
+++ b/api/app/signals/apps/questionnaires/tests/services/test_questionnaires.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Gemeente Amsterdam
 from datetime import datetime, timedelta
 
+import pytz
 from django.core.exceptions import ValidationError as django_validation_error
 from django.test import TestCase
 from freezegun import freeze_time
@@ -556,7 +557,7 @@ class TestQuestionnairesService(TestCase):
 
     def test_get_session_expired(self):
         # A session that expired should raise a SessionExpired
-        signal_created_at = datetime(2021, 8, 18, 12, 0, 0)
+        signal_created_at = datetime(2021, 8, 18, 12, 0, 0, tzinfo=pytz.UTC)
         submit_before = signal_created_at + timedelta(days=REACTION_REQUEST_DAYS_OPEN)
         get_session_at = signal_created_at + timedelta(days=REACTION_REQUEST_DAYS_OPEN * 2)
 
@@ -590,14 +591,14 @@ class TestGetAnswersFromSession(TestCase):
         self.graph = _question_graph_with_decision()
         self.session = SessionFactory.create(questionnaire__graph=self.graph)
 
-        with freeze_time('2021-08-17 12:00:00'):
+        with freeze_time('2021-08-17 12:00:00+00:00'):
             AnswerFactory.create(session=self.session, question=self.graph.first_question, payload='no')
 
-        with freeze_time('2021-08-17 12:10:00'):
+        with freeze_time('2021-08-17 12:10:00+00:00'):
             AnswerFactory.create(session=self.session, question=self.graph.first_question, payload='yes')
 
         self.q2 = Question.objects.get(retrieval_key='q_yes')
-        with freeze_time('2021-08-17 12:20:00'):
+        with freeze_time('2021-08-17 12:20:00+00:00'):
             AnswerFactory.create(session=self.session, question=self.q2, payload='yes happy')
 
     def test_get_latest_answers(self):

--- a/api/app/signals/apps/questionnaires/tests/services/test_session.py
+++ b/api/app/signals/apps/questionnaires/tests/services/test_session.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2021 Gemeente Amsterdam
 from datetime import datetime, timedelta
 
+import pytz
 from django.core.exceptions import ValidationError as django_validation_error
 from django.test import TestCase
 from freezegun import freeze_time
@@ -475,8 +476,8 @@ class TestSessionService(TestCase):
 
     def test_create_answer_session_expired(self):
         # expired session must not accept answers
-        t_creation = datetime(2021, 1, 1, 0, 0, 0)
-        t_now = datetime(2021, 6, 1, 0, 0, 0)
+        t_creation = datetime(2021, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
+        t_now = datetime(2021, 6, 1, 0, 0, 0, tzinfo=pytz.UTC)
 
         q_graph = create_diamond_plus()
         session = SessionFactory.create(questionnaire__graph=q_graph, created_at=t_creation, submit_before=t_creation)
@@ -523,8 +524,8 @@ class TestSessionService(TestCase):
         q_graph = create_diamond_plus()
         # Sessions that have expired because the submit_before deadline was
         # passed are no longer publicly available:
-        t_creation = datetime(2021, 1, 1, 0, 0, 0)
-        t_now = datetime(2021, 6, 1, 0, 0, 0)
+        t_creation = datetime(2021, 1, 1, 0, 0, 0, tzinfo=pytz.UTC)
+        t_now = datetime(2021, 6, 1, 0, 0, 0, tzinfo=pytz.UTC)
 
         session_expired_i = SessionFactory.create(
             questionnaire__graph=q_graph,

--- a/api/app/signals/apps/services/domain/images.py
+++ b/api/app/signals/apps/services/domain/images.py
@@ -24,7 +24,7 @@ class DataUriImageEncodeService:
             width = int((max_size / image.height) * image.width)
             height = max_size
 
-        return image.resize(size=(width, height), resample=Image.LANCZOS).convert('RGB')
+        return image.resize(size=(width, height), resample=Image.Resampling.LANCZOS).convert('RGB')
 
     @staticmethod
     def get_context_data_images(signal, max_size):

--- a/api/app/signals/apps/services/tests/domain/test_images.py
+++ b/api/app/signals/apps/services/tests/domain/test_images.py
@@ -19,14 +19,14 @@ class TestImagesService(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         too_wide.width = 1600
         too_wide.height = 800
         DataUriImageEncodeService.resize(too_wide, 800)
-        too_wide.resize.assert_called_with(size=(800, 400), resample=Image.LANCZOS)
+        too_wide.resize.assert_called_with(size=(800, 400), resample=Image.Resampling.LANCZOS)
 
     def test_resize_iamge_too_heigh(self):
         too_heigh = MagicMock()
         too_heigh.width = 800
         too_heigh.height = 1600
         DataUriImageEncodeService.resize(too_heigh, 800)
-        too_heigh.resize.assert_called_with(size=(400, 800), resample=Image.LANCZOS)
+        too_heigh.resize.assert_called_with(size=(400, 800), resample=Image.Resampling.LANCZOS)
 
     def test_get_context_data_no_images(self):
         AttachmentFactory(_signal=self.signal, file__filename='blah.txt', file__data=b'blah', is_image=False)

--- a/api/app/signals/apps/signals/tests/test_models.py
+++ b/api/app/signals/apps/signals/tests/test_models.py
@@ -382,7 +382,7 @@ class TestSignalModel(TestCase):
         signal = factories.SignalFactory.create()
         feedback = FeedbackFactory.create(
             _signal=signal,
-            submitted_at='2022-01-01',
+            submitted_at='2022-01-01 00:00:00+00:00',
             allows_contact=False
         )
         feedback.save()
@@ -395,7 +395,7 @@ class TestSignalModel(TestCase):
         signal = factories.SignalFactory.create()
         feedback = FeedbackFactory.create(
             _signal=signal,
-            submitted_at='2022-01-01',
+            submitted_at='2022-01-01 00:00:00+00:00',
             allows_contact=True
         )
         feedback.save()
@@ -437,7 +437,7 @@ class TestSignalModel(TestCase):
         feedback = FeedbackFactory.create(
             _signal=signal,
             allows_contact=False,
-            submitted_at='2022-01-01'
+            submitted_at='2022-01-01 00:00:00+00:00'
         )
         feedback.save()
         self.assertTrue(signal.allows_contact)


### PR DESCRIPTION
## Description

Small clean-up of test-suite runtime warnings. Fixed timezone problems and used `self.assertEqual` in stead of `self.assertEquals`. This silences the majority of warnings caused by our code in the test suite - a number of libraries still cause warnings that need to be fixed in those libraries.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
