### PR TITLE
Product steering/250 (Fix public map endpoint filtering)

### DIFF
--- a/api/app/signals/apps/api/tests/test_public_signal_geography_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_public_signal_geography_endpoint.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Gemeente Amsterdam
+# Copyright (C) 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 from datetime import timedelta
 
 from django.contrib.gis.geos import Point
@@ -301,12 +301,13 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         Get all the signals when no category is set
         """
         cat1 = ParentCategoryFactory.create(name='trash')
+        plastic = CategoryFactory.create(parent=cat1, public_name='plastic_trash', is_public_accessible=True)
+        compost = CategoryFactory.create(parent=cat1, public_name='compost_trash', is_public_accessible=True)
 
-        SignalFactoryValidLocation.create(category_assignment__category=cat1)
+        SignalFactoryValidLocation.create(category_assignment__category=plastic)
+        SignalFactoryValidLocation.create(category_assignment__category=plastic)
 
-        cat2 = ParentCategoryFactory.create(name='animals')
-        SignalFactoryValidLocation.create(category_assignment__category=cat2)
-        SignalFactoryValidLocation.create(category_assignment__category=cat2)
+        SignalFactoryValidLocation.create(category_assignment__category=compost)
 
         response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000')
 
@@ -371,7 +372,6 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=GEANNULEERD)
         SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=VERZOEK_TOT_HEROPENEN)
         SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=GEMELD)
-
 
         response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000&'
                                    f'maincategory_slug={parent_cat.slug}')

--- a/api/app/signals/apps/api/tests/test_public_signal_geography_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_public_signal_geography_endpoint.py
@@ -13,6 +13,13 @@ from signals.apps.signals.factories import (
     SignalFactoryValidLocation
 )
 from signals.apps.signals.tests.valid_locations import ARENA, STADHUIS
+from signals.apps.signals.workflow import (
+    AFGEHANDELD,
+    AFGEHANDELD_EXTERN,
+    GEANNULEERD,
+    GEMELD,
+    VERZOEK_TOT_HEROPENEN
+)
 from signals.test.utils import SignalsBaseApiTestCase
 
 
@@ -349,3 +356,67 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
 
         data = response.json()
         self.assertEqual(3, len(data['features']))
+
+    def test_exclude_closed_states(self):
+        """
+        Signals in "closed" states should be excluded from the public map.
+
+        Failing testcase for VNG product-steering #250.
+        """
+        parent_cat = ParentCategoryFactory.create()
+        child_cat = CategoryFactory.create(name='child', parent=parent_cat, is_public_accessible=True)
+
+        SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=AFGEHANDELD)
+        SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=AFGEHANDELD_EXTERN)
+        SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=GEANNULEERD)
+        SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=VERZOEK_TOT_HEROPENEN)
+        SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=GEMELD)
+
+
+        response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000&'
+                                   f'maincategory_slug={parent_cat.slug}')
+
+        self.assertEqual(200, response.status_code)
+        data = response.json()
+        self.assertEqual(1, len(data['features']))
+
+    def test_exclude_non_public_categories(self):
+        """
+        Signals in non-public categories should be excluded from the public map.
+
+        Failing testcase for VNG product-steering #250.
+        """
+        parent_cat = ParentCategoryFactory.create()
+        non_accessible_cat = CategoryFactory.create(parent=parent_cat, is_public_accessible=False)
+        accessible_cat = CategoryFactory.create(parent=parent_cat, is_public_accessible=True)
+
+        SignalFactoryValidLocation.create(category_assignment__category=non_accessible_cat, status__state=GEMELD)
+        SignalFactoryValidLocation.create(category_assignment__category=accessible_cat, status__state=GEMELD)
+
+        response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000&'
+                                   f'maincategory_slug={parent_cat.slug}')
+
+        self.assertEqual(200, response.status_code)
+        data = response.json()
+        self.assertEqual(1, len(data['features']))
+
+    def test_exclude_closed_states_and_non_public_categories(self):
+        """
+        Signals in non-public categories that are in a "closed" state should be
+        excluded from the public map.
+
+        Succeeding testcase for VNG product-steering #250. (Shows only signals
+        that are both in non-public categories and in closed state are excluded
+        from the public map.)
+        """
+        parent_cat = ParentCategoryFactory.create()
+        non_accessible_cat = CategoryFactory.create(parent=parent_cat, is_public_accessible=False)
+
+        SignalFactoryValidLocation.create(category_assignment__category=non_accessible_cat, status__state=AFGEHANDELD)
+
+        response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000&'
+                                   f'maincategory_slug={parent_cat.slug}')
+
+        self.assertEqual(200, response.status_code)
+        data = response.json()
+        self.assertEqual(None, data['features'])

--- a/api/app/signals/apps/api/views/signals/public/signals.py
+++ b/api/app/signals/apps/api/views/signals/public/signals.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
-from django.db.models import CharField, Min, Value
+from django.db.models import CharField, Min, Q, Value
 from django.db.models.expressions import Case, When
 from django.db.models.functions import JSONObject
 from django.http import Http404
@@ -106,10 +106,10 @@ class PublicSignalViewSet(GenericViewSet):
             )
         ).exclude(
             # Only signals that are in an "Open" state
-            status__state__in=[AFGEHANDELD, AFGEHANDELD_EXTERN, GEANNULEERD, VERZOEK_TOT_HEROPENEN],
-        ).exclude(
+            Q(status__state__in=[AFGEHANDELD, AFGEHANDELD_EXTERN, GEANNULEERD, VERZOEK_TOT_HEROPENEN]) |
+
             # Only Signal's that are in categories that are publicly accessible
-            category_assignment__category__is_public_accessible=False,
+            Q(category_assignment__category__is_public_accessible=False),
         )
 
         # Paginate our queryset and turn it into a GeoJSON feature collection:

--- a/api/app/signals/apps/api/views/signals/public/signals.py
+++ b/api/app/signals/apps/api/views/signals/public/signals.py
@@ -107,7 +107,7 @@ class PublicSignalViewSet(GenericViewSet):
         ).exclude(
             # Only signals that are in an "Open" state
             status__state__in=[AFGEHANDELD, AFGEHANDELD_EXTERN, GEANNULEERD, VERZOEK_TOT_HEROPENEN],
-
+        ).exclude(
             # Only Signal's that are in categories that are publicly accessible
             category_assignment__category__is_public_accessible=False,
         )

--- a/api/app/signals/apps/api/views/signals/public/signals.py
+++ b/api/app/signals/apps/api/views/signals/public/signals.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
+# Copyright (C) 2019 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 from django.db.models import CharField, Min, Value
 from django.db.models.expressions import Case, When
 from django.db.models.functions import JSONObject


### PR DESCRIPTION
## Description

Closed nuisance complaints and those in non public categories are not correctly filtered. This PR contains failing test, fixes the filtering, and fixes a test that was inappropriately assigning nuisance complaints to main categories (behavior currently not supported by Signalen).

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
