### PR TITLE
Only save location and timestamp to avoid unwanted state changes

### DIFF
--- a/api/app/signals/apps/signals/management/commands/assign_area.py
+++ b/api/app/signals/apps/signals/management/commands/assign_area.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
                 new_location.save()
 
                 signal.location = new_location
-                signal.save()
+                signal.save(update_fields=['location', 'updated_at'])
 
                 n_assigned += 1
             else:


### PR DESCRIPTION
## Description

Unwanted state changes were observed under load while updating the area_names. This is most likely caused by writing back too much of the Signal model when saving a location update.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations
- [X] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
