### PR TITLE
Added additional information to the public signals geography response

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -3127,6 +3127,19 @@ components:
                       name:
                         description: The public name of the category (fallback is the internal name)
                         example: Zwerfvuil op straat
+                      slug:
+                        description: The slug of the category
+                        example: zwerfvuil-op-straat
+                      parent:
+                        description: The parent category the signal is in
+                        type: object
+                        properties:
+                          name:
+                            description: The public name of the parent category (fallback is the internal name)
+                            example: Afval
+                          slug:
+                            description: The slug of the parent category
+                            example: afval
                   created_at:
                     type: string
                     format: date-time

--- a/api/app/signals/apps/api/tests/test_public_signal_geography_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_public_signal_geography_endpoint.py
@@ -173,7 +173,10 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
 
         data = response.json()
         self.assertEqual(1, len(data['features']))
-        self.assertEqual(data['features'][0]['properties']['category']['name'], child_category.public_name)
+        self.assertEqual(child_category.public_name, data['features'][0]['properties']['category']['name'])
+        self.assertEqual(child_category.slug, data['features'][0]['properties']['category']['slug'])
+        self.assertEqual(parent_category.name, data['features'][0]['properties']['category']['parent']['name'])
+        self.assertEqual(parent_category.slug, data['features'][0]['properties']['category']['parent']['slug'])
 
     def test_lon_lat_parameters(self):
         """
@@ -197,7 +200,10 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         self.assertEqual(1, len(data['features']))
 
         for feature in data['features']:
-            self.assertEqual(feature['properties']['category']['name'], child_category.public_name)
+            self.assertEqual(child_category.public_name, feature['properties']['category']['name'])
+            self.assertEqual(child_category.slug, feature['properties']['category']['slug'])
+            self.assertEqual(parent_category.name, feature['properties']['category']['parent']['name'])
+            self.assertEqual(parent_category.slug, feature['properties']['category']['parent']['slug'])
 
     def test_missing_bbox_and_lonlat(self):
         """
@@ -248,7 +254,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         """
         An empty public_name (None) must fallback to the name
         """
-        parent_category = ParentCategoryFactory.create()
+        parent_category = ParentCategoryFactory.create(public_name='parent-test')
         child_category = CategoryFactory.create(parent=parent_category, public_name='test', is_public_accessible=True)
         SignalFactoryValidLocation.create(category_assignment__category=child_category)
 
@@ -261,12 +267,15 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         self.assertEqual(1, len(data['features']))
         self.assertEqual(child_category.public_name, data['features'][0]['properties']['category']['name'])
         self.assertNotEqual(child_category.name, data['features'][0]['properties']['category']['name'])
+        self.assertEqual(child_category.slug, data['features'][0]['properties']['category']['slug'])
+        self.assertEqual(parent_category.public_name, data['features'][0]['properties']['category']['parent']['name'])
+        self.assertEqual(parent_category.slug, data['features'][0]['properties']['category']['parent']['slug'])
 
     def test_public_name_is_none(self):
         """
         An empty public_name (None) must fallback to the name
         """
-        parent_category = ParentCategoryFactory.create()
+        parent_category = ParentCategoryFactory.create(public_name=None)
         child_category = CategoryFactory.create(parent=parent_category, public_name=None, is_public_accessible=True)
         SignalFactoryValidLocation.create(category_assignment__category=child_category)
 
@@ -278,12 +287,15 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         data = response.json()
         self.assertEqual(1, len(data['features']))
         self.assertEqual(child_category.name, data['features'][0]['properties']['category']['name'])
+        self.assertEqual(child_category.slug, data['features'][0]['properties']['category']['slug'])
+        self.assertEqual(parent_category.name, data['features'][0]['properties']['category']['parent']['name'])
+        self.assertEqual(parent_category.slug, data['features'][0]['properties']['category']['parent']['slug'])
 
     def test_public_name_is_empty(self):
         """
         An empty public_name ('') must fallback to the name
         """
-        parent_category = ParentCategoryFactory.create()
+        parent_category = ParentCategoryFactory.create(public_name='')
         child_category = CategoryFactory.create(parent=parent_category, public_name='', is_public_accessible=True)
         SignalFactoryValidLocation.create(category_assignment__category=child_category)
 
@@ -295,6 +307,9 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         data = response.json()
         self.assertEqual(1, len(data['features']))
         self.assertEqual(child_category.name, data['features'][0]['properties']['category']['name'])
+        self.assertEqual(child_category.slug, data['features'][0]['properties']['category']['slug'])
+        self.assertEqual(parent_category.name, data['features'][0]['properties']['category']['parent']['name'])
+        self.assertEqual(parent_category.slug, data['features'][0]['properties']['category']['parent']['slug'])
 
     def test_no_category_filters(self):
         """

--- a/api/app/signals/apps/api/views/signals/public/signals.py
+++ b/api/app/signals/apps/api/views/signals/public/signals.py
@@ -97,7 +97,19 @@ class PublicSignalViewSet(GenericViewSet):
                                      then='category_assignment__category__name'),
                                 default='category_assignment__category__public_name',
                                 output_field=CharField(),
-                            )
+                            ),
+                            slug='category_assignment__category__slug',
+                            parent=JSONObject(
+                                name=Case(
+                                    When(category_assignment__category__parent__public_name__exact='',
+                                         then='category_assignment__category__parent__name'),
+                                    When(category_assignment__category__parent__public_name__isnull=True,
+                                         then='category_assignment__category__parent__name'),
+                                    default='category_assignment__category__parent__public_name',
+                                    output_field=CharField(),
+                                ),
+                                slug='category_assignment__category__parent__slug'
+                            ),
                         ),
                         # Creation date of the Signal
                         created_at='created_at',


### PR DESCRIPTION
## Description

Added additional category information to the properties of the features in the FeatureCollection response of the public signals geography endpoint (SIG-4761 on the Amsterdam JIRA board)

Example response:
```JSON 
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          4.890986949631043,
          52.41875227274259
        ]
      },
      "properties": {
        "category": {
          "name": "Zwerfvuil op straat",
          "slug": "zwerfvuil-op-straat",
          "parent": {
            "name": "afval"
            "slug": "afval"
          }
        },
        "created_at": "2022-09-06T00:00:00+00:00"
      }
    }
  ]
}
```

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
