### PR TITLE
SIG-4791 extra_property with a location only must be shown as "Locatie gepind op de kaart" in the signal created email

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/signal_created.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_created.py
@@ -59,7 +59,7 @@ class SignalCreatedAction(AbstractAction):
                 context[extra_property['label']].append(self._get_answer_from_extra_property(extra_property['answer']))
         return context
 
-    def _get_answer_from_extra_property(self, extra_property):
+    def _get_answer_from_extra_property(self, extra_property):  # noqa C901
         """
         Returns the first option that is available in the extra property and not empty as the answer.
         Defaults to '-' if no option is available.
@@ -76,6 +76,12 @@ class SignalCreatedAction(AbstractAction):
             return extra_property['id']
         elif 'type' in extra_property and extra_property['type']:
             return extra_property['type']
+        elif set(extra_property.keys()) == {'location'}:
+            # Hacky solution that will be refactored when Questionnaires will be in use.
+            #
+            # Sometimes it happens the extra_properties of a selected object only contains a location
+            # In this case we want to show "Locatie gepind op de kaart"
+            return 'Locatie gepind op de kaart'
         elif extra_property:
             return extra_property
         else:

--- a/api/app/signals/apps/email_integrations/tests/test_action_signal_created_extra_properties.py
+++ b/api/app/signals/apps/email_integrations/tests/test_action_signal_created_extra_properties.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+from django.conf import settings
+from django.core import mail
+from django.test import TestCase
+
+from signals.apps.email_integrations.actions import SignalCreatedAction
+from signals.apps.email_integrations.models import EmailTemplate
+from signals.apps.signals import workflow
+from signals.apps.signals.factories import SignalFactory
+from signals.apps.signals.models import Note
+
+
+class TestSignalCreatedActionExtraProperties(TestCase):
+    state = workflow.GEMELD
+    action = SignalCreatedAction()
+
+    def setUp(self):
+        EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_CREATED,
+                                     title='Uw melding {{ formatted_signal_id }}'
+                                           f' {EmailTemplate.SIGNAL_CREATED}',
+                                     body='{% for label, answers in extra_properties.items %}{{ label }} {% for answer in answers %}{{ answer}}{% if not forloop.last %}, {% endif %}{% endfor %} {% endfor %}')  # noqa
+
+    def test_signal_created_with_extra_properties(self):
+        self.assertEqual(len(mail.outbox), 0)
+
+        extra_properties = [
+            {
+                "id": "test-1",
+                "label": "Is dit de eerste vraag?",
+                "answer": "Ja, en dit is het antwoord op de eerste vraag",
+                "category_url": "/signals/v1/public/terms/categories/overig/sub_categories/overig"
+            }, {
+                "id": "test-2",
+                "label": "Is dit de tweede vraag en selecteren wij hier een of meerdere objecten?",
+                "answer": [{
+                    "id": 12345,
+                    "type": "type-1",
+                    "description": "Overig lichtpunt",
+                    "label": "Overig lichtpunt",
+                }, {
+                    "id": 67890,
+                    "type": "not-on-map",
+                    "label": "Lichtpunt niet op de kaart"
+                }, {
+                    "type": "not-on-map"
+                }],
+                "category_url": "/signals/v1/public/terms/categories/overig/sub_categories/overig"
+            }, {
+                "id": "extra_straatverlichting_probleem",
+                "label": "Probleem",
+                "category_url": "/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/lantaarnpaal-straatverlichting",  # noqa
+                "answer": {
+                    "id": "lamp_doet_het_niet",
+                    "label": "Lamp doet het niet",
+                    "info": ""
+                }
+            },
+            {
+                "id": "extra_straatverlichting",
+                "label": "Denkt u dat de situatie gevaarlijk is?",
+                "category_url": "/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/lantaarnpaal-straatverlichting",  # noqa
+                "answer": {
+                    "id": "niet_gevaarlijk",
+                    "label": "Nee, niet gevaarlijk",
+                    "info": ""
+                }
+            },
+            {
+                "id": "extra_fietswrak",
+                "label": "Extra informatie",
+                "answer": "2 wrakken met hele oude gemeentelijke labels en 2 tegen een lantaarnpaal in het gras en nog een losse zwarte met zachte band",  # noqa
+                "category_url": "/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/fietswrak"  # noqa
+            }
+        ]
+
+        signal = SignalFactory.create(status__state=self.state, reporter__email='test@example.com',
+                                      extra_properties=extra_properties)
+
+        self.assertTrue(self.action(signal, dry_run=False))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
+        self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
+        self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
+
+        self.assertIn('Is dit de eerste vraag?', mail.outbox[0].body)
+        self.assertIn('Ja, en dit is het antwoord op de eerste vraag', mail.outbox[0].body)
+        self.assertIn('Overig lichtpunt, Lichtpunt niet op de kaart, not-on-map', mail.outbox[0].body)
+        self.assertIn('Probleem', mail.outbox[0].body)
+        self.assertIn('Lamp doet het niet', mail.outbox[0].body)
+        self.assertIn('Denkt u dat de situatie gevaarlijk is?', mail.outbox[0].body)
+        self.assertIn('Nee, niet gevaarlijk', mail.outbox[0].body)
+        self.assertEqual(Note.objects.count(), 1)
+        self.assertTrue(Note.objects.filter(text=self.action.note).exists())
+
+    def test_signal_created_with_extra_properties_set_to_none(self):
+        self.assertEqual(len(mail.outbox), 0)
+
+        signal = SignalFactory.create(status__state=self.state, reporter__email='test@example.com',
+                                      extra_properties=None)
+
+        self.assertTrue(self.action(signal, dry_run=False))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
+        self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
+        self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
+
+        self.assertEqual(Note.objects.count(), 1)
+        self.assertTrue(Note.objects.filter(text=self.action.note).exists())
+
+    def test_signal_created_with_extra_properties_selected_objects_only_location(self):
+        self.assertEqual(len(mail.outbox), 0)
+
+        extra_properties = [
+            {
+                "id": "extra_straatverlichting_nummer",
+                "label": "Lichtpunt(en) op kaart",
+                "answer": {
+                    "location": {
+                        "address": {
+                            "postcode": "1016EA",
+                            "huisnummer": "237A",
+                            "woonplaats": "Amsterdam",
+                            "openbare_ruimte": "Keizersgracht"
+                        },
+                        "coordinates": {
+                            "lat": 52.37223359027052,
+                            "lng": 4.884936393337258
+                        }
+                    }
+                },
+                "category_url": "/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/lantaarnpaal-straatverlichting"  # noqa
+            }
+        ]
+
+        signal = SignalFactory.create(status__state=self.state, reporter__email='test@example.com',
+                                      extra_properties=extra_properties)
+
+        self.assertTrue(self.action(signal, dry_run=False))
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, f'Uw melding {signal.get_id_display()} {self.action.key}')
+        self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
+        self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
+        self.assertIn('Lichtpunt(en) op kaart', mail.outbox[0].body)
+        self.assertIn('Locatie gepind op de kaart', mail.outbox[0].body)
+        self.assertIn('Lichtpunt(en) op kaart Locatie gepind op de kaart', mail.outbox[0].body)
+
+        self.assertEqual(Note.objects.count(), 1)
+        self.assertTrue(Note.objects.filter(text=self.action.note).exists())


### PR DESCRIPTION
## Description

If a extra_property answer only contains a location this must be shown as "Locatie gepind op de kaart" in the signal created e-mail.

Example of the extra_property:
```JSON
{
      "id": "extra_straatverlichting_nummer",
      "label": "Lichtpunt(en) op kaart",
      "answer": {
        "location": {
          "address": {
            "postcode": "1016EA",
            "huisnummer": "237A",
            "woonplaats": "Amsterdam",
            "openbare_ruimte": "Keizersgracht"
          },
          "coordinates": {
            "lat": 52.37223359027052,
            "lng": 4.884936393337258
          }
        }
      },
      "category_url": "/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/lantaarnpaal-straatverlichting"
},
```

The generated e-mail:

![Screenshot from 2022-09-13 11-48-16](https://user-images.githubusercontent.com/23056530/190117553-c4ae1982-c8ab-4b05-9693-f236ff32adf5.png)


## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
