### PR TITLE
Bumped Django 3.2.16

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,7 +24,7 @@ debtcollector==2.5.0
 defusedxml==0.7.1
 Deprecated==1.2.13
 distlib==0.3.5
-Django==3.2.15
+Django==3.2.16
 django-appconf==1.0.5
 django-celery-beat==2.3.0
 django-celery-email==3.0.0


### PR DESCRIPTION
## Description

Bumped Django 3.2.16

```
CVE-2022-41323: Potential denial-of-service vulnerability in internationalized URLs
Internationalized URLs were subject to potential denial of service attack via the locale parameter. This is now escaped to avoid this possibility.

This issue has medium severity, according to the Django security policy.

Thanks to Benjamin Balder Bach for the report.
```

More information about this Django update can be found on https://www.djangoproject.com/weblog/2022/oct/04/security-releases/

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
