### PR TITLE
Refactored the Health app to contain all rest code in the "rest_frame…

### DIFF
--- a/api/app/signals/apps/health/rest_framework/__init__.py
+++ b/api/app/signals/apps/health/rest_framework/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam

--- a/api/app/signals/apps/health/rest_framework/views.py
+++ b/api/app/signals/apps/health/rest_framework/views.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import logging
 
 from django.apps import apps

--- a/api/app/signals/apps/health/tests/rest_framework/__init__.py
+++ b/api/app/signals/apps/health/tests/rest_framework/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam

--- a/api/app/signals/apps/health/tests/rest_framework/test_endpoints.py
+++ b/api/app/signals/apps/health/tests/rest_framework/test_endpoints.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam
 from unittest import mock
 
 from django.core.exceptions import ImproperlyConfigured
@@ -17,7 +17,7 @@ class TestHealthEndpoints(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b'Connectivity OK')
 
-    @mock.patch('signals.apps.health.views.connection')
+    @mock.patch('signals.apps.health.rest_framework.views.connection')
     def test_status_health_failed(self, mocked_connection):
         mocked_cursor = mock.MagicMock()
         mocked_cursor.execute.side_effect = Error()

--- a/api/app/signals/apps/health/urls.py
+++ b/api/app/signals/apps/health/urls.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam
 from django.urls import path
 
-from signals.apps.health import views
+from signals.apps.health.rest_framework import views
 
 urlpatterns = [
     path('health', views.health),


### PR DESCRIPTION
## Description

Refactored the Health app to contain all rest code in the "rest_framework" folder

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
