### PR TITLE
Add area_code and area_name fields to location CSV dumps

### DIFF
--- a/api/app/signals/apps/reporting/csv/datawarehouse/locations.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/locations.py
@@ -23,6 +23,8 @@ def create_locations_csv(location: str) -> str:
         'created_at',
         'updated_at',
         '_signal_id',
+        'area_code',
+        'area_name',
         lat=ExpressionWrapper(Func('geometrie', function='st_x'), output_field=FloatField()),
         lng=ExpressionWrapper(Func('geometrie', function='st_y'), output_field=FloatField()),
         _stadsdeel=Coalesce(map_choices('stadsdeel', STADSDELEN), Cast('area_code', output_field=CharField())),
@@ -45,7 +47,7 @@ def create_locations_csv(location: str) -> str:
 
     ordered_field_names = ['id', 'lat', 'lng', 'stadsdeel', 'buurt_code', 'address', 'address_text', 'created_at',
                            'updated_at', 'extra_properties', '_signal_id', 'address_street', 'address_number',
-                           'address_postalcode', 'address_city']
+                           'address_postalcode', 'address_city', 'area_code', 'area_name']
     reorder_csv(csv_file.name, ordered_field_names, remove_leading_trailing_quotes=True)
 
     return csv_file.name

--- a/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
+++ b/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
@@ -242,7 +242,7 @@ class TestDatawarehouse(testcases.TestCase):
                 # self.assertEqual(row['type_created_at'], str(signal.type_assignment.created_at))
 
     def test_create_locations_csv(self):
-        signal = SignalFactory.create()
+        signal = SignalFactory.create(location__area_code='AREACODE', location__area_name='AREA_NAME')
         location = signal.location
 
         csv_file = datawarehouse.create_locations_csv(self.csv_tmp_dir)
@@ -276,6 +276,8 @@ class TestDatawarehouse(testcases.TestCase):
                 self.assertEqual(row['address_number'], str(location.address['huisnummer']))
                 self.assertEqual(row['address_postalcode'], location.address['postcode'])
                 self.assertEqual(row['address_city'], location.address['woonplaats'])
+                self.assertEqual(row['area_code'], location.area_code)
+                self.assertEqual(row['area_name'], location.area_name)
 
     def test_create_reporters_csv(self):
         signal = SignalFactory.create()


### PR DESCRIPTION
## Description

The `area_code` and `area_name` fields as used by VNG installations are not part of the CSV dumps, this PR adds them.

(We disregard `_stadsdeel` field which can contain the `area_code` or `stadsdeel` as used in Amsterdam.)

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `master` and is up to date with `master`
- [x] Check that the PR targets `master`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
