### PR TITLE
Refactor workflow names

### DIFF
--- a/.github/workflows/build_and_push_to_docker_hub.yml
+++ b/.github/workflows/build_and_push_to_docker_hub.yml
@@ -1,4 +1,4 @@
-name: Build a Docker image and push to Docker when a new release is published
+name: Build Docker image and push to Docker Hub
 
 on:
   release:

--- a/.github/workflows/build_and_push_to_github_container_registry.yml
+++ b/.github/workflows/build_and_push_to_github_container_registry.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Build Docker image and optionally push to GitHub container registry
 
 on:
   push:

--- a/.github/workflows/manual_build_and_push_to_docker_hub.yml
+++ b/.github/workflows/manual_build_and_push_to_docker_hub.yml
@@ -28,6 +28,5 @@ jobs:
           cd api/
           docker build -t signalen/backend:${{ github.event.inputs.tag }} .
 
-
       - name: Push the tagged image to Docker
         run: docker push signalen/backend:${{ github.event.inputs.tag }}


### PR DESCRIPTION
This PR refactors the workflow names to make it more clear that they are specific to Docker Hub and GitHub Container Registry. Also the workflows are in line with the frontend, see https://github.com/Amsterdam/signals-frontend/pull/2348