### PR TITLE
Added a celery task to the search app to index all updated Signals in a given date range

### DIFF
--- a/api/app/signals/apps/search/tasks.py
+++ b/api/app/signals/apps/search/tasks.py
@@ -50,9 +50,11 @@ def delete_from_elastic(signal):
 
 
 @app.task
-def index_signals_updated_in_date_range(from_date, to_date):
+def index_signals_updated_in_date_range(from_date=None, to_date=None):
     """
     Index all Signals updated in the given date range (Copied from the elastic_index management command)
+
+    The from_date and to_date are optional. By default, this task will update all signals changed in the last 2 days.
     """
     if not SignalDocument.ping():
         raise Exception('Elastic cluster is unreachable')

--- a/api/app/signals/apps/search/tasks.py
+++ b/api/app/signals/apps/search/tasks.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import logging
 
+from django.utils import timezone
 from elasticsearch import NotFoundError
 
 from signals.apps.search.documents.signal import SignalDocument
@@ -46,3 +47,40 @@ def delete_from_elastic(signal):
         signal_document.delete()
     except NotFoundError:
         log.warning(f'Signal {signal.id} not found in Elasticsearch')
+
+
+@app.task
+def index_signals_updated_in_date_range(from_date, to_date):
+    """
+    Index all Signals updated in the given date range (Copied from the elastic_index management command)
+    """
+    if not SignalDocument.ping():
+        raise Exception('Elastic cluster is unreachable')
+
+    if from_date:
+        from_date = timezone.make_aware(timezone.datetime.strptime(from_date, '%Y-%m-%d'))
+    else:
+        # Default is 2 days ago
+        from_date = timezone.now() - timezone.timedelta(days=2)
+
+    from_date = from_date.replace(hour=00, minute=00, second=00)  # Beginning of the day given in from_date
+
+    if to_date:
+        to_date = timezone.make_aware(timezone.datetime.strptime(to_date, '%Y-%m-%d'))
+    else:
+        # Default is today
+        to_date = timezone.now()
+
+    to_date = to_date + timezone.timedelta(days=1)
+    to_date = to_date.replace(hour=00, minute=00, second=00)  # Beginning of the day after the to_date
+
+    log.info(f'index_signals_updated_in_date_range - from {from_date}, to {to_date}')
+
+    if to_date < from_date:
+        log.warning('To date cannot be before the from date')
+        return
+
+    signal_qs = Signal.objects.filter(updated_at__range=[from_date, to_date]).order_by('-updated_at')
+    SignalDocument.index_documents(queryset=signal_qs)
+
+    log.info('index_signals_updated_in_date_range - done!')


### PR DESCRIPTION
## Description

Added a celery task to the search app to index all Signals updated in a given date range. This functionality is copied from the elastic_index management command.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations
- [X] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
