### PR TITLE
Added the setting "overwrite_files" for the DWH AzureStorage

### DIFF
--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -183,7 +183,8 @@ if AZURE_STORAGE_ENABLED:
             'azure_container': AZURE_CONTAINER
         },
         'datawarehouse': {
-            'azure_container': os.getenv('DWH_AZURE_STORAGE_CONTAINER_NAME', AZURE_CONTAINER)
+            'azure_container': os.getenv('DWH_AZURE_STORAGE_CONTAINER_NAME', AZURE_CONTAINER),
+            'overwrite_files': os.getenv('DWH_AZURE_OVERWRITE_FILES', True)
         }
     }
 

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -184,7 +184,7 @@ if AZURE_STORAGE_ENABLED:
         },
         'datawarehouse': {
             'azure_container': os.getenv('DWH_AZURE_STORAGE_CONTAINER_NAME', AZURE_CONTAINER),
-            'overwrite_files': os.getenv('DWH_AZURE_OVERWRITE_FILES', True)
+            'overwrite_files': os.getenv('DWH_AZURE_OVERWRITE_FILES', True) in TRUE_VALUES
         }
     }
 


### PR DESCRIPTION
## Description

Added the setting "overwrite_files" for the DWH AzureStorage. This settings is default "True" and can be set by the ENV variable "DWH_AZURE_OVERWRITE_FILES". This ensures the same behaviour as the current implementation of the SwiftStorage used in Amsterdam.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `master` and is up to date with `master`
- [X] Check that the PR targets `master`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
