### PR TITLE
Add service and celery task for deleting signals

### DIFF
--- a/api/app/signals/apps/services/domain/delete_signals.py
+++ b/api/app/signals/apps/services/domain/delete_signals.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+import uuid
+
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.db import transaction
+from django.utils import timezone
+
+from signals.apps.search.tasks import delete_from_elastic
+from signals.apps.signals.models import DeletedSignal, Signal
+from signals.apps.signals.workflow import AFGEHANDELD, GEANNULEERD, GESPLITST
+
+
+class SignalDeletionService:
+    STATE_CHOICES = (AFGEHANDELD, GEANNULEERD, GESPLITST, )
+
+    @staticmethod
+    def delete_signals(state, days, signal_id=None, dry_run=True):
+        """
+        Delete signals and child signals in given state and older than some number of days.
+        """
+        start_time = timezone.now()
+        SignalDeletionService.check_preconditions(state, days, signal_id)  # May raise a ValueError
+
+        batch_uuid = uuid.uuid4()
+
+        signal_qs = SignalDeletionService.get_queryset_for_deletion(state, days)
+
+        if signal_qs.exists():
+            with transaction.atomic():
+                SignalDeletionService.delete_queryset(signal_qs, batch_uuid, dry_run)
+
+        ds_qs = DeletedSignal.objects.filter(batch_uuid=batch_uuid)
+
+        return ds_qs.count(), batch_uuid, timezone.now() - start_time
+
+    @staticmethod
+    def check_preconditions(state, days, signal_id):
+        """
+        Check if all given options are valid
+        """
+        if not settings.FEATURE_FLAGS.get('DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED', False):
+            raise ValueError('Feature flag "DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED" is not enabled')
+
+        if state not in SignalDeletionService.STATE_CHOICES:
+            raise ValueError(f'Invalid state(s) provided must be one of "{", ".join(SignalDeletionService.STATE_CHOICES)}"')  # noqa
+
+        if days < 365:
+            raise ValueError('Invalid days provided must be at least 365')
+
+        if signal_id and not Signal.objects.filter(id=signal_id, parent_id__isnull=True).exists():
+            raise ValueError(f'Invalid signal_id provided, no (parent) Signal with id "{signal_id}" exists')
+
+    @staticmethod
+    def get_queryset_for_deletion(state, days, signal_id=None):
+        """
+        Select signals for deletion.
+
+        Selected signals are in given state and older than some number of days.
+        """
+        # Select Signals that are in the given states and the state has been set more than X days ago
+        # Only select normal signals or parent signals
+        queryset = Signal.objects.filter(parent_id__isnull=True, status__state=state,
+                                         status__created_at__lt=timezone.now() - timezone.timedelta(days=days))
+
+        if signal_id:
+            # A specific Signal ID was given, only select that Signal
+            queryset = queryset.filter(id=signal_id)
+
+        return queryset
+
+    @staticmethod
+    def delete_queryset(signal_qs, batch_uuid, dry_run):
+        """
+        Delete all signals and child signals included in given queryset
+        """
+        deleted_signals = []
+        for signal in signal_qs:
+            signal_id = signal.id
+            if signal.is_parent:
+                # First delete all child Signals
+                deleted_children = SignalDeletionService.delete_queryset(signal.children.all(), batch_uuid, dry_run)
+                deleted_signals.extend(deleted_children)
+
+            # Delete the Signal
+            SignalDeletionService._delete_signal(signal, batch_uuid, dry_run)
+            deleted_signals.append(signal_id)
+
+        return deleted_signals
+
+    @staticmethod
+    def _delete_signal(signal, batch_uuid, dry_run):
+        """
+        Deletes the given signal and all related objects. Will also remove the Signal from the elasticsearch index.
+        """
+        if not dry_run:
+            # Meta data needed for reporting
+            DeletedSignal.objects.create_from_signal(
+                signal=signal,
+                action='automatic',
+                note=SignalDeletionService.get_log_note(signal),
+                batch_uuid=batch_uuid
+            )
+
+            attachment_files = [attachment.file.path for attachment in signal.attachments.all()]
+            signal.attachments.all().delete()
+
+            try:
+                delete_from_elastic(signal=signal)
+            except Exception:
+                pass
+
+            signal.delete()
+
+            for attachment_file in attachment_files:
+                if default_storage.exists(attachment_file):
+                    default_storage.delete(attachment_file)
+
+    @staticmethod
+    def get_log_note(signal):
+        """
+        Get log note for DeletedSignal instance
+        """
+        now = timezone.now()
+        diff = now - signal.status.created_at
+        if signal.is_child:
+            diff = now - signal.parent.status.created_at
+            return f'Parent signal was in state "{signal.parent.status.get_state_display()}" for {diff.days} days'
+        return f'signal was in state "{signal.status.get_state_display()}" for {diff.days} days'

--- a/api/app/signals/apps/services/tests/domain/test_delete_signals.py
+++ b/api/app/signals/apps/services/tests/domain/test_delete_signals.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import timezone
+from freezegun import freeze_time
+
+from signals.apps.services.domain.delete_signals import SignalDeletionService
+from signals.apps.signals.factories import SignalFactory, SignalFactoryWithImage
+from signals.apps.signals.models import DeletedSignal, Signal
+from signals.apps.signals.workflow import AFGEHANDELD, GEANNULEERD, GEMELD, GESPLITST
+
+
+class TestSignalDeletionService(TestCase):
+    def setUp(self):
+        self.feature_flags = settings.FEATURE_FLAGS
+
+    def test_signal_should_not_be_deleted_feature_disabled(self):
+        """
+        Signal created 370 days ago and the final state set 369 days ago. The feature flag is disabled. So the signals
+        should not be deleted.
+        """
+        self.feature_flags['DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED'] = False
+
+        with freeze_time(timezone.now() - timezone.timedelta(days=370)):
+            signal = SignalFactory.create(status__state=AFGEHANDELD)
+
+        with self.assertRaises(ValueError):
+            SignalDeletionService.delete_signals(AFGEHANDELD, 365, dry_run=False)
+
+        self.assertTrue(Signal.objects.filter(id=signal.id).exists())
+        self.assertFalse(DeletedSignal.objects.filter(signal_id=signal.id).exists())
+
+    def test_signal_should_not_be_deleted_dry_run(self):
+        """
+        Signal created 370 days ago and the final state set 369 days ago. The dry run flag is set. So the signal should
+        not be deleted.
+        """
+        self.feature_flags['DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED'] = True
+
+        with freeze_time(timezone.now() - timezone.timedelta(days=370)):
+            signal = SignalFactory.create(status__state=GEANNULEERD)
+
+        with override_settings(FEATURE_FLAGS=self.feature_flags):
+            n_deleted, batch_uuid, t_taken = SignalDeletionService.delete_signals(GEANNULEERD, 365, dry_run=True)
+
+        self.assertTrue(Signal.objects.filter(id=signal.id).exists())
+        self.assertFalse(DeletedSignal.objects.filter(signal_id=signal.id).exists())
+        self.assertEqual(n_deleted, 0)
+
+    def test_signal_should_not_be_deleted(self):
+        """
+        Signal created 6 days ago and the final state set 5 days ago. So the signal should not be deleted.
+        """
+        self.feature_flags['DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED'] = True
+
+        with freeze_time(timezone.now() - timezone.timedelta(days=6)):
+            signal = SignalFactory.create(status__state=AFGEHANDELD)
+
+        with override_settings(FEATURE_FLAGS=self.feature_flags):
+            n_deleted, batch_uuid, t_taken = SignalDeletionService.delete_signals(AFGEHANDELD, 365, dry_run=False)
+
+        self.assertTrue(Signal.objects.filter(id=signal.id).exists())
+        self.assertFalse(DeletedSignal.objects.filter(signal_id=signal.id).exists())
+        self.assertEqual(n_deleted, 0)
+
+    def test_signal_should_be_deleted(self):
+        """
+        Signal created 370 days ago and the final state set 369 days ago. So the signal should be deleted.
+        """
+        self.feature_flags['DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED'] = True
+
+        with freeze_time(timezone.now() - timezone.timedelta(days=370)):
+            signal = SignalFactory.create(status__state=GEANNULEERD)
+
+        with override_settings(FEATURE_FLAGS=self.feature_flags):
+            n_deleted, batch_uuid, t_taken = SignalDeletionService.delete_signals(GEANNULEERD, 365, dry_run=False)
+
+        self.assertFalse(Signal.objects.filter(id=signal.id).exists())
+        self.assertTrue(DeletedSignal.objects.filter(signal_id=signal.id).exists())
+        self.assertEqual(n_deleted, 1)
+
+    def test_signal_should_not_be_deleted_wrong_states(self):
+        """
+        Signal created 370 days ago and the wrong state set 369 days ago. So the signal should be deleted.
+        """
+        self.feature_flags['DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED'] = True
+
+        with freeze_time(timezone.now() - timezone.timedelta(days=370)):
+            signal = SignalFactory.create(status__state=GEMELD)
+
+        with override_settings(FEATURE_FLAGS=self.feature_flags):
+            n_deleted, batch_uuid, t_taken = SignalDeletionService.delete_signals(AFGEHANDELD, 365, dry_run=False)
+
+        self.assertTrue(Signal.objects.filter(id=signal.id).exists())
+        self.assertFalse(DeletedSignal.objects.filter(signal_id=signal.id).exists())
+        self.assertEqual(n_deleted, 0)
+
+    def test_parent_and_child_signals_should_be_deleted(self):
+        """
+        Parent signal created 370 days ago and the final state set 369 days ago. So the signal and its children should
+        be deleted.
+        """
+        self.feature_flags['DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED'] = True
+
+        with freeze_time(timezone.now() - timezone.timedelta(days=370)):
+            parent_signal = SignalFactory.create(status__state=GEANNULEERD)
+            child_signal = SignalFactory.create(parent=parent_signal)
+
+        with override_settings(FEATURE_FLAGS=self.feature_flags):
+            n_deleted, batch_uuid, t_taken = SignalDeletionService.delete_signals(GEANNULEERD, 365, dry_run=False)
+
+        self.assertFalse(Signal.objects.filter(id=parent_signal.id).exists())
+        self.assertTrue(DeletedSignal.objects.filter(signal_id=parent_signal.id).exists())
+
+        self.assertFalse(Signal.objects.filter(id=child_signal.id).exists())
+        self.assertTrue(DeletedSignal.objects.filter(signal_id=child_signal.id).exists())
+        self.assertEqual(n_deleted, 2)
+
+    def test_signal_and_attachments_should_be_deleted(self):
+        """
+        Signal created 370 days ago and the final state set 369 days ago. So the signal should be deleted.
+        The attachment should be deleted.
+        """
+        self.feature_flags['DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED'] = True
+
+        with freeze_time(timezone.now() - timezone.timedelta(days=370)):
+            signal = SignalFactoryWithImage.create(status__state=GEANNULEERD)
+
+        attachment_file_path = signal.attachments.first().file.path
+        self.assertTrue(default_storage.exists(attachment_file_path))
+
+        with override_settings(FEATURE_FLAGS=self.feature_flags):
+            n_deleted, batch_uuid, t_taken = SignalDeletionService.delete_signals(GEANNULEERD, 365, dry_run=False)
+
+        self.assertFalse(Signal.objects.filter(id=signal.id).exists())
+        self.assertTrue(DeletedSignal.objects.filter(signal_id=signal.id).exists())
+        self.assertFalse(default_storage.exists(attachment_file_path))
+        self.assertEqual(n_deleted, 1)
+
+    def test_gesplits_parent_and_child_signals_should_be_deleted(self):
+        """
+        Parent signal created 370 days ago and the final state set 369 days ago. So the signal and its children should
+        be deleted.
+        """
+        self.feature_flags['DELETE_SIGNALS_IN_STATE_X_AFTER_PERIOD_Y_ENABLED'] = True
+
+        with freeze_time(timezone.now() - timezone.timedelta(days=370)):
+            parent_signal = SignalFactory.create(status__state=GESPLITST)
+            child_signal = SignalFactory.create(parent=parent_signal)
+
+        with override_settings(FEATURE_FLAGS=self.feature_flags):
+            n_deleted, batch_uuid, t_taken = SignalDeletionService.delete_signals(GESPLITST, 365, dry_run=False)
+
+        self.assertFalse(Signal.objects.filter(id=parent_signal.id).exists())
+        self.assertTrue(DeletedSignal.objects.filter(signal_id=parent_signal.id).exists())
+
+        self.assertFalse(Signal.objects.filter(id=child_signal.id).exists())
+        self.assertTrue(DeletedSignal.objects.filter(signal_id=child_signal.id).exists())
+
+        self.assertEqual(n_deleted, 2)

--- a/api/app/signals/apps/signals/tasks.py
+++ b/api/app/signals/apps/signals/tasks.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from signals.apps.services.domain.auto_create_children.service import AutoCreateChildrenService
+from signals.apps.services.domain.delete_signals import SignalDeletionService
 from signals.apps.services.domain.dsl import SignalDslService
 from signals.apps.signals.models import Reporter
 from signals.apps.signals.models.signal import Signal
@@ -101,3 +102,13 @@ def apply_auto_create_children(signal_id):
     :param signal_id:
     """
     AutoCreateChildrenService.run(signal_id=signal_id)
+
+
+@app.task
+def delete_closed_signals(days=365):
+    """
+    Delete Signals in one of the Signalen system's closed states
+    """
+    SignalDeletionService.delete_signals(AFGEHANDELD, days, dry_run=False)
+    SignalDeletionService().delete_signals(GEANNULEERD, days, dry_run=False)
+    SignalDeletionService().delete_signals(GESPLITST, days, dry_run=False)


### PR DESCRIPTION
## Description

To schedule deleting too-old closed signals via Celery Beat this PR adds a Celery task and service that allow deletion of old closed signals. This PR furthermore refactors the existing management command to delete signals as well.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
