### PR TITLE
Change string representation of choice to display attribute.

### DIFF
--- a/api/app/signals/apps/questionnaires/models/choice.py
+++ b/api/app/signals/apps/questionnaires/models/choice.py
@@ -11,6 +11,9 @@ class Choice(models.Model):
     payload = models.JSONField(blank=True, null=True)
     display = models.TextField(blank=True, null=True)
 
+    def __str__(self):
+        return self.display
+
     class Meta:
         order_with_respect_to = 'question'
 


### PR DESCRIPTION
## Description

Change string representation of choice model to display attribute, thereby making Django admin's questionnaire a little easier to use.


## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
