### PR TITLE
Added endpoint "/my/signals/me" that returns information about the currently logged in Reporter

### DIFF
--- a/api/app/signals/apps/my_signals/README.md
+++ b/api/app/signals/apps/my_signals/README.md
@@ -44,8 +44,25 @@ Request:
   "email": "reporter@example.com"
 }
 ```
+
+## /signals/v1/my/signals/me
+
+Method: GET  
+Status code: 200  
+Request:   
+```json
+{
+  "email": "reporter@example.com"
+}
+```
+
+Method: GET  
+Status code: 401  
 Response: 
 ```json
+{
+  "detail": "Invalid token."
+}
 ```
 
 ### /signals/v1/my/signals

--- a/api/app/signals/apps/my_signals/rest_framework/serializers/me.py
+++ b/api/app/signals/apps/my_signals/rest_framework/serializers/me.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+from rest_framework import serializers
+
+
+class MySignalsLoggedInReporterSerializer(serializers.Serializer):
+    email = serializers.EmailField(read_only=True)

--- a/api/app/signals/apps/my_signals/rest_framework/views/me.py
+++ b/api/app/signals/apps/my_signals/rest_framework/views/me.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+from rest_framework.generics import RetrieveAPIView
+
+from signals.apps.my_signals.models import Token
+from signals.apps.my_signals.rest_framework.authentication import MySignalsTokenAuthentication
+from signals.apps.my_signals.rest_framework.serializers.me import (
+    MySignalsLoggedInReporterSerializer
+)
+
+
+class MySignalsLoggedInReporterView(RetrieveAPIView):
+    """
+    Detail for the currently logged in Reporter
+    """
+    queryset = Token.objects.none()
+
+    authentication_classes = (MySignalsTokenAuthentication, )
+
+    serializer_class = MySignalsLoggedInReporterSerializer
+    pagination_class = None
+
+    def get_object(self):
+        return self.request.user

--- a/api/app/signals/apps/my_signals/templates/my_signals/swagger/public_openapi.yaml
+++ b/api/app/signals/apps/my_signals/templates/my_signals/swagger/public_openapi.yaml
@@ -37,6 +37,30 @@ paths:
         '200':
           description: A login link will be sent to the email if there are any Signals created by this reporter in the last 12 months
 
+  /signals/v1/my/signals/me:
+    get:
+      responses:
+        '200':
+          description: A couple of details of the logged in reporter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoggedInReporter'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/401'
+        '404':
+          description: When the feature has been disabled a 404 will be returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/404'
+      security:
+        - AuthToken: [ ]
+
   /signals/v1/my/signals:
     parameters:
       - name: status
@@ -351,6 +375,14 @@ components:
                 minItems: 2
                 maxItems: 3
               example: [ 4.87170696258545, 52.36805320057393 ]
+
+    LoggedInReporter:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          example: reporter@example.com
 
     401:
       type: object

--- a/api/app/signals/apps/my_signals/tests/rest_framework/views/test_my_signals_logged_in_reporter.py
+++ b/api/app/signals/apps/my_signals/tests/rest_framework/views/test_my_signals_logged_in_reporter.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+from django.test import override_settings
+from django.urls import include, path
+from django.utils import timezone
+from faker import Faker
+from freezegun import freeze_time
+from rest_framework.status import HTTP_200_OK, HTTP_401_UNAUTHORIZED
+from rest_framework.test import APITestCase
+
+from signals.apps.api.views import NamespaceView
+from signals.apps.my_signals.models import Token
+from signals.apps.signals.factories import SignalFactory
+
+urlpatterns = [
+    path('v1/relations/', NamespaceView.as_view(), name='signal-namespace'),
+    path('', include('signals.apps.my_signals.urls')),
+]
+
+
+class NameSpace:
+    pass
+
+
+test_urlconf = NameSpace()
+test_urlconf.urlpatterns = urlpatterns
+
+
+fake = Faker()
+
+
+@override_settings(ROOT_URLCONF=test_urlconf)
+class TestMySignalsLoggedInReporterEndpoint(APITestCase):
+    endpoint = '/my/signals/me'
+
+    def test_me_endpoint(self):
+        for _ in range(5):
+            email = fake.free_email()
+            SignalFactory.create(reporter__email=email)
+
+            token = Token.objects.create(reporter_email=email)
+            request_headers = {'HTTP_AUTHORIZATION': f'Token {token.key}'}
+
+            response = self.client.get(self.endpoint, **request_headers)
+
+            self.assertEqual(response.status_code, HTTP_200_OK)
+            self.assertEqual(response.json()['email'], email)
+
+    def test_me_endpoint_expired_token(self):
+        email = fake.free_email()
+
+        now = timezone.now()
+        with freeze_time(now - timezone.timedelta(days=7)):
+            token = Token.objects.create(reporter_email=email)
+
+        request_headers = {'HTTP_AUTHORIZATION': f'Token {token.key}'}
+
+        response = self.client.get(self.endpoint, **request_headers)
+        self.assertEqual(response.status_code, HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.json()['detail'], 'Invalid token.')

--- a/api/app/signals/apps/my_signals/urls.py
+++ b/api/app/signals/apps/my_signals/urls.py
@@ -6,6 +6,7 @@ from django.urls import include, path
 from django.views.generic.base import TemplateView
 
 from signals.apps.api.generics.routers import SignalsRouter
+from signals.apps.my_signals.rest_framework.views.me import MySignalsLoggedInReporterView
 from signals.apps.my_signals.rest_framework.views.signals import MySignalsViewSet
 from signals.apps.my_signals.rest_framework.views.token import ObtainMySignalsTokenViewSet
 
@@ -15,6 +16,7 @@ router.register(r'my/signals', MySignalsViewSet, basename='my-signals')
 
 urlpatterns = [
     path('my/signals/request-auth-token', ObtainMySignalsTokenViewSet.as_view()),
+    path('my/signals/me', MySignalsLoggedInReporterView.as_view()),
     path('', include((router.urls, 'signals.apps.my_signals'), namespace='my_signals')),
 
     # Swagger documentation for the public endpoints


### PR DESCRIPTION
## Description

Added endpoint "/my/signals/me" that returns information about the currently logged in Reporter. At this moment the response contains the email address.

GET: `/signals/v1/my/signals/me`
```json
{
    "email": "reporter@example.com"
}
```

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
