### PR TITLE
Run routing expressions on signal location or category change

### DIFF
--- a/api/app/signals/apps/signals/admin/expression.py
+++ b/api/app/signals/apps/signals/admin/expression.py
@@ -7,7 +7,9 @@ from signals.apps.dsl.ExpressionEvaluator import ExpressionEvaluator
 
 class RoutingExpressionAdmin(admin.ModelAdmin):
     list_filter = ['_expression___type__name', '_department__code']
-    list_display = ['_expression', '_department', 'is_active']
+    list_display = ['order', '_expression', '_department', 'is_active']
+    list_editable = ['order']
+    list_display_links = ['_expression']
 
     def save_model(self, request, obj, form, change):
         # if is_active is true, try to compile code, deactivate when invalid

--- a/api/app/signals/apps/signals/models/routing_expression.py
+++ b/api/app/signals/apps/signals/models/routing_expression.py
@@ -22,6 +22,10 @@ class RoutingExpression(models.Model):
     order = models.PositiveIntegerField(default=0, db_index=True)
     is_active = models.BooleanField(default=False)
 
+
+    class Meta:
+        ordering = ['order']
+
     def clean(self):
         super(RoutingExpression, self).clean()
 

--- a/api/app/signals/apps/signals/models/routing_expression.py
+++ b/api/app/signals/apps/signals/models/routing_expression.py
@@ -22,7 +22,6 @@ class RoutingExpression(models.Model):
     order = models.PositiveIntegerField(default=0, db_index=True)
     is_active = models.BooleanField(default=False)
 
-
     class Meta:
         ordering = ['order']
 

--- a/api/app/signals/apps/signals/signal_receivers.py
+++ b/api/app/signals/apps/signals/signal_receivers.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
+from django.conf import settings
 from django.dispatch import receiver
 
 from signals.apps.signals import tasks
@@ -19,11 +20,17 @@ def signals_create_initial_handler(sender, signal_obj, **kwargs):
 
 @receiver(update_location, dispatch_uid='signals_update_location')
 def signals_update_location_handler(sender, signal_obj, **kwargs):
+    if not settings.FEATURE_FLAGS['DSL_RUN_ROUTING_EXPRESSIONS_ON_UPDATES']:
+        return
+
     tasks.apply_routing(signal_obj.id)
 
 
 @receiver(update_category_assignment, dispatch_uid='signals_update_category_assignment')
 def signals_update_category_assignment_handler(sender, signal_obj, **kwargs):
+    if not settings.FEATURE_FLAGS['DSL_RUN_ROUTING_EXPRESSIONS_ON_UPDATES']:
+        return
+
     tasks.apply_routing(signal_obj.id)
 
 

--- a/api/app/signals/apps/signals/signal_receivers.py
+++ b/api/app/signals/apps/signals/signal_receivers.py
@@ -14,7 +14,7 @@ from signals.apps.signals.managers import (
 
 @receiver(create_initial, dispatch_uid='signals_create_initial')
 def signals_create_initial_handler(sender, signal_obj, **kwargs):
-    tasks.apply_routing(signal_obj.id)
+    tasks.apply_routing.delay(signal_obj.id)
     tasks.apply_auto_create_children.apply_async(kwargs={'signal_id': signal_obj.id}, countdown=30)
 
 
@@ -23,7 +23,7 @@ def signals_update_location_handler(sender, signal_obj, **kwargs):
     if not settings.FEATURE_FLAGS['DSL_RUN_ROUTING_EXPRESSIONS_ON_UPDATES']:
         return
 
-    tasks.apply_routing(signal_obj.id)
+    tasks.apply_routing.delay(signal_obj.id)
 
 
 @receiver(update_category_assignment, dispatch_uid='signals_update_category_assignment')
@@ -31,7 +31,7 @@ def signals_update_category_assignment_handler(sender, signal_obj, **kwargs):
     if not settings.FEATURE_FLAGS['DSL_RUN_ROUTING_EXPRESSIONS_ON_UPDATES']:
         return
 
-    tasks.apply_routing(signal_obj.id)
+    tasks.apply_routing.delay(signal_obj.id)
 
 
 @receiver(update_status, dispatch_uid='signals_update_status')

--- a/api/app/signals/apps/signals/signal_receivers.py
+++ b/api/app/signals/apps/signals/signal_receivers.py
@@ -3,13 +3,23 @@
 from django.dispatch import receiver
 
 from signals.apps.signals import tasks
-from signals.apps.signals.managers import create_initial, update_status
+from signals.apps.signals.managers import create_initial, update_category_assignment, update_location, update_status
 
 
 @receiver(create_initial, dispatch_uid='signals_create_initial')
 def signals_create_initial_handler(sender, signal_obj, **kwargs):
     tasks.apply_routing(signal_obj.id)
     tasks.apply_auto_create_children.apply_async(kwargs={'signal_id': signal_obj.id}, countdown=30)
+
+
+@receiver(update_location, dispatch_uid='signals_update_location')
+def signals_update_location_handler(sender, signal_obj, **kwargs):
+    tasks.apply_routing(signal_obj.id)
+
+
+@receiver(update_category_assignment, dispatch_uid='signals_update_category_assignment')
+def signals_update_category_assignment_handler(sender, signal_obj, **kwargs):
+    tasks.apply_routing(signal_obj.id)
 
 
 @receiver(update_status, dispatch_uid='signals_update_status')

--- a/api/app/signals/apps/signals/signal_receivers.py
+++ b/api/app/signals/apps/signals/signal_receivers.py
@@ -3,7 +3,12 @@
 from django.dispatch import receiver
 
 from signals.apps.signals import tasks
-from signals.apps.signals.managers import create_initial, update_category_assignment, update_location, update_status
+from signals.apps.signals.managers import (
+    create_initial,
+    update_category_assignment,
+    update_location,
+    update_status
+)
 
 
 @receiver(create_initial, dispatch_uid='signals_create_initial')

--- a/api/app/signals/apps/signals/tests/test_signal_receivers.py
+++ b/api/app/signals/apps/signals/tests/test_signal_receivers.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Delta10 B.V.
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+from signals.apps.signals.factories import SignalFactory
+from signals.apps.signals.managers import (
+    create_initial,
+    update_category_assignment,
+    update_location
+)
+
+
+@override_settings(FEATURE_FLAGS={'DSL_RUN_ROUTING_EXPRESSIONS_ON_UPDATES': True})
+class TestSignalsSignalReceivers(TestCase):
+    def setUp(self):
+        self.signal = SignalFactory.create()
+
+    @mock.patch('signals.apps.signals.signal_receivers.tasks', autospec=True)
+    def test_signals_create_initial_handler(self, mocked_tasks):
+        create_initial.send_robust(
+            sender=self.__class__,
+            signal_obj=self.signal,
+        )
+
+        mocked_tasks.apply_routing.delay.assert_called_once_with(
+            self.signal.id
+        )
+
+    @mock.patch('signals.apps.signals.signal_receivers.tasks', autospec=True)
+    def test_signals_update_location_handler(self, mocked_tasks):
+        update_location.send_robust(
+            sender=self.__class__,
+            signal_obj=self.signal,
+        )
+
+        mocked_tasks.apply_routing.delay.assert_called_once_with(
+            self.signal.id
+        )
+
+    @mock.patch('signals.apps.signals.signal_receivers.tasks', autospec=True)
+    def test_signals_update_category_assignment_handler(self, mocked_tasks):
+        update_category_assignment.send_robust(
+            sender=self.__class__,
+            signal_obj=self.signal,
+        )
+
+        mocked_tasks.apply_routing.delay.assert_called_once_with(
+            self.signal.id
+        )

--- a/api/app/signals/settings/feature_flags.py
+++ b/api/app/signals/settings/feature_flags.py
@@ -37,4 +37,7 @@ FEATURE_FLAGS = {
 
     # Enable/Disable the "my signals" endpoint/flows (Disabled by default)
     'MY_SIGNALS_ENABLED': os.getenv('MY_SIGNALS_ENABLED', False) in TRUE_VALUES,
+
+    # Run routing expressions again when updating signal subcategory or location
+    'DSL_RUN_ROUTING_EXPRESSIONS_ON_UPDATES': os.getenv('DSL_RUN_ROUTING_EXPRESSIONS_ON_UPDATES', False) in TRUE_VALUES,
 }


### PR DESCRIPTION
This change runs routing expressions also when the Signal location or category changes. 

Also there is a small change that allows seeing and changing the routing expressions order in the admin and sets the default ordering of the RoutingExpression model to the order field.

⚠️ This PR includes functional changes and should be included in the release notes.

Closes https://github.com/Signalen/product-steering/issues/294