### PR TITLE
Proposal: add trigger type to DSL signal context

### DIFF
--- a/api/app/signals/apps/services/domain/dsl.py
+++ b/api/app/signals/apps/services/domain/dsl.py
@@ -48,7 +48,7 @@ class SignalContext:
             self._areas = self._init_areas()
         return self._areas
 
-    def __call__(self, signal: Signal):
+    def __call__(self, signal: Signal, trigger: str):
 
         t = timezone.make_naive(signal.incident_date_start).strftime("%H:%M:%S")
 
@@ -59,7 +59,8 @@ class SignalContext:
             'stadsdeel': signal.location.stadsdeel,
             'time': time.strptime(t, "%H:%M:%S"),
             'day': signal.incident_date_start.strftime("%A"),
-            'areas': self.areas
+            'areas': self.areas,
+            'trigger': trigger,
         }
 
         # add additonal question answers id to context
@@ -85,8 +86,8 @@ class SignalDslService(DslService):
     context_func = SignalContext()
     signal_manager = SignalManager()
 
-    def process_routing_rules(self, signal):  # noqa C901
-        ctx = self.context_func(signal)
+    def process_routing_rules(self, signal, trigger):  # noqa C901
+        ctx = self.context_func(signal, trigger)
         rules = RoutingExpression.objects.select_related('_expression', '_department')
         for rule in rules.filter(is_active=True, _expression___type__name='routing').order_by('order'):
             if rule._user and not rule._user.is_active:

--- a/api/app/signals/apps/signals/admin/expression.py
+++ b/api/app/signals/apps/signals/admin/expression.py
@@ -7,7 +7,9 @@ from signals.apps.dsl.ExpressionEvaluator import ExpressionEvaluator
 
 class RoutingExpressionAdmin(admin.ModelAdmin):
     list_filter = ['_expression___type__name', '_department__code']
-    list_display = ['_expression', '_department', 'is_active']
+    list_display = ['order', '_expression', '_department', 'is_active']
+    list_editable = ['order']
+    list_display_links = ['_expression']
 
     def save_model(self, request, obj, form, change):
         # if is_active is true, try to compile code, deactivate when invalid

--- a/api/app/signals/apps/signals/models/routing_expression.py
+++ b/api/app/signals/apps/signals/models/routing_expression.py
@@ -22,6 +22,10 @@ class RoutingExpression(models.Model):
     order = models.PositiveIntegerField(default=0, db_index=True)
     is_active = models.BooleanField(default=False)
 
+
+    class Meta:
+        ordering = ['order']
+
     def clean(self):
         super(RoutingExpression, self).clean()
 

--- a/api/app/signals/apps/signals/models/routing_expression.py
+++ b/api/app/signals/apps/signals/models/routing_expression.py
@@ -22,7 +22,6 @@ class RoutingExpression(models.Model):
     order = models.PositiveIntegerField(default=0, db_index=True)
     is_active = models.BooleanField(default=False)
 
-
     class Meta:
         ordering = ['order']
 

--- a/api/app/signals/apps/signals/signal_receivers.py
+++ b/api/app/signals/apps/signals/signal_receivers.py
@@ -3,13 +3,23 @@
 from django.dispatch import receiver
 
 from signals.apps.signals import tasks
-from signals.apps.signals.managers import create_initial, update_status
+from signals.apps.signals.managers import create_initial, update_category_assignment, update_location, update_status
 
 
 @receiver(create_initial, dispatch_uid='signals_create_initial')
 def signals_create_initial_handler(sender, signal_obj, **kwargs):
     tasks.apply_routing(signal_obj.id)
     tasks.apply_auto_create_children.apply_async(kwargs={'signal_id': signal_obj.id}, countdown=30)
+
+
+@receiver(update_location, dispatch_uid='signals_update_location')
+def signals_update_location_handler(sender, signal_obj, **kwargs):
+    tasks.apply_routing(signal_obj.id)
+
+
+@receiver(update_category_assignment, dispatch_uid='signals_update_category_assignment')
+def signals_update_category_assignment_handler(sender, signal_obj, **kwargs):
+    tasks.apply_routing(signal_obj.id)
 
 
 @receiver(update_status, dispatch_uid='signals_update_status')

--- a/api/app/signals/apps/signals/signal_receivers.py
+++ b/api/app/signals/apps/signals/signal_receivers.py
@@ -13,18 +13,18 @@ from signals.apps.signals.managers import (
 
 @receiver(create_initial, dispatch_uid='signals_create_initial')
 def signals_create_initial_handler(sender, signal_obj, **kwargs):
-    tasks.apply_routing(signal_obj.id)
+    tasks.apply_routing(signal_obj.id, 'CREATE_INITIAL')
     tasks.apply_auto_create_children.apply_async(kwargs={'signal_id': signal_obj.id}, countdown=30)
 
 
 @receiver(update_location, dispatch_uid='signals_update_location')
 def signals_update_location_handler(sender, signal_obj, **kwargs):
-    tasks.apply_routing(signal_obj.id)
+    tasks.apply_routing(signal_obj.id, 'UPDATE_LOCATION')
 
 
 @receiver(update_category_assignment, dispatch_uid='signals_update_category_assignment')
 def signals_update_category_assignment_handler(sender, signal_obj, **kwargs):
-    tasks.apply_routing(signal_obj.id)
+    tasks.apply_routing(signal_obj.id, 'UPDATE_CATEGORY_ASSIGNMENT')
 
 
 @receiver(update_status, dispatch_uid='signals_update_status')

--- a/api/app/signals/apps/signals/signal_receivers.py
+++ b/api/app/signals/apps/signals/signal_receivers.py
@@ -3,7 +3,12 @@
 from django.dispatch import receiver
 
 from signals.apps.signals import tasks
-from signals.apps.signals.managers import create_initial, update_category_assignment, update_location, update_status
+from signals.apps.signals.managers import (
+    create_initial,
+    update_category_assignment,
+    update_location,
+    update_status
+)
 
 
 @receiver(create_initial, dispatch_uid='signals_create_initial')

--- a/api/app/signals/apps/signals/tasks.py
+++ b/api/app/signals/apps/signals/tasks.py
@@ -22,9 +22,9 @@ dsl_service = SignalDslService()
 
 
 @app.task
-def apply_routing(signal_id):
+def apply_routing(signal_id, trigger):
     signal = Signal.objects.get(pk=signal_id)
-    dsl_service.process_routing_rules(signal)
+    dsl_service.process_routing_rules(signal, trigger)
 
 
 @app.task

--- a/api/app/signals/apps/signals/tests/test_routing_mechanism.py
+++ b/api/app/signals/apps/signals/tests/test_routing_mechanism.py
@@ -49,7 +49,7 @@ class TestRoutingMechanism(TestCase):
         signal_outside.refresh_from_db()
         self.assertIsNone(signal_outside.routing_assignment)
         # simulate apply routing rules
-        self.dsl_service.process_routing_rules(signal_outside)
+        self.dsl_service.process_routing_rules(signal_outside, 'TEST_PLACEHOLDER')
         signal_outside.refresh_from_db()
         self.assertIsNone(signal_outside.routing_assignment)
 
@@ -60,7 +60,7 @@ class TestRoutingMechanism(TestCase):
         signal_inside.refresh_from_db()
         self.assertIsNone(signal_inside.routing_assignment)
         # simulate apply routing rules
-        self.dsl_service.process_routing_rules(signal_inside)
+        self.dsl_service.process_routing_rules(signal_inside, 'TEST_PLACEHOLDER')
         signal_inside.refresh_from_db()
         self.assertIsNotNone(signal_inside.routing_assignment)
         self.assertEqual(len(signal_inside.routing_assignment.departments.all()), 1)
@@ -87,7 +87,7 @@ class TestRoutingMechanism(TestCase):
         )
         self.assertIsNone(signal_inside.routing_assignment)
         # simulate apply routing rules
-        self.dsl_service.process_routing_rules(signal_inside)
+        self.dsl_service.process_routing_rules(signal_inside, 'TEST_PLACEHOLDER')
         signal_inside.refresh_from_db()
 
         # routing rule will be de-activated due to syntax/compilation errors
@@ -120,7 +120,7 @@ class TestRoutingMechanism(TestCase):
         )
         self.assertIsNone(signal_inside.routing_assignment)
         # simulate apply routing rules
-        self.dsl_service.process_routing_rules(signal_inside)
+        self.dsl_service.process_routing_rules(signal_inside, 'TEST_PLACEHOLDER')
         signal_inside.refresh_from_db()
 
         # runtime errors should not effect is_active status
@@ -173,7 +173,7 @@ class TestRoutingMechanism(TestCase):
         ]
 
         ctx_func = SignalContext()
-        ctx = ctx_func(signal)
+        ctx = ctx_func(signal, 'TEST_PLACEHOLDER')
         self.assertEqual(ctx['key1'], "value 1")
         self.assertEqual(ctx['key2'], "value 2")
         self.assertEqual(type(ctx['key3_list']), set)

--- a/api/app/signals/apps/signals/tests/test_user_routing_mechanism.py
+++ b/api/app/signals/apps/signals/tests/test_user_routing_mechanism.py
@@ -37,7 +37,7 @@ class TestRoutingMechanism(TestCase):
         # simulate applying routing rules
         dsl_service = SignalDslService()
 
-        dsl_service.process_routing_rules(signal)
+        dsl_service.process_routing_rules(signal, 'TEST_PLACEHOLDER')
 
         signal.refresh_from_db()
         self.assertEqual(signal.user_assignment.user.id, user.id)
@@ -67,7 +67,7 @@ class TestRoutingMechanism(TestCase):
         # simulate applying routing rules
         dsl_service = SignalDslService()
 
-        dsl_service.process_routing_rules(signal)
+        dsl_service.process_routing_rules(signal, 'TEST_PLACEHOLDER')
 
         signal.refresh_from_db()
         self.assertIsNone(signal.user_assignment)
@@ -101,7 +101,7 @@ class TestRoutingMechanism(TestCase):
         # simulate applying routing rules
         dsl_service = SignalDslService()
 
-        dsl_service.process_routing_rules(signal)
+        dsl_service.process_routing_rules(signal, 'TEST_PLACEHOLDER')
 
         signal.refresh_from_db()
         self.assertIsNone(signal.user_assignment)


### PR DESCRIPTION
## Description

There was some discussion about RoutingExpressions and whether it should be possible to run them only on creation or update of certain nuisance complaint properties. This PR proposes (in sketch form for now) how we might allow rules to take into account how they were triggered.

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
