### PR TITLE
Refactor slow performing "V1 public signals geography" endpoint

### DIFF
--- a/api/app/signals/apps/api/filters/signal.py
+++ b/api/app/signals/apps/api/filters/signal.py
@@ -333,13 +333,11 @@ class PublicSignalGeographyFilter(FilterSet):
     lon = filters.NumberFilter()
 
     maincategory_slug = filters.ModelMultipleChoiceFilter(
-        queryset=_get_parent_category_queryset(), to_field_name='slug',
-        field_name='parent_category_slug',
+        queryset=_get_parent_category_queryset(), to_field_name='slug'
     )  # Only parent categories are allowed
 
     category_slug = filters.ModelMultipleChoiceFilter(
-        queryset=_get_child_category_queryset().filter(is_public_accessible=True),
-        to_field_name='slug', field_name='child_category_slug'
+        queryset=_get_child_category_queryset().filter(is_public_accessible=True), to_field_name='slug'
     )  # Only child categories that are public accessible are allowed
 
     def is_valid(self):

--- a/api/app/signals/apps/api/filters/signal.py
+++ b/api/app/signals/apps/api/filters/signal.py
@@ -334,12 +334,12 @@ class PublicSignalGeographyFilter(FilterSet):
 
     maincategory_slug = filters.ModelMultipleChoiceFilter(
         queryset=_get_parent_category_queryset(), to_field_name='slug',
-        field_name='category_assignment__category__parent__slug',
+        field_name='parent_category_slug',
     )  # Only parent categories are allowed
 
     category_slug = filters.ModelMultipleChoiceFilter(
         queryset=_get_child_category_queryset().filter(is_public_accessible=True),
-        to_field_name='slug', field_name='category_assignment__category__slug'
+        to_field_name='slug', field_name='child_category_slug'
     )  # Only child categories that are public accessible are allowed
 
     def is_valid(self):
@@ -368,16 +368,16 @@ class PublicSignalGeographyFilter(FilterSet):
         lat = self.form.cleaned_data.pop('lat', None)
         lon = self.form.cleaned_data.pop('lon', None)
 
-        geometrie_filter = Q(location__geometrie__within=Polygon.from_bbox(bbox)) if bbox \
-            else Q(location__geometrie=Point(float(lon), float(lat), srid=4326))
+        geometrie_filter = Q(geometry__within=Polygon.from_bbox(bbox)) if bbox \
+            else Q(geometry=Point(float(lon), float(lat), srid=4326))
 
         category_filter = Q()
 
         if main_categories:
-            category_filter &= Q(category_assignment__category__parent_id__in=[c.pk for c in main_categories])
+            category_filter &= Q(parent_category_id__in=[c.pk for c in main_categories])
 
         if sub_categories:
-            category_filter &= Q(category_assignment__category_id__in=[c.pk for c in sub_categories])
+            category_filter &= Q(child_category_id__in=[c.pk for c in sub_categories])
 
         return super().filter_queryset(queryset=queryset.filter(
             category_filter &

--- a/api/app/signals/apps/api/tests/test_public_signal_geography_endpoint.py
+++ b/api/app/signals/apps/api/tests/test_public_signal_geography_endpoint.py
@@ -12,6 +12,9 @@ from signals.apps.signals.factories import (
     SignalFactory,
     SignalFactoryValidLocation
 )
+from signals.apps.signals.tasks import (
+    refresh_materialized_view_public_signals_geography_feature_collection
+)
 from signals.apps.signals.tests.valid_locations import ARENA, STADHUIS
 from signals.apps.signals.workflow import (
     AFGEHANDELD,
@@ -38,6 +41,8 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         for x in range(5):
             with (freeze_time(now-timedelta(days=x))):
                 SignalFactoryValidLocation.create(category_assignment__category=child_category)
+
+        refresh_materialized_view_public_signals_geography_feature_collection()
 
         response = self.client.get(f'{self.geography_endpoint}/?maincategory_slug={parent_category.slug}'
                                    f'&category_slug={child_category.slug}&bbox=4.700000,52.200000,5.000000,52.500000')
@@ -70,6 +75,8 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
                 SignalFactory.create(location__geometrie=Point(ARENA['lon'], ARENA['lat']),
                                      location__buurt_code=ARENA['buurt_code'],
                                      category_assignment__category=child_category)
+
+        refresh_materialized_view_public_signals_geography_feature_collection()
 
         response = self.client.get(f'{self.geography_endpoint}/?maincategory_slug={parent_category.slug}'
                                    f'&category_slug={child_category.slug}&bbox=4.875759,52.360656,4.921221,52.37942')
@@ -107,6 +114,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
                                                 is_public_accessible=True)
 
         SignalFactoryValidLocation.create_batch(5)
+        refresh_materialized_view_public_signals_geography_feature_collection()
 
         response = self.client.get(f'{self.geography_endpoint}/?maincategory_slug={parent_category.slug}'
                                    f'&category_slug={child_category.slug}&bbox=4.700000,52.200000,5.000000,52.500000')
@@ -165,6 +173,8 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
                                      location__buurt_code=STADHUIS['buurt_code'],
                                      category_assignment__category=child_category)
 
+        refresh_materialized_view_public_signals_geography_feature_collection()
+
         response = self.client.get(f'{self.geography_endpoint}/?maincategory_slug={parent_category.slug}'
                                    f'&category_slug={child_category.slug}&bbox=4.875759,52.360656,4.921221,52.37942'
                                    '&group_by=category')
@@ -187,6 +197,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
                                                 is_public_accessible=True)
 
         signal = SignalFactoryValidLocation.create(category_assignment__category=child_category)
+        refresh_materialized_view_public_signals_geography_feature_collection()
         lon = signal.location.geometrie.x
         lat = signal.location.geometrie.y
 
@@ -257,6 +268,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         parent_category = ParentCategoryFactory.create(public_name='parent-test')
         child_category = CategoryFactory.create(parent=parent_category, public_name='test', is_public_accessible=True)
         SignalFactoryValidLocation.create(category_assignment__category=child_category)
+        refresh_materialized_view_public_signals_geography_feature_collection()
 
         response = self.client.get(f'{self.geography_endpoint}/?maincategory_slug={parent_category.slug}'
                                    f'&category_slug={child_category.slug}&bbox=4.700000,52.200000,5.000000,52.500000')
@@ -278,6 +290,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         parent_category = ParentCategoryFactory.create(public_name=None)
         child_category = CategoryFactory.create(parent=parent_category, public_name=None, is_public_accessible=True)
         SignalFactoryValidLocation.create(category_assignment__category=child_category)
+        refresh_materialized_view_public_signals_geography_feature_collection()
 
         response = self.client.get(f'{self.geography_endpoint}/?maincategory_slug={parent_category.slug}'
                                    f'&category_slug={child_category.slug}&bbox=4.700000,52.200000,5.000000,52.500000')
@@ -298,6 +311,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         parent_category = ParentCategoryFactory.create(public_name='')
         child_category = CategoryFactory.create(parent=parent_category, public_name='', is_public_accessible=True)
         SignalFactoryValidLocation.create(category_assignment__category=child_category)
+        refresh_materialized_view_public_signals_geography_feature_collection()
 
         response = self.client.get(f'{self.geography_endpoint}/?maincategory_slug={parent_category.slug}'
                                    f'&category_slug={child_category.slug}&bbox=4.700000,52.200000,5.000000,52.500000')
@@ -324,6 +338,8 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
 
         SignalFactoryValidLocation.create(category_assignment__category=compost)
 
+        refresh_materialized_view_public_signals_geography_feature_collection()
+
         response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000')
 
         data = response.json()
@@ -342,6 +358,8 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         SignalFactoryValidLocation.create(category_assignment__category=plastic)
 
         SignalFactoryValidLocation.create(category_assignment__category=compost)
+
+        refresh_materialized_view_public_signals_geography_feature_collection()
 
         response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000&'
                                    f'category_slug={plastic.slug}')
@@ -367,6 +385,8 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         SignalFactoryValidLocation.create(category_assignment__category=child_animal)
         SignalFactoryValidLocation.create(category_assignment__category=child_animal)
 
+        refresh_materialized_view_public_signals_geography_feature_collection()
+
         response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000&'
                                    f'maincategory_slug={parent_cat.slug}')
 
@@ -388,6 +408,8 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=VERZOEK_TOT_HEROPENEN)
         SignalFactoryValidLocation.create(category_assignment__category=child_cat, status__state=GEMELD)
 
+        refresh_materialized_view_public_signals_geography_feature_collection()
+
         response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000&'
                                    f'maincategory_slug={parent_cat.slug}')
 
@@ -407,6 +429,8 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
 
         SignalFactoryValidLocation.create(category_assignment__category=non_accessible_cat, status__state=GEMELD)
         SignalFactoryValidLocation.create(category_assignment__category=accessible_cat, status__state=GEMELD)
+
+        refresh_materialized_view_public_signals_geography_feature_collection()
 
         response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000&'
                                    f'maincategory_slug={parent_cat.slug}')
@@ -428,6 +452,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
         non_accessible_cat = CategoryFactory.create(parent=parent_cat, is_public_accessible=False)
 
         SignalFactoryValidLocation.create(category_assignment__category=non_accessible_cat, status__state=AFGEHANDELD)
+        refresh_materialized_view_public_signals_geography_feature_collection()
 
         response = self.client.get(f'{self.geography_endpoint}/?bbox=4.700000,52.200000,5.000000,52.500000&'
                                    f'maincategory_slug={parent_cat.slug}')

--- a/api/app/signals/apps/api/views/signals/public/signals.py
+++ b/api/app/signals/apps/api/views/signals/public/signals.py
@@ -21,6 +21,7 @@ from signals.apps.signals.workflow import (
     AFGEHANDELD,
     AFGEHANDELD_EXTERN,
     GEANNULEERD,
+    GESPLITST,
     VERZOEK_TOT_HEROPENEN
 )
 from signals.throttling import PostOnlyNoUserRateThrottle
@@ -36,7 +37,7 @@ class PublicSignalViewSet(GenericViewSet):
     # geography endpoint
     geography_queryset = PublicSignalGeographyFeature.objects.exclude(
         # Only signals that are in an "Open" state
-        Q(state__in=[AFGEHANDELD, AFGEHANDELD_EXTERN, GEANNULEERD, VERZOEK_TOT_HEROPENEN])
+        Q(state__in=[AFGEHANDELD, AFGEHANDELD_EXTERN, GEANNULEERD, GESPLITST, VERZOEK_TOT_HEROPENEN])
     )
 
     filter_backends = (DjangoFilterBackend, OrderingFilter)

--- a/api/app/signals/apps/signals/migrations/0164_materialized_view_public_signals_geography_feature_collection.py
+++ b/api/app/signals/apps/signals/migrations/0164_materialized_view_public_signals_geography_feature_collection.py
@@ -12,10 +12,8 @@ CREATE MATERIALIZED VIEW "public_signals_geography_feature_collection" AS
     "signals_location"."geometrie" AS geometry,
     "signals_status"."state" AS state,
     scp."id" as parent_category_id,
-    scp."slug" as parent_category_slug,
     "signals_category"."id" as child_category_id,
     "signals_category"."is_public_accessible" as child_category_is_public_accessible,
-    "signals_category"."slug" as child_category_slug,
     "signals_signal"."created_at",
     JSONB_BUILD_OBJECT(
       'type', 'Feature',
@@ -42,8 +40,6 @@ CREATE MATERIALIZED VIEW "public_signals_geography_feature_collection" AS
 
   CREATE UNIQUE INDEX psgfc_id_uniq ON "public_signals_geography_feature_collection" ("id");
   CREATE INDEX psgfc_geometry_id ON "public_signals_geography_feature_collection" USING GIST ("geometry");
-  CREATE INDEX psgfc_child_category_slug_key ON "public_signals_geography_feature_collection" ("child_category_slug");
-  CREATE INDEX psgfc_parent_category_slug_key ON "public_signals_geography_feature_collection" ("parent_category_slug");
   CREATE INDEX psgfc_state_key ON "public_signals_geography_feature_collection" ("state");
 '''  # noqa
 

--- a/api/app/signals/apps/signals/migrations/0164_materialized_view_public_signals_geography_feature_collection.py
+++ b/api/app/signals/apps/signals/migrations/0164_materialized_view_public_signals_geography_feature_collection.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+
+import django.contrib.gis.db.models.fields
+from django.db import migrations, models
+
+create_materialized_view = '''
+CREATE MATERIALIZED VIEW "public_signals_geography_feature_collection" AS
+  SELECT
+    "signals_signal"."id",
+    "signals_signal"."uuid",
+    "signals_location"."geometrie" AS geometry,
+    "signals_status"."state" AS state,
+    scp."id" as parent_category_id,
+    scp."slug" as parent_category_slug,
+    "signals_category"."id" as child_category_id,
+    "signals_category"."is_public_accessible" as child_category_is_public_accessible,
+    "signals_category"."slug" as child_category_slug,
+    "signals_signal"."created_at",
+    JSONB_BUILD_OBJECT(
+      'type', 'Feature',
+      'geometry', st_asgeojson("signals_location"."geometrie")::jsonb,
+      'properties', JSONB_BUILD_OBJECT(
+      'category', JSONB_BUILD_OBJECT(
+        'name', CASE WHEN "signals_category"."public_name" = '' THEN "signals_category"."name" WHEN "signals_category"."public_name" IS NULL THEN "signals_category"."name" ELSE "signals_category"."public_name" END,
+        'slug', "signals_category"."slug",
+        'parent', JSONB_BUILD_OBJECT(
+          'name', CASE WHEN scp."public_name" = ''  THEN scp."name" WHEN scp."public_name" IS NULL THEN scp."name" ELSE scp."public_name" END,
+          'slug', scp."slug"
+        )
+      ),
+      'created_at', "signals_signal"."created_at"
+    )
+    ) AS "feature"
+  FROM "signals_signal"
+    lEFT OUTER JOIN "signals_status" ON ("signals_signal"."status_id" = "signals_status"."id")
+    LEFT OUTER JOIN "signals_categoryassignment" ON ("signals_signal"."category_assignment_id" = "signals_categoryassignment"."id")
+    LEFT OUTER JOIN "signals_category" ON ("signals_categoryassignment"."category_id" = "signals_category"."id")
+    INNER JOIN "signals_location" ON ("signals_signal"."location_id" = "signals_location"."id")
+    LEFT OUTER JOIN "signals_category" scp ON ("signals_category"."parent_id" = scp."id")
+  WHERE NOT ("signals_status"."state" IN ('o', 'done external', 'a', 'reopen requested'));
+
+  CREATE UNIQUE INDEX psgfc_id_uniq ON "public_signals_geography_feature_collection" ("id");
+  CREATE INDEX psgfc_geometry_id ON "public_signals_geography_feature_collection" USING GIST ("geometry");
+  CREATE INDEX psgfc_child_category_slug_key ON "public_signals_geography_feature_collection" ("child_category_slug");
+  CREATE INDEX psgfc_parent_category_slug_key ON "public_signals_geography_feature_collection" ("parent_category_slug");
+  CREATE INDEX psgfc_state_key ON "public_signals_geography_feature_collection" ("state");
+'''  # noqa
+
+drop_materialized_view = '''
+DROP MATERIALIZED VIEW IF EXISTS "public_signals_geography_feature_collection";
+'''
+
+
+def create_default_periodic_task_to_refresh_the_materialized_view(apps, schema_editor):
+    """
+    Create a periodic task to refresh the materialized view
+    """
+    CrontabSchedule = apps.get_model('django_celery_beat', 'CrontabSchedule')
+    PeriodicTask = apps.get_model('django_celery_beat', 'PeriodicTask')
+
+    # Every 30 minutes past every hour
+    crontab, _ = CrontabSchedule.objects.get_or_create(minute='*/30', hour='*/1')
+
+    # Create periodic task only if it does not exist already
+    periodic_task, created = PeriodicTask.objects.get_or_create(
+        task='signals.apps.signals.tasks.refresh_materialized_view_public_signals_geography_feature_collection',
+        defaults={
+            'name': 'Refresh materialized view "public_signals_geography_feature_collection"',
+            'crontab': crontab
+        }
+    )
+
+    if not created and not periodic_task.enabled:
+        periodic_task.enabled = True
+        periodic_task.save()
+
+
+def rollback_default_periodic_task_to_refresh_the_materialized_view(apps, schema_editor):
+    """
+    Remove all periodic tasks that are present for the task that refreshed the materialized view
+    """
+    PeriodicTask = apps.get_model('django_celery_beat', 'PeriodicTask')
+    periodic_task_queryset = PeriodicTask.objects.filter(
+        task='signals.apps.signals.tasks.refresh_materialized_view_public_signals_geography_feature_collection'
+    )
+    periodic_task_queryset.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0163_category_icon'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PublicSignalGeographyFeature',
+            fields=[
+                ('id', models.BigIntegerField(primary_key=True, serialize=False)),
+                ('uuid', models.UUIDField()),
+                ('geometry', django.contrib.gis.db.models.fields.PointField(srid=4326)),
+                ('state', models.CharField(max_length=36)),
+                ('child_category_id', models.BigIntegerField()),
+                ('child_category_is_public_accessible', models.BooleanField()),
+                ('parent_category_id', models.BigIntegerField()),
+                ('created_at', models.DateTimeField()),
+                ('feature', models.JSONField()),
+            ],
+            options={
+                'db_table': 'public_signals_geography_feature_collection',
+                'managed': False,
+            },
+        ),
+
+        # Create the view, and a rollback option
+        migrations.RunSQL(create_materialized_view,
+                          reverse_sql=drop_materialized_view),
+        # Create the periodic task, and a rollback option
+        migrations.RunPython(create_default_periodic_task_to_refresh_the_materialized_view,
+                             reverse_code=rollback_default_periodic_task_to_refresh_the_materialized_view)
+    ]

--- a/api/app/signals/apps/signals/models/views/__init__.py
+++ b/api/app/signals/apps/signals/models/views/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam

--- a/api/app/signals/apps/signals/models/views/signal.py
+++ b/api/app/signals/apps/signals/models/views/signal.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2022 Gemeente Amsterdam
+from django.contrib.gis.db import models
+
+
+class PublicSignalGeographyFeature(models.Model):
+    """
+    A materialized view is used to query information for the public geography endpoint
+
+    Migration:
+        api/app/signals/apps/signals/migrations/0164_materialized_view_public_signals_geography_feature_collection.py
+    """
+    id = models.BigIntegerField(primary_key=True)
+    uuid = models.UUIDField()
+    geometry = models.PointField()
+    state = models.CharField(max_length=36)
+    child_category_id = models.BigIntegerField()
+    child_category_is_public_accessible = models.BooleanField()
+    parent_category_id = models.BigIntegerField()
+    created_at = models.DateTimeField()
+    feature = models.JSONField()
+
+    # No changes to this database view please!
+    def save(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def delete(self, *args, **kwargs):
+        raise NotImplementedError
+
+    class Meta:
+        managed = False
+        db_table = 'public_signals_geography_feature_collection'

--- a/api/app/signals/apps/signals/tasks.py
+++ b/api/app/signals/apps/signals/tasks.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import logging
 
+from django.db import connection
 from django.db.models import Q
 from django.utils import timezone
 
@@ -112,3 +113,19 @@ def delete_closed_signals(days=365):
     SignalDeletionService.delete_signals(AFGEHANDELD, days, dry_run=False)
     SignalDeletionService().delete_signals(GEANNULEERD, days, dry_run=False)
     SignalDeletionService().delete_signals(GESPLITST, days, dry_run=False)
+
+
+@app.task
+def refresh_materialized_view_public_signals_geography_feature_collection():
+    """
+    A task to refresh the materialized view that contains the data for the public/v1/signals/geography endpoint
+    """
+    refresh_query = 'REFRESH MATERIALIZED VIEW CONCURRENTLY "public_signals_geography_feature_collection";'
+
+    cursor = connection.cursor()
+    try:
+        cursor.execute(refresh_query)
+    except Exception as e:
+        log.error(f'Failed to execute the query: {refresh_query}', exc_info=e)
+    finally:
+        cursor.close()


### PR DESCRIPTION
## Description

The "public/v1/signals/geography" endpoint was using a query against the tables containing the signals and all relevant data, it was aggregating the feature collection in postgres. However this was giving performance issues and therefore a materialized view has been created. This materialized view contains all the data needed for the endpoint. Also additional data has been added so that the endpoint can filter. The materialized view is kept in sync by a celery task that is created initially to run every 30th minute of every hour, this can be changed in the Django admin.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
