### PR TITLE
Avoid issues with stale routing rule caches

### DIFF
--- a/api/app/signals/apps/signals/tasks.py
+++ b/api/app/signals/apps/signals/tasks.py
@@ -20,12 +20,13 @@ from signals.apps.signals.workflow import (
 from signals.celery import app
 
 log = logging.getLogger(__name__)
-dsl_service = SignalDslService()
 
 
 @app.task
 def apply_routing(signal_id):
     signal = Signal.objects.get(pk=signal_id)
+
+    dsl_service = SignalDslService()
     dsl_service.process_routing_rules(signal)
 
 


### PR DESCRIPTION
## Description

By initializing a new DSL service on each run

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
