### PR TITLE
Added missing headers to the "CORS_ALLOW_HEADERS" setting

### DIFF
--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import os
 
+from corsheaders.defaults import default_headers
 from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -25,6 +26,11 @@ INTERNAL_IPS = ('127.0.0.1', '0.0.0.0')
 
 CORS_ALLOWED_ORIGINS = [origin.strip() for origin in os.getenv('CORS_ALLOWED_ORIGINS', 'null').split(',')]
 CORS_ALLOW_ALL_ORIGINS = os.getenv('CORS_ALLOW_ALL_ORIGINS', True) in TRUE_VALUES
+CORS_ALLOW_HEADERS = list(default_headers) + [
+    'Link',  # Added for the geography endpoints
+    'X-API-Version',  # General API version
+    'X-Total-Count',  # Added for the geography endpoints
+]
 
 SITE_ID = 1
 SITE_NAME = 'Signalen API'


### PR DESCRIPTION
## Description

Added "Links", "X-API-Version" and "X-Total-Count" to the CORS_ALLOW_HEADERS setting. See https://github.com/adamchainz/django-cors-headers#cors_allow_headers-sequencestr for more information.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
