### PR TITLE
Add request context to NestedPublicAttachedFileSerializer to get host…

### DIFF
--- a/api/app/signals/apps/questionnaires/rest_framework/serializers/public/attached_section.py
+++ b/api/app/signals/apps/questionnaires/rest_framework/serializers/public/attached_section.py
@@ -21,4 +21,4 @@ class NestedPublicAttachedSectionSerializer(ModelSerializer):
 
     def get_files(self, obj):
         qs = obj.files.all().order_by('stored_file__id')
-        return NestedPublicAttachedFileSerializer(qs, many=True).data
+        return NestedPublicAttachedFileSerializer(qs, many=True, context=self.context).data


### PR DESCRIPTION
Files attached to a questionnaires explanation were lacking the hostname when serialized. This PR fixes that.
