### PR TITLE
Update cors_expose_headers to make use of them in the client.

### DIFF
--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import os
 
-from corsheaders.defaults import default_headers
 from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -26,7 +25,7 @@ INTERNAL_IPS = ('127.0.0.1', '0.0.0.0')
 
 CORS_ALLOWED_ORIGINS = [origin.strip() for origin in os.getenv('CORS_ALLOWED_ORIGINS', 'null').split(',')]
 CORS_ALLOW_ALL_ORIGINS = os.getenv('CORS_ALLOW_ALL_ORIGINS', True) in TRUE_VALUES
-CORS_EXPOSE_HEADERS = list(default_headers) + [
+CORS_EXPOSE_HEADERS = [
     'Link',  # Added for the geography endpoints
     'X-API-Version',  # General API version
     'X-Total-Count',  # Added for the geography endpoints

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -26,7 +26,7 @@ INTERNAL_IPS = ('127.0.0.1', '0.0.0.0')
 
 CORS_ALLOWED_ORIGINS = [origin.strip() for origin in os.getenv('CORS_ALLOWED_ORIGINS', 'null').split(',')]
 CORS_ALLOW_ALL_ORIGINS = os.getenv('CORS_ALLOW_ALL_ORIGINS', True) in TRUE_VALUES
-CORS_ALLOW_HEADERS = list(default_headers) + [
+CORS_EXPOSE_HEADERS = list(default_headers) + [
     'Link',  # Added for the geography endpoints
     'X-API-Version',  # General API version
     'X-Total-Count',  # Added for the geography endpoints


### PR DESCRIPTION
## Description

Instead of setting the headers in the `CORS_ALLOW_HEADERS` they should have been set in the `CORS_EXPOSE_HEADERS` setting.

The `CORS_ALLOW_HEADERS` is used for non-standard HTTP headers that you permit in requests from the browser. For more information see https://github.com/adamchainz/django-cors-headers#cors_allow_headers-sequencestr

The `CORS_EXPOSE_HEADERS` is used for extra HTTP headers to expose to the browser. For more information see https://github.com/adamchainz/django-cors-headers#cors_expose_headers-sequencestr

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
