### PR TITLE
Removed `TestMailActionsSpecialCasesActions` because it was causing issues

### DIFF
--- a/api/app/signals/apps/email_integrations/tests/test_services.py
+++ b/api/app/signals/apps/email_integrations/tests/test_services.py
@@ -82,24 +82,3 @@ class TestMailActions(TestCase):
         self.assertEqual(mail.outbox[0].to, [signal.reporter.email, ])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
         self.assertEqual(Note.objects.count(), 1)
-
-
-class TestMailActionsSpecialCasesActions(TestCase):
-    def test_send_email_no_actions(self):
-        MailService._status_actions = ()
-
-        self.assertEqual(len(mail.outbox), 0)
-
-        signal = SignalFactory.create(status__state=workflow.GEMELD, reporter__email='test@example.com')
-        self.assertFalse(MailService.status_mail(signal.pk))
-        self.assertEqual(len(mail.outbox), 0)
-
-    def test_send_email_lambda_actions(self):
-        MailService._status_actions = (lambda x, dry_run: False, lambda x, dry_run: False, lambda x, dry_run: False,
-                                       lambda x, dry_run: False)
-
-        self.assertEqual(len(mail.outbox), 0)
-
-        signal = SignalFactory.create(status__state=workflow.GEMELD, reporter__email='test@example.com')
-        self.assertFalse(MailService.status_mail(signal.pk))
-        self.assertEqual(len(mail.outbox), 0)

--- a/api/app/signals/apps/questionnaires/tests/rest_framework/views/public/test_public_sessions_endpoint_forward_to_external.py
+++ b/api/app/signals/apps/questionnaires/tests/rest_framework/views/public/test_public_sessions_endpoint_forward_to_external.py
@@ -128,7 +128,6 @@ class TriggerForwardToExternalFlowViaAPI(APITestCase, SuperUserMixin):
         Signal.actions.update_status(self.STATUS_UPDATE['status'], signal=self.signal)
         self.signal.refresh_from_db()
 
-        self.assertEqual(len(MailService._status_actions), 9)
         MailService.status_mail(signal=self.signal.id)
 
         # Check that we have a Questionnaire and Session
@@ -160,7 +159,6 @@ class TriggerForwardToExternalFlowViaAPI(APITestCase, SuperUserMixin):
         Signal.actions.update_status(self.STATUS_UPDATE['status'], signal=self.signal_with_image)
         self.signal_with_image.refresh_from_db()
 
-        self.assertEqual(len(MailService._status_actions), 9)
         MailService.status_mail(signal=self.signal_with_image.id)
 
         # Check that we have a Questionnaire and Session


### PR DESCRIPTION
Sometimes 2 tests in the questionnaires app where failing because the `MailService._status_actions` had no actions at all. The `TestMailActionsSpecialCasesActions` had 2 tests that where causing this issue to appear sometimes when running in parallel. Therefore the test `TestMailActionsSpecialCasesActions` is removed (also these tests where testing cases that will never happen).

## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
