### PR TITLE
Add a new permission for communication with Sigmax

### DIFF
--- a/api/app/signals/apps/signals/migrations/0167_alter_signal_options.py
+++ b/api/app/signals/apps/signals/migrations/0167_alter_signal_options.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Vereniging van Nederlandse Gemeenten
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0166_rename_status_forward_to_external'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='signal',
+            options={
+                'ordering': ('created_at',),
+                'permissions': (
+                    ('sia_read', 'Leesrechten algemeen'),
+                    ('sia_write', 'Schrijfrechten algemeen'),
+                    ('sia_split', 'Splitsen van een melding'),
+                    ('sia_signal_create_initial', 'Melding aanmaken'),
+                    ('sia_signal_create_note', 'Notitie toevoegen bij een melding'),
+                    ('sia_signal_change_status', 'Wijzigen van status van een melding'),
+                    ('sia_signal_change_category', 'Wijzigen van categorie van een melding'),
+                    ('sia_signal_export', 'Meldingen exporteren'), ('sia_signal_report', 'Rapportage beheren'),
+                    ('perform_sigmax_updates', 'Updates door CityControl uitvoeren')
+                )
+            },
+        ),
+    ]

--- a/api/app/signals/apps/signals/models/signal.py
+++ b/api/app/signals/apps/signals/models/signal.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+
 import uuid
 
 from django.conf import settings
@@ -69,6 +70,9 @@ class Signal(CreatedUpdatedModel):
             ('sia_signal_change_category', 'Wijzigen van categorie van een melding'),  # SIG-2192
             ('sia_signal_export', 'Meldingen exporteren'),  # SIG-2192
             ('sia_signal_report', 'Rapportage beheren'),  # SIG-2192
+            # Following permission has no sia prefix, so cannot be set through
+            # backoffice/frontend (product-steering/241):
+            ('perform_sigmax_updates', 'Updates door CityControl uitvoeren'),
         )
         ordering = ('created_at',)
         indexes = [


### PR DESCRIPTION
## Description

To check that a Signalen user is allowed to update nuisance complaints upon reception of updates from CityControl we add a custom permission. This PR is agains the main branch and is required to be merged for PR #1140 to be able to work. That latter PR checks the new permission.

Note: only the Sigmax system user in a Signalen instance should get this permission

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
