### PR TITLE
Correct backend's OpenAPI spec.

### DIFF
--- a/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/api/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -157,7 +157,7 @@ paths:
             ASC:
               value: 'ASC'
               summary: Will select all (parent) Signals where ASC is set explicitly as the directing department
-            null:
+            'null':
               value: 'null'
               summary: Will select all (parent) Signals without a directing department assignment
           required: false
@@ -1957,7 +1957,7 @@ paths:
           in: query
           description: >-
             Filter returns only areas with a certain code. Can be used to filter on multiple type
-            codes. For example the code for stadsdeel centrum van amsterdam "03630000000018"
+            codes. For example the code for stadsdeel centrum van amsterdam "03630000000018".
           schema:
             type: string
             format: string


### PR DESCRIPTION
## Description

When I tried to use the available OpenAPI spec, in conjunction with Gitlab's DAST, I got schema validation errors.
This PR corrects those.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

The patched spec has been used as input to Gitlab's DAST scanner.