### PR TITLE
Add client certificate / key support for outgoing Sigmax connections

### DIFF
--- a/api/app/signals/apps/sigmax/stuf_protocol/outgoing/stuf.py
+++ b/api/app/signals/apps/sigmax/stuf_protocol/outgoing/stuf.py
@@ -45,11 +45,16 @@ def _send_stuf_message(stuf_msg: str, soap_action: str):
         'Content-Length': b'%d' % len(encoded)
     }
 
+    cert = None
+    if settings.SIGMAX_CLIENT_CERT and settings.SIGMAX_CLIENT_KEY:
+        cert = (settings.SIGMAX_CLIENT_CERT, settings.SIGMAX_CLIENT_KEY)
+
     # Send our message to Sigmax. Network problems, and HTTP status codes
     # are all raised as errors.
     try:
         response = requests.post(
             url=settings.SIGMAX_SERVER,
+            cert=cert,
             headers=headers,
             data=encoded
         )

--- a/api/app/signals/apps/sigmax/stuf_protocol/outgoing/stuf.py
+++ b/api/app/signals/apps/sigmax/stuf_protocol/outgoing/stuf.py
@@ -51,8 +51,7 @@ def _send_stuf_message(stuf_msg: str, soap_action: str):
         response = requests.post(
             url=settings.SIGMAX_SERVER,
             headers=headers,
-            data=encoded,
-            verify=False
+            data=encoded
         )
         response.raise_for_status()
     except requests.RequestException as e:

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -360,6 +360,8 @@ SWAGGER_SETTINGS = {
 # Sigmax settings
 SIGMAX_AUTH_TOKEN = os.getenv('SIGMAX_AUTH_TOKEN', None)
 SIGMAX_SERVER = os.getenv('SIGMAX_SERVER', None)
+SIGMAX_CLIENT_CERT = os.getenv('SIGMAX_CLIENT_CERT', None)
+SIGMAX_CLIENT_KEY = os.getenv('SIGMAX_CLIENT_KEY', None)
 SIGMAX_SEND_FAIL_TIMEOUT_MINUTES = os.getenv('SIGMAX_SEND_FAIL_TIMEOUT_MINUTES', 60*24)  # noqa Default is 24hrs.
 
 # Child settings


### PR DESCRIPTION
## Description

This PR adds the ability to configure a client certificate (`SIGMAX_CLIENT_CERT`) and key (`SIGMAX_CLIENT_KEY`) that can be used for authenticating to Sigmax or an API gateway that is inbetween.

⚠️ This PR also removes the `verify=False` flag that is currently in the outgoing POST request to Sigmax. Using this flag is considered evil and is not required any more.
