### PR TITLE
Remove 'view site' button in Django admin, as this link does not work

### DIFF
--- a/api/app/signals/urls.py
+++ b/api/app/signals/urls.py
@@ -8,6 +8,9 @@ from django.urls import include, path
 from signals.admin.oidc import views as admin_oidc_views
 from signals.apps.api.generics.routers import BaseSignalsAPIRootView
 
+# Remove "view website" button in the Django admin
+admin.site.site_url = None
+
 urlpatterns = [
     # Used to determine API health when deploying
     path('status/', include('signals.apps.health.urls')),


### PR DESCRIPTION
## Description

Currently this button returns a page that cannot be found, and therefore is rather confusing for administrators.
