### PR TITLE
CSV Export for Feedback will now have the "text_list" in the following format: "[""a text with spaces"", ""nospacesatall""]"

### DIFF
--- a/api/app/signals/apps/reporting/csv/datawarehouse/utils.py
+++ b/api/app/signals/apps/reporting/csv/datawarehouse/utils.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam
+from django.db.models import Func
+
+
+class ToJsonB(Func):
+    # TODO: Find a better place for this code
+    function = 'to_jsonb'


### PR DESCRIPTION
## Description

The "text_list" was rendered in the following format: `"{""a text with spaces"",nospacesatall,test}"`. This was an issue for the Datawarehouse. With this change the "text_list" is rendered as: `"[""a text with spaces"", ""nospacesatall"", ""test""]"`

Before:
```
2,True,False,a text with spaces,,2023-01-25 08:24:48.100385+00,2023-01-25 09:24:51.498+00,"{""a text with spaces"",nospacesatall,test}"
```

After:
```
2,True,False,a text with spaces,,2023-01-25 08:24:48.100385+00,2023-01-25 09:24:51.498+00,"[""a text with spaces"", ""nospacesatall"", ""test""]"
```



## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
