### PR TITLE
Fix/csv export users from admin slow

### DIFF
--- a/api/app/signals/apps/users/admin.py
+++ b/api/app/signals/apps/users/admin.py
@@ -102,7 +102,7 @@ class SignalsUserAdmin(UserAdmin):
 
     def save_model(self, request, obj, form, change):
         """
-        On the save from the model also add an history log in the admin panel
+        On the save from the model also add a history log in the admin panel
         """
         # TODO:: This currently only saves the changes on the user object.
         # it does not log the users rights/group and related Profile changes


### PR DESCRIPTION
## Description

When exporting a large set of users to CSV from the Django Admin, the process was quite slow.
The reason for that seemed to be the great amount of database queries that were executed, in fact 3 per result in the total result set.

This change retrieves the results with a single query, significantly increasing the performance.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations
- [X] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
