### PR TITLE
Allow an empty text field when changing from VERZOEK_TOT_HEROPENEN to AFGEHANDELD

### DIFF
--- a/api/app/signals/apps/signals/models/status.py
+++ b/api/app/signals/apps/signals/models/status.py
@@ -108,7 +108,12 @@ class Status(CreatedUpdatedModel):
             errors['target_api'] = ValidationError(error_msg, code='invalid')
 
         # Validating text field required.
-        if new_state in [workflow.AFGEHANDELD, workflow.HEROPEND] and not self.text:
+        if new_state == workflow.AFGEHANDELD and current_state != workflow.VERZOEK_TOT_HEROPENEN and not self.text:
+            error_msg = 'This field is required when changing `state` to `{new_state}`.'.format(
+                new_state=new_state_display)
+            errors['text'] = ValidationError(error_msg, code='required')
+
+        if new_state == workflow.HEROPEND and not self.text:
             error_msg = 'This field is required when changing `state` to `{new_state}`.'.format(
                 new_state=new_state_display)
             errors['text'] = ValidationError(error_msg, code='required')


### PR DESCRIPTION
It should be possible to transition from VERZOEK_TOT_HEROPENEN to AFGEHANDELD without providing any text, as no e-mail is sent to the reporter. The frontend already handles it this way.