### PR TITLE
When changing the Signal status to "INGEPLAND" it should be able to trigger the optional email to be send

### DIFF
--- a/api/app/signals/apps/email_integrations/rules/signal_optional.py
+++ b/api/app/signals/apps/email_integrations/rules/signal_optional.py
@@ -9,14 +9,21 @@ class SignalOptionalRule(AbstractRule):
         """
         Run status validations for the Rule
 
-        - The status is GEMELD, AFWACHTING, BEHANDELING, ON_HOLD, VERZOEK_TOT_AFHANDELING or GEANNULEERD
+        - The status is GEMELD, AFWACHTING, BEHANDELING, ON_HOLD, VERZOEK_TOT_AFHANDELING, GEANNULEERD or INGEPLAND
         - send_mail must be True
         """
         return self._validate_status_state(status) and self._validate_status_send_mail(status)
 
     def _validate_status_state(self, status):
         """
-        Validate that the status is GEMELD, AFWACHTING, BEHANDELING, ON_HOLD, VERZOEK_TOT_AFHANDELING or GEANNULEERD
+        Validate that the status is one of:
+         - GEMELD
+         - AFWACHTING
+         - BEHANDELING
+         - ON_HOLD
+         - VERZOEK_TOT_AFHANDELING
+         - GEANNULEERD
+         - INGEPLAND
         """
         return status.state in [
             workflow.GEMELD,
@@ -25,6 +32,7 @@ class SignalOptionalRule(AbstractRule):
             workflow.ON_HOLD,
             workflow.VERZOEK_TOT_AFHANDELING,
             workflow.GEANNULEERD,
+            workflow.INGEPLAND,
         ]
 
     def _validate_status_send_mail(self, status):

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -797,6 +797,7 @@ class TestSignalOptionalAction(TestCase):
             workflow.ON_HOLD,
             workflow.VERZOEK_TOT_AFHANDELING,
             workflow.GEANNULEERD,
+            workflow.INGEPLAND,
         ]
 
         for state in statuses:
@@ -816,6 +817,7 @@ class TestSignalOptionalAction(TestCase):
             workflow.ON_HOLD,
             workflow.VERZOEK_TOT_AFHANDELING,
             workflow.GEANNULEERD,
+            workflow.INGEPLAND,
         ]
 
         for state in statuses:
@@ -833,7 +835,6 @@ class TestSignalOptionalAction(TestCase):
             workflow.AFGEHANDELD,
             workflow.GESPLITST,
             workflow.HEROPEND,
-            workflow.INGEPLAND,
             workflow.VERZOEK_TOT_HEROPENEN,
             workflow.TE_VERZENDEN,
             workflow.VERZONDEN,

--- a/api/app/signals/apps/email_integrations/tests/test_rules.py
+++ b/api/app/signals/apps/email_integrations/tests/test_rules.py
@@ -304,6 +304,7 @@ class TestSignalOptionalRule(TestCase):
             workflow.ON_HOLD,
             workflow.VERZOEK_TOT_AFHANDELING,
             workflow.GEANNULEERD,
+            workflow.INGEPLAND,
         ]
 
         for state in statuses:
@@ -323,6 +324,7 @@ class TestSignalOptionalRule(TestCase):
             workflow.ON_HOLD,
             workflow.VERZOEK_TOT_AFHANDELING,
             workflow.GEANNULEERD,
+            workflow.INGEPLAND,
         ]
 
         for state in statuses:
@@ -340,7 +342,6 @@ class TestSignalOptionalRule(TestCase):
             workflow.AFGEHANDELD,
             workflow.GESPLITST,
             workflow.HEROPEND,
-            workflow.INGEPLAND,
             workflow.VERZOEK_TOT_HEROPENEN,
             workflow.TE_VERZENDEN,
             workflow.VERZONDEN,


### PR DESCRIPTION
## Description

When a Signal status is updated to "INGEPLAND" it should also be possible to send an email if the `send_email` flag is set to `True`. This should trigger the "optional" email action and send the "optional" email template. 

Added the case to the unit tests.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
