### PR TITLE
Add more context to reopened email

### DIFF
--- a/api/app/signals/apps/email_integrations/actions/signal_reopened.py
+++ b/api/app/signals/apps/email_integrations/actions/signal_reopened.py
@@ -16,3 +16,27 @@ class SignalReopenedAction(AbstractAction):
     subject = 'Meer over uw melding {formatted_signal_id}'
 
     note = 'Automatische e-mail bij heropenen is verzonden aan de melder.'
+
+    def get_additional_context(self, signal, dry_run=False):
+        feedback_qs = signal.feedback.filter(submitted_at__isnull=False)
+        feedback_received = feedback_qs.exists()
+
+        if feedback_received:
+            last_received_feedback = feedback_qs.order_by('submitted_at').last()
+            feedback_is_satisfied = last_received_feedback.is_satisfied
+            feedback_text = last_received_feedback.text
+            feedback_text_extra = last_received_feedback.text_extra
+            feedback_text_list = last_received_feedback.text_list
+        else:
+            feedback_is_satisfied = None
+            feedback_text = None
+            feedback_text_extra = None
+            feedback_text_list = None
+
+        return {
+            'feedback_received': feedback_received,
+            'feedback_is_satisfied': feedback_is_satisfied,
+            'feedback_text': feedback_text,
+            'feedback_text_extra': feedback_text_extra,
+            'feedback_text_list': feedback_text_list,
+        }

--- a/api/app/signals/apps/email_integrations/tests/test_actions.py
+++ b/api/app/signals/apps/email_integrations/tests/test_actions.py
@@ -763,7 +763,6 @@ class TestSignalReopenedAction(ActionTestMixin, TestCase):
         self.assertEqual(text_list, context['feedback_text_list'])
 
     def test_get_additional_context_no_feedback(self):
-
         signal = SignalFactory.create(status__state=self.state)
 
         context = self.action.get_additional_context(signal)


### PR DESCRIPTION
## Description

Add additional context to reopened emails.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
