### PR TITLE
Remove SwiftStorage as it is no longer used

### DIFF
--- a/api/app/signals/apps/reporting/csv/utils.py
+++ b/api/app/signals/apps/reporting/csv/utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2022 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import csv
 import logging
 import os
@@ -12,7 +12,6 @@ from django.db import connection
 from django.db.models import Case, CharField, QuerySet, Value, When
 from django.utils import timezone
 from storages.backends.azure_storage import AzureStorage
-from swift.storage import SwiftStorage
 
 from signals.apps.reporting.utils import _get_storage_backend
 
@@ -61,7 +60,7 @@ def rotate_zip_files(using: str, max_csv_amount: int = 30) -> None:
 def save_csv_files(csv_files: list, using: str, path: str = None) -> list:
     """
     Writes the CSV files to the configured storage backend
-    This could either be the AzureStorage, SwiftStorage or FileSystemStorage
+    This could either be the AzureStorage or FileSystemStorage
 
     :param csv_files:
     :param using:
@@ -74,7 +73,7 @@ def save_csv_files(csv_files: list, using: str, path: str = None) -> list:
         with open(csv_file_path, 'rb') as opened_csv_file:
             file_name = os.path.basename(opened_csv_file.name)
             file_path = None
-            if isinstance(storage, (AzureStorage, SwiftStorage, )):
+            if isinstance(storage, AzureStorage):
                 file_path = f'{path}{file_name}' if path else file_name
                 storage.save(name=file_path, content=opened_csv_file)
             else:

--- a/api/app/signals/apps/reporting/management/commands/dump_tdo_csv_files.py
+++ b/api/app/signals/apps/reporting/management/commands/dump_tdo_csv_files.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from timeit import default_timer as timer
 
 from django.conf import settings
@@ -31,10 +31,6 @@ class Command(BaseCommand):
             self.stdout.write('Azure storage: Enabled')
             azure_parameters = settings.AZURE_CONTAINERS.get('datawarehouse')
             self.stdout.write(f'* Azure storage container name: {azure_parameters["azure_container"]}')
-        elif settings.SWIFT_STORAGE_ENABLED:
-            self.stdout.write('Swift storage: Enabled')
-            swift_parameters = settings.SWIFT.get('datawarehouse')
-            self.stdout.write(f'* Swift storage container name: {swift_parameters["container_name"]}')
         else:
             now = timezone.now()
             self.stdout.write('Local file storage: Enabled')

--- a/api/app/signals/apps/reporting/management/commands/dump_test_csv.py
+++ b/api/app/signals/apps/reporting/management/commands/dump_test_csv.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2022 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import csv
 import os
 from timeit import default_timer as timer
@@ -27,21 +27,8 @@ class Command(BaseCommand):
         start = timer()
         self.stdout.write('Store a test CSV file')
 
-        very_verbose = kwargs['verbosity'] >= 2
-
         if settings.AZURE_STORAGE_ENABLED:
             self.stdout.write('* AzureStorage enabled, file will be sent to the azure blob storage')
-        elif settings.SWIFT_STORAGE_ENABLED:
-            self.stdout.write('* SwiftStorage enabled, file will be sent to the ObjectStore')
-            if very_verbose:
-                swift_parameters = settings.SWIFT.get('datawarehouse')
-                self.stdout.write('* DWH SwiftStorage parameters:')
-
-                for key, value in swift_parameters.items():
-                    if key.lower() in ['api_key', ]:
-                        continue
-
-                    self.stdout.write(f'** {key}: {value}')
         else:
             self.stdout.write('* FileSystemStorage enabled, file will be sent to the local storage')
 

--- a/api/app/signals/apps/reporting/management/commands/dumpcsv.py
+++ b/api/app/signals/apps/reporting/management/commands/dumpcsv.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from timeit import default_timer as timer
 
 from django.conf import settings
@@ -58,10 +58,6 @@ class Command(BaseCommand):
             self.stdout.write('Azure storage: Enabled')
             azure_parameters = settings.AZURE_CONTAINERS.get('datawarehouse')
             self.stdout.write(f'* Azure storage container name: {azure_parameters["azure_container"]}')
-        elif settings.SWIFT_STORAGE_ENABLED:
-            self.stdout.write('Swift storage: Enabled')
-            swift_parameters = settings.SWIFT.get('datawarehouse')
-            self.stdout.write(f'* Swift storage container name: {swift_parameters["container_name"]}')
         else:
             now = timezone.now()
             self.stdout.write('Local file storage: Enabled')

--- a/api/app/signals/apps/reporting/services/clean_up_datawarehouse.py
+++ b/api/app/signals/apps/reporting/services/clean_up_datawarehouse.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+# Copyright (C) 2022 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import os
 import pathlib
 from datetime import date, timedelta
@@ -15,8 +15,7 @@ class DataWarehouseDiskCleaner:
     """
     Clean-up disk storage used by datawarehouse CSV dumps.
 
-    Note: this uses can only be used for local disks not for remote file storage
-    like SWIFT storage.
+    Note: this uses can only be used for local disks not for remote file storage like Azure storage.
     """
     GLOB_PATTERNS = [
         '[0-9]' * 6 + '*.csv',

--- a/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
+++ b/api/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2022 Gemeente Amsterdam
+# Copyright (C) 2018 - 2023 Gemeente Amsterdam
 import csv
 import json
 import os
@@ -142,42 +142,6 @@ class TestDatawarehouse(testcases.TestCase):
         self.assertTrue(list_of_files[0].endswith('20200910_150000UTC.zip'))
 
     @override_settings(
-        AZURE_STORAGE_ENABLED=False,
-        SWIFT_STORAGE_ENABLED=True,
-        SWIFT={
-            'datawarehouse': {
-                'api_auth_url': 'dwh_auth_url',
-                'api_username': 'dwh_username',
-                'api_key': 'dwh_password',
-                'tenant_name': 'dwh_tenant_name',
-                'tenant_id': 'dwh_tenant_id',
-                'region_name': 'dwh_region_name',
-                'container_name': 'dwh_container_name',
-                'auto_overwrite': True
-            }
-        }
-    )
-    @mock.patch('signals.apps.reporting.utils.SwiftStorage', autospec=True)
-    def test_get_swift_storage_backend(self, mocked_swift_storage):
-        mocked_swift_storage_instance = mock.Mock()
-        mocked_swift_storage.return_value = mocked_swift_storage_instance
-
-        result = _get_storage_backend(using='datawarehouse')
-
-        self.assertEqual(result, mocked_swift_storage_instance)
-        mocked_swift_storage.assert_called_once_with(
-            api_auth_url='dwh_auth_url',
-            api_username='dwh_username',
-            api_key='dwh_password',
-            tenant_name='dwh_tenant_name',
-            tenant_id='dwh_tenant_id',
-            region_name='dwh_region_name',
-            container_name='dwh_container_name',
-            auto_overwrite=True
-        )
-
-    @override_settings(
-        SWIFT_STORAGE_ENABLED=False,
         AZURE_STORAGE_ENABLED=True,
         AZURE_CONTAINERS={
             'datawarehouse': {

--- a/api/app/signals/apps/reporting/utils.py
+++ b/api/app/signals/apps/reporting/utils.py
@@ -1,23 +1,21 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2022 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from typing import Union
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import FileSystemStorage
 from storages.backends.azure_storage import AzureStorage
-from swift.storage import SwiftStorage
 
 
-def _get_storage_backend(using: str) -> Union[AzureStorage, FileSystemStorage, SwiftStorage]:
+def _get_storage_backend(using: str) -> Union[AzureStorage, FileSystemStorage]:
     """
     Returns one of the following storages:
         - AzureStorage, the "using" must be present in the AZURE_CONTAINERS setting.
         - FileSystemStorage, location is set to the settings.DWH_MEDIA_ROOT.
-        - SwiftStorage, the "using" must be present in the SWIFT setting.
 
     :param using:
-    :returns: AzureStorage, FileSystemStorage or SwiftStorage
+    :returns: AzureStorage or FileSystemStorage
     """
     if settings.AZURE_STORAGE_ENABLED:
         if not hasattr(settings, 'AZURE_CONTAINERS'):
@@ -26,10 +24,5 @@ def _get_storage_backend(using: str) -> Union[AzureStorage, FileSystemStorage, S
             raise ImproperlyConfigured(f'{using} not present in the AZURE_CONTAINERS settings')
 
         return AzureStorage(**settings.AZURE_CONTAINERS.get(using, {}))
-    elif settings.SWIFT_STORAGE_ENABLED:
-        if not hasattr(settings, 'SWIFT'):
-            raise ImproperlyConfigured('SWIFT settings must be set!')
-
-        return SwiftStorage(**settings.SWIFT.get(using, {}))
     else:
         return FileSystemStorage(location=settings.DWH_MEDIA_ROOT)

--- a/api/app/signals/settings/base.py
+++ b/api/app/signals/settings/base.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2022 Gemeente Amsterdam
+# Copyright (C) 2018 - 2023 Gemeente Amsterdam
 import os
-
-from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -189,11 +187,6 @@ MEDIA_URL = '/signals/media/'
 MEDIA_ROOT = os.path.join(os.path.dirname(os.path.dirname(BASE_DIR)), 'media')
 
 AZURE_STORAGE_ENABLED = os.getenv('AZURE_STORAGE_ENABLED', False) in TRUE_VALUES
-SWIFT_STORAGE_ENABLED = os.getenv('SWIFT_ENABLED', False) in TRUE_VALUES
-
-if AZURE_STORAGE_ENABLED and SWIFT_STORAGE_ENABLED:
-    raise ImproperlyConfigured('Enable AzureStorage OR SwiftStorage, not both')
-
 if AZURE_STORAGE_ENABLED:
     # Azure Settings
     DEFAULT_FILE_STORAGE = 'storages.backends.azure_storage.AzureStorage'
@@ -210,49 +203,6 @@ if AZURE_STORAGE_ENABLED:
         'datawarehouse': {
             'azure_container': os.getenv('DWH_AZURE_STORAGE_CONTAINER_NAME', AZURE_CONTAINER),
             'overwrite_files': os.getenv('DWH_AZURE_OVERWRITE_FILES', True) in TRUE_VALUES
-        }
-    }
-
-elif SWIFT_STORAGE_ENABLED:
-    # The default settings when using SwiftStorage to the general SIA ObjectStore
-    DEFAULT_FILE_STORAGE = 'swift.storage.SwiftStorage'
-
-    SWIFT_USERNAME = os.getenv('SWIFT_USERNAME')
-    SWIFT_PASSWORD = os.getenv('SWIFT_PASSWORD')
-    SWIFT_AUTH_URL = os.getenv('SWIFT_AUTH_URL')
-    SWIFT_TENANT_ID = os.getenv('SWIFT_TENANT_ID')
-    SWIFT_TENANT_NAME = os.getenv('SWIFT_TENANT_NAME')
-    SWIFT_REGION_NAME = os.getenv('SWIFT_REGION_NAME')
-    SWIFT_CONTAINER_NAME = os.getenv('SWIFT_CONTAINER_NAME')
-    SWIFT_TEMP_URL_KEY = os.getenv('SWIFT_TEMP_URL_KEY')
-    SWIFT_USE_TEMP_URLS = True
-
-    SWIFT = {
-        # These settings are used to create override the default Swift storage settings.
-        # Useful when writing to different ObjectStores
-        'datawarehouse': {
-            'api_username': os.getenv('DWH_SWIFT_USERNAME'),
-            'api_key': os.getenv('DWH_SWIFT_PASSWORD'),
-            'tenant_name': os.getenv('DWH_SWIFT_TENANT_NAME'),
-            'tenant_id': os.getenv('DWH_SWIFT_TENANT_ID'),
-            'container_name': os.getenv('DWH_SWIFT_CONTAINER_NAME'),
-            'auto_overwrite': os.getenv('DWH_SWIFT_AUTO_OVERWRITE', True)
-        },
-        'horeca': {
-            'api_username': os.getenv('HORECA_SWIFT_USERNAME'),
-            'api_key': os.getenv('HORECA_SWIFT_PASSWORD'),
-            'tenant_name': os.getenv('HORECA_SWIFT_TENANT_NAME'),
-            'tenant_id': os.getenv('HORECA_SWIFT_TENANT_ID'),
-            'container_name': os.getenv('HORECA_SWIFT_CONTAINER_NAME'),
-            'auto_overwrite': os.getenv('HORECA_SWIFT_AUTO_OVERWRITE', True)
-        },
-        'tdo': {
-            'api_username': os.getenv('TDO_SWIFT_USERNAME'),
-            'api_key': os.getenv('TDO_SWIFT_PASSWORD'),
-            'tenant_name': os.getenv('TDO_SWIFT_TENANT_NAME'),
-            'tenant_id': os.getenv('TDO_SWIFT_TENANT_ID'),
-            'container_name': os.getenv('TDO_SWIFT_CONTAINER_NAME'),
-            'auto_overwrite': os.getenv('TDO_SWIFT_AUTO_OVERWRITE', True)
         }
     }
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -38,7 +38,6 @@ django-extensions==3.2.0
 django-filter==22.1
 django-markdownx==3.0.1
 django-rest-swagger==2.2.0
-django-storage-swift==1.2.19
 django-storages==1.12.3
 django-timezone-field==5.0
 djangorestframework==3.13.1
@@ -130,7 +129,6 @@ python-crontab==2.6.0
 python-dateutil==2.8.2
 python-keystoneclient==5.0.0
 python-magic==0.4.27
-python-swiftclient==4.0.1
 pytz==2022.1
 PyYAML==6.0
 raven==6.10.0

--- a/api/requirements/req-base.txt
+++ b/api/requirements/req-base.txt
@@ -9,7 +9,6 @@ django-cors-headers
 django-extensions
 django-filter
 django-rest-swagger
-django-storage-swift
 django-storages
 
 # Database


### PR DESCRIPTION
## Description

SwiftStorage is no longer used by any of the municipalities. 

All municipalities are either using Azure blob storage or a form of local storage that is currently migrated to Azure blob storage. Therefore it was decided to remove SwiftStorage from the code base.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
