### PR TITLE
Removed V0 from API_VERSIONS

### DIFF
--- a/api/app/signals/__init__.py
+++ b/api/app/signals/__init__.py
@@ -14,24 +14,18 @@ from django.db.models.sql import datastructures  # noqa
 from django.core.exceptions import EmptyResultSet  # noqa
 
 datastructures.EmptyResultSet = EmptyResultSet
-# ---
-
 
 # Versioning
 # ==========
-# SIA / Signalen follows the semantic versioning standard. Previously we had
-# separate version numbers for the V0 (now defunct) and V1 versions of the API.
-# We now no longer separately version these, as their releases were always
-# tied to the backend. For backwards compatibility, and to not break external
-# systems that rely on SIA / Signalen we still expose all the separate version
-# numbers, but they are now all the same.
-
+# SIA / Signalen follows the semantic versioning standard. For backwards
+# compatibility, and to not break external systems that rely on
+# SIA / Signalen we still expose all the separate version numbers, but
+# they are now all the same.
 
 # Application version (Major, minor, patch)
 VERSION = (2, 15, '0')
 
 API_VERSIONS = {
-    'v0': VERSION,
     'v1': VERSION,
 }
 


### PR DESCRIPTION
## Description

V0 has been removed since 2020 and the V0 version is no longer exposed therefore it could be removed from the API_VERSIONS.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
