### PR TITLE
Removed work-arround that was in place for drf-extensions

### DIFF
--- a/api/app/signals/__init__.py
+++ b/api/app/signals/__init__.py
@@ -7,14 +7,6 @@ from signals.utils.version import get_version
 
 __all__ = ['celery_app', 'VERSION', 'API_VERSIONS', ]
 
-# Workaround an import issue in Django REST Framework Extensions, see:
-# https://github.com/chibisov/drf-extensions/issues/294
-# These lines can be removed when a new version is released (> 0.6.0)
-from django.db.models.sql import datastructures  # noqa
-from django.core.exceptions import EmptyResultSet  # noqa
-
-datastructures.EmptyResultSet = EmptyResultSet
-
 # Versioning
 # ==========
 # SIA / Signalen follows the semantic versioning standard. For backwards


### PR DESCRIPTION
## Description

Removed work-arround that was in place for drf-extensions. This work-arround is no longer needed because drf-extensions fixed the issue.

https://github.com/chibisov/drf-extensions/issues/294

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
