### PR TITLE
Removed "django.contrib.sites" and settings

### DIFF
--- a/app/signals/apps/signals/migrations/0019_auto_20181009_1321.py
+++ b/app/signals/apps/signals/migrations/0019_auto_20181009_1321.py
@@ -5,21 +5,18 @@ from django.db import migrations
 
 
 def initial_data_contrib_site(apps, schema_editor):
-    Site = apps.get_model('sites', 'Site')
-    Site.objects.update_or_create(
-        id=settings.SITE_ID,
-        defaults={
-            'domain': settings.SITE_DOMAIN,
-            'name': settings.SITE_NAME,
-        })
+    if 'django.contrib.sites' in settings.INSTALLED_APPS:
+        Site = apps.get_model('sites', 'Site')
+        Site.objects.update_or_create(
+            id=settings.SITE_ID,
+            defaults={
+                'domain': settings.SITE_DOMAIN,
+                'name': settings.SITE_NAME,
+            })
 
 
 class Migration(migrations.Migration):
-
-    dependencies = [
-        ('signals', '0018_auto_20181003_1206'),
-        ('sites', '0002_alter_domain_unique'),
-    ]
+    dependencies = [('signals', '0018_auto_20181003_1206'), ]
 
     operations = [
         migrations.RunPython(initial_data_contrib_site),

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -29,10 +29,6 @@ CORS_EXPOSE_HEADERS = [
     'X-Total-Count',  # Added for the geography endpoints
 ]
 
-SITE_ID = 1
-SITE_NAME = 'Signalen API'
-SITE_DOMAIN = os.getenv('SITE_DOMAIN', 'api.data.amsterdam.nl')
-
 ORGANIZATION_NAME = os.getenv('ORGANIZATION_NAME', 'Gemeente Amsterdam')
 
 # The prefix of the display value of the signal ID. Defaults to 'SIG-'. This wil generate an id like SIG-123456 when
@@ -74,7 +70,6 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.messages',
     'django.contrib.sessions',
-    'django.contrib.sites',
     'django.contrib.auth',
     'django.contrib.admin',
     'django.contrib.gis',
@@ -102,7 +97,6 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'signals.apps.api.middleware.APIVersionHeaderMiddleware',
 ]


### PR DESCRIPTION
## Description

Removed "django.contrib.sites" and all settings. The functionality is not used, therefore it was decided to remove it.

Before deploying this change run the following command:

```
python manage.py migrate sites zero
```

When the command above has not been executed the "django_site" table is still present (and so are the entries in the "django_migrations" table. These should then be removed manually.


## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
