### PR TITLE
Mark failed e-mail send tasks as FAILURE

### DIFF
--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -255,6 +255,11 @@ EMAIL_REST_ENDPOINT_CLIENT_KEY = os.getenv('EMAIL_REST_ENDPOINT_CLIENT_KEY', Non
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', 'Meldingen gemeente Amsterdam <noreply@meldingen.amsterdam.nl>')
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
+CELERY_EMAIL_CHUNK_SIZE = 1
+CELERY_EMAIL_TASK_CONFIG = {
+    'ignore_result': False,
+}
+
 # Sentry logging
 RAVEN_CONFIG = {
     'dsn': os.getenv('SENTRY_RAVEN_DSN'),


### PR DESCRIPTION
## Description

Currently failed e-mail send tasks still show up as SUCCESS in the task results. This PR makes sure failed e-mail send tasks come up as FAILURE. This PR adds the ability to monitor task results.

Note that e-mail tasks that are in a retry state temporarily incorrectly show SUCCESS in the task results. This is due to a [missing raise condition in django-celery-email](https://github.com/pmclanahan/django-celery-email/blob/d47da19c09e29eea90684692e8dfa059e026c046/djcelery_email/tasks.py):

```python
            send_emails.retry([[message], combined_kwargs], exc=e, throw=False)
```

should be:

```python
    raise send_emails.retry(exc=e)
```

according to the [Celery docs](https://docs.celeryq.dev/en/stable/userguide/tasks.html#retrying).

Not sure if they are willing to fix this in djcelery_email, as reliable delivery seems not to be the primary goal of the project.