### PR TITLE
Add task monitoring using Flower

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -53,6 +53,7 @@ factory-boy==3.2.1
 Faker==13.15.1
 filelock==3.7.1
 flake8==5.0.4
+flower==1.2.0
 freezegun==1.2.1
 future==0.18.3
 google-api-core==2.10.1

--- a/app/requirements/req-base.txt
+++ b/app/requirements/req-base.txt
@@ -34,6 +34,9 @@ coreapi
 # Celery
 Celery
 
+# Flower
+flower
+
 # Sentry
 raven
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,26 @@ services:
       - ./app:/app
     command: celery -A signals worker -l debug
 
+  flower:
+    build:
+      context: .
+    ports:
+      - "5566:5566"
+    depends_on:
+      mailhog:
+        condition: service_started
+      database:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+      rabbit:
+        condition: service_started
+    env_file:
+      - docker-compose/environments/.celery
+    volumes:
+      - ./app:/app
+    command: celery -A signals flower --port=5566
+
   celery_beat:
     build:
       context: .


### PR DESCRIPTION
## Description

This PR adds task monitoring using [Flower](https://flower.readthedocs.io/). During local development via Docker compose, Flower is available via:

http://localhost:5566/

For production we can add a deployment to the Helm chart and use the [Prometheus endpoint of Flower](https://flower.readthedocs.io/en/latest/prometheus-integration.html#prometheus-integration) to scrape the metrics.
