### PR TITLE
Remove EXCLUDED_PERMISSIONS_IN_RESPONSE setting as permissions are now implemented in frontend

### DIFF
--- a/app/signals/apps/users/rest_framework/views/permission.py
+++ b/app/signals/apps/users/rest_framework/views/permission.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2022 Gemeente Amsterdam
 from datapunt_api.rest import DatapuntViewSet
-from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.db.models import Q
 from rest_framework.permissions import DjangoModelPermissions
@@ -21,12 +20,3 @@ class PermissionViewSet(DatapuntViewSet):
 
     serializer_detail_class = PermissionSerializer
     serializer_class = PermissionSerializer
-
-    def get_queryset(self, *args, **kwargs):
-        # TODO: Remove this when the frontend is updated
-        qs = super(PermissionViewSet, self).get_queryset(*args, **kwargs)
-
-        if exclude_permissions := settings.FEATURE_FLAGS.get('EXCLUDED_PERMISSIONS_IN_RESPONSE'):
-            return qs.exclude(codename__in=exclude_permissions)
-        else:
-            return qs

--- a/app/signals/apps/users/tests/rest_framework/test_permissions.py
+++ b/app/signals/apps/users/tests/rest_framework/test_permissions.py
@@ -7,8 +7,7 @@ class TestPermissionsViews(SIAReadUserMixin, SignalsBaseApiTestCase):
     def test_get_permissions(self):
         self.client.force_authenticate(user=self.sia_read_user)
 
-        with self.settings(FEATURE_FLAGS={'EXCLUDED_PERMISSIONS_IN_RESPONSE': None}):
-            response = self.client.get('/signals/v1/private/permissions/')
+        response = self.client.get('/signals/v1/private/permissions/')
         self.assertEqual(response.status_code, 200)
 
         data = response.json()

--- a/app/signals/settings/feature_flags.py
+++ b/app/signals/settings/feature_flags.py
@@ -14,15 +14,6 @@ FEATURE_FLAGS = {
     'SIGNAL_HISTORY_LOG_ENABLED': os.getenv('SIGNAL_HISTORY_LOG_ENABLED', False) in TRUE_VALUES,
     'API_USE_QUESTIONNAIRES_APP_FOR_FEEDBACK': os.getenv('API_USE_QUESTIONNAIRES_APP_FOR_FEEDBACK', False) in TRUE_VALUES,  # noqa
 
-    # Temporary added to exclude permissions in the signals/v1/permissions endpoint that are not yet implemented in
-    # the frontend
-    # TODO: Remove this when the frontend is updated
-    'EXCLUDED_PERMISSIONS_IN_RESPONSE': os.getenv('EXCLUDED_PERMISSIONS_IN_RESPONSE',
-                                                  'sia_delete_attachment_of_normal_signal,'
-                                                  'sia_delete_attachment_of_parent_signal,'
-                                                  'sia_delete_attachment_of_child_signal,'
-                                                  'sia_delete_attachment_of_other_user').split(','),
-
     # Enable/disable system mail for Feedback Received
     'SYSTEM_MAIL_FEEDBACK_RECEIVED_ENABLED': os.getenv('SYSTEM_MAIL_FEEDBACK_RECEIVED_ENABLED', False) in TRUE_VALUES,  # noqa
 


### PR DESCRIPTION
The setting no longer is required, as these permissions are now implemented in the frontend.

See: https://github.com/Amsterdam/signals-frontend/commit/5ac1aef2b6e2fa407abd138dd4f6cf02fa2c63b0
