### PR TITLE
Fix typo in signal_forward_to_external default mail

### DIFF
--- a/app/signals/apps/email_integrations/templates/email/signal_forward_to_external.html
+++ b/app/signals/apps/email_integrations/templates/email/signal_forward_to_external.html
@@ -15,7 +15,7 @@
 
     <p>
         <strong>Wat kunt u doen?</strong><br>
-        U kunt de melding gelijk inzien en oppakken. Als de melding verwerkt, ontvangen wij graag een bericht.<br>
+        U kunt de melding gelijk inzien en oppakken. Als de melding is verwerkt, ontvangen wij graag een bericht.<br>
         <a href="{{ reaction_url }}">Bekijk de actie</a>
     </p>
 

--- a/app/signals/apps/email_integrations/templates/email/signal_forward_to_external.txt
+++ b/app/signals/apps/email_integrations/templates/email/signal_forward_to_external.txt
@@ -3,7 +3,7 @@ Geachte behandelaar,
 Er is een melding binnengekomen bij de Gemeente. Kunnen jullie hier naar kijken en ons late weten of jullie deze kunnen afhandelen.
 
 Wat kunt u doen?
-U kunt de melding gelijk inzien en oppakken. Als de melding verwerkt, ontvangen wij graag een bericht.
+U kunt de melding gelijk inzien en oppakken. Als de melding is verwerkt, ontvangen wij graag een bericht.
 
 [Bekijk de actie]({{ reaction_url }})
 


### PR DESCRIPTION
Add this word "is"