### PR TITLE
Remove category_assignment__category__parent from select_related list

### DIFF
--- a/app/signals/apps/api/views/signals/private/signals.py
+++ b/app/signals/apps/api/views/signals/private/signals.py
@@ -52,7 +52,6 @@ class PrivateSignalViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, Dat
         'location',
         'status',
         'category_assignment',
-        'category_assignment__category__parent',
         'reporter',
         'priority',
         'parent',


### PR DESCRIPTION
## Description

Remove category_assignment__category__parent from select_related list as it produces more queries instead of less.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
