### PR TITLE
Add parent to select_related in order to reduce the number of queries

### DIFF
--- a/app/signals/apps/api/fields/category.py
+++ b/app/signals/apps/api/fields/category.py
@@ -45,7 +45,7 @@ class CategoryHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
 
 class CategoryHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
     view_name = 'public-subcategory-detail'
-    queryset = Category.objects.all()
+    queryset = Category.objects.all().select_related('parent')
     parent_lookup_prefix = extensions_api_settings.DEFAULT_PARENT_LOOKUP_KWARG_NAME_PREFIX
 
     def get_object(self, view_name, view_args, view_kwargs):
@@ -57,6 +57,7 @@ class CategoryHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
     def get_url(self, obj, view_name, request, format):
         # We want a Category instance, DRF can also return a PKOnlyObject when use_pk_only_optimization is enabled
         category = obj if isinstance(obj, Category) else self.get_queryset().get(pk=obj.pk)
+
         return category_public_url(category, request=request, format=format)
 
     def to_internal_value(self, data):


### PR DESCRIPTION
## Description

Add parent to select_related in order to reduce the number of queries produced when calling the signals list endpoint.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
