### PR TITLE
Upgrade to python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install geospatial libraries # https://docs.djangoproject.com/en/3.0/ref/contrib/gis/install/geolibs/
         run: sudo apt update && sudo apt install binutils libproj-dev gdal-bin graphviz
 
-      - name: Setup Python 3.10
+      - name: Setup Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.11
 
 ##################################################
 #                   Python                       #
@@ -38,6 +38,7 @@ RUN set -eux;  \
         libmagic1 \
         libcairo2 \
         libpango1.0-0 \
+        libpq-dev \
         gcc \
         graphviz \
     ; \

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -22,7 +22,6 @@ coreschema==0.0.4
 coverage==6.4.2
 cryptography==39.0.1
 cssselect2==0.6.0
-cycler==0.11.0
 datapunt-authorization-django==1.3.2
 debtcollector==2.5.0
 defusedxml==0.7.1
@@ -54,7 +53,6 @@ Faker==13.15.1
 filelock==3.7.1
 flake8==5.0.4
 flex==6.14.1
-fonttools==4.34.4
 freezegun==1.2.1
 future==0.18.3
 google-api-core==2.10.1
@@ -73,7 +71,6 @@ jsonpointer==2.3
 jsonschema==4.9.1
 jwcrypto==1.4.2
 keystoneauth1==5.0.0
-kiwisolver==1.4.4
 kombu==5.2.4
 lxml==4.9.1
 Markdown==3.4.1
@@ -88,7 +85,6 @@ msrest==0.7.1
 netaddr==0.8.0
 netifaces==0.11.0
 networkx==2.8.5
-numpy==1.23.1
 oauthlib==3.2.2
 openapi-codec==1.3.2
 opencensus==0.11.0

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -155,7 +155,7 @@ tzdata==2022.1
 unicodecsv==0.14.1
 uritemplate==4.1.1
 urllib3==1.26.11
-uWSGI==2.0.20
+uWSGI==2.0.21
 validate-email==1.3
 vine==5.0.0
 virtualenv==20.16.3

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -52,7 +52,6 @@ factory-boy==3.2.1
 Faker==13.15.1
 filelock==3.7.1
 flake8==5.0.4
-flex==6.14.1
 freezegun==1.2.1
 future==0.18.3
 google-api-core==2.10.1
@@ -60,14 +59,12 @@ google-auth==2.12.0
 googleapis-common-protos==1.56.4
 html5lib==1.1
 idna==3.3
-importlib-metadata==4.12.0
 iniconfig==1.1.1
 iso8601==1.0.2
 isodate==0.6.1
 isort==5.10.1
 itypes==1.2.0
 Jinja2==3.1.2
-jsonpointer==2.3
 jsonschema==4.9.1
 jwcrypto==1.4.2
 keystoneauth1==5.0.0
@@ -133,13 +130,11 @@ requests==2.28.1
 requests-mock==1.9.3
 requests-oauthlib==1.3.1
 rfc3986==2.0.0
-rfc3987==1.3.8
 rsa==4.9
 simplejson==3.17.6
 six==1.16.0
 sqlparse==0.4.2
 stevedore==4.0.0
-strict-rfc3339==0.7
 textX==3.0.0
 tinycss2==1.1.1
 toml==0.10.2
@@ -152,7 +147,6 @@ unicodecsv==0.14.1
 uritemplate==4.1.1
 urllib3==1.26.11
 uWSGI==2.0.21
-validate-email==1.3
 vine==5.0.0
 virtualenv==20.16.3
 wcwidth==0.2.5
@@ -160,4 +154,3 @@ WeasyPrint==52.5
 webencodings==0.5.1
 wrapt==1.14.1
 xmlunittest==0.5.0
-zipp==3.8.1

--- a/app/requirements/req-base.txt
+++ b/app/requirements/req-base.txt
@@ -1,5 +1,5 @@
 # LTS Django 3.2.x
-Django==3.2.18
+Django==3.2
 
 # Django packages
 django-celery-beat


### PR DESCRIPTION
## Description

Updated the python version to 3.11.

The Dockerfile and Github CI is now based on python 3.11. Added libpq-dev to the Dockerfile, needed for psycopg and updated uWSGI from 2.20.20 to 2.20.21.

🧹 Removed several dependencies from the requirements.txt file that were not being used by the application, including flex, importlib-metadata, jsonpointer, rfc3987, strict-rfc3339, cycler, fonttools, kiwisolver, and numpy.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
