### PR TITLE
Concatenate the responsible department codes on the V1 private signals endpoints

### DIFF
--- a/app/signals/apps/api/serializers/nested/category.py
+++ b/app/signals/apps/api/serializers/nested/category.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from rest_framework import serializers
 
 from signals.apps.api.fields import CategoryHyperlinkedRelatedField
@@ -63,6 +63,12 @@ class _NestedCategoryModelSerializer(SIAModelSerializer):
         return super().validate(attrs=attrs)
 
     def get_departments(self, obj):
-        return ', '.join(
-            obj.category.departments.filter(categorydepartment__is_responsible=True).values_list('code', flat=True)
-        )
+        """
+        Get the annotated field from the signal that is related to this category_assignment
+        """
+        if hasattr(obj.signal, 'category_assignment__category__department_codes'):
+            return obj.signal.category_assignment__category__department_codes
+        else:
+            return ', '.join(
+                obj.category.departments.filter(categorydepartment__is_responsible=True).values_list('code', flat=True)
+            )


### PR DESCRIPTION
## Description

Use STRING_AGG to concatenate all resonsible department codes in the main queryset used for the v1 private signals endpoints.

Made sure that this change is backwards compatible because in the v1 public signals endpoints this serializer is used without the data from a queryset.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
