### PR TITLE
Update the _NestedReporterModelSerializer to use the signal attribute instead of _signal to retrieve the allows_contact field

### DIFF
--- a/app/signals/apps/api/serializers/nested/reporter.py
+++ b/app/signals/apps/api/serializers/nested/reporter.py
@@ -8,7 +8,7 @@ from signals.apps.signals.models import Reporter
 
 class _NestedReporterModelSerializer(SIAModelSerializer):
 
-    allows_contact = serializers.BooleanField(source='_signal.allows_contact', read_only=True)
+    allows_contact = serializers.BooleanField(source='signal.allows_contact', read_only=True)
 
     class Meta:
         model = Reporter


### PR DESCRIPTION
## Description

Update the _NestedReporterModelSerializer to use the signal attribute instead of _signal to retrieve the allows_contact field from the related Signal object. This change results in fewer queries being executed and improves performance.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
