### PR TITLE
Added the incident date start to the general email context

### DIFF
--- a/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
+++ b/app/signals/apps/email_integrations/templates/admin/change_email_template_form.html
@@ -58,6 +58,7 @@
             <li>signal_id</li>
             <li>formatted_signal_id</li>
             <li>created_at</li>
+            <li>incident_date_start</li>
             <li>text</li>
             <li>text_extra</li>
             <li>address</li>

--- a/app/signals/apps/email_integrations/tests/test_utils.py
+++ b/app/signals/apps/email_integrations/tests/test_utils.py
@@ -134,6 +134,7 @@ class TestUtils(TestCase):
         self.assertEqual(context['handling_message'], signal.category_assignment.stored_handling_message)
         self.assertEqual(context['ORGANIZATION_NAME'], settings.ORGANIZATION_NAME)
         self.assertEqual(context['source'], signal.source)
+        self.assertEqual(context['incident_date_start'], signal.incident_date_start)
 
     def test_make_email_context_for_category_with_or_without_public_name(self):
         # Check categories with public names.
@@ -171,6 +172,7 @@ class TestUtils(TestCase):
         self.assertEqual(context['status_state'], signal.status.state)
         self.assertEqual(context['handling_message'], signal.category_assignment.stored_handling_message)
         self.assertEqual(context['ORGANIZATION_NAME'], settings.ORGANIZATION_NAME)
+        self.assertEqual(context['incident_date_start'], signal.incident_date_start)
         self.assertEqual(context['extra'], 'context')
 
     def test_make_email_context_additional_context_should_not_override_default_variables(self):

--- a/app/signals/apps/email_integrations/utils.py
+++ b/app/signals/apps/email_integrations/utils.py
@@ -160,6 +160,7 @@ def make_email_context(signal: Signal, additional_context: Optional[dict] = None
         'main_category_public_name': parent_public_name,
         'sub_category_public_name': category.public_name if category.public_name else category.name,
         'source': signal.source,
+        'incident_date_start': signal.incident_date_start,
     }
 
     if 'MY_SIGNALS_ENABLED' in settings.FEATURE_FLAGS and settings.FEATURE_FLAGS['MY_SIGNALS_ENABLED']:


### PR DESCRIPTION
## Description

Added the incident date start to the general email context

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
