### PR TITLE
Story/allows contact using annotation

### DIFF
--- a/app/signals/apps/api/serializers/nested/__init__.py
+++ b/app/signals/apps/api/serializers/nested/__init__.py
@@ -13,7 +13,10 @@ from signals.apps.api.serializers.nested.department import (
 from signals.apps.api.serializers.nested.location import _NestedLocationModelSerializer
 from signals.apps.api.serializers.nested.note import _NestedNoteModelSerializer
 from signals.apps.api.serializers.nested.priority import _NestedPriorityModelSerializer
-from signals.apps.api.serializers.nested.reporter import _NestedReporterModelSerializer
+from signals.apps.api.serializers.nested.reporter import (
+    _NestedReporterModelSerializer,
+    _NestedReporterModelListSerializer
+)
 from signals.apps.api.serializers.nested.status import (
     _NestedPublicStatusModelSerializer,
     _NestedStatusModelSerializer
@@ -26,6 +29,7 @@ __all__ = (
     '_NestedPublicStatusModelSerializer',
     '_NestedCategoryModelSerializer',
     '_NestedReporterModelSerializer',
+    '_NestedReporterModelListSerializer',
     '_NestedPriorityModelSerializer',
     '_NestedNoteModelSerializer',
     '_NestedAttachmentModelSerializer',

--- a/app/signals/apps/api/serializers/nested/__init__.py
+++ b/app/signals/apps/api/serializers/nested/__init__.py
@@ -13,10 +13,7 @@ from signals.apps.api.serializers.nested.department import (
 from signals.apps.api.serializers.nested.location import _NestedLocationModelSerializer
 from signals.apps.api.serializers.nested.note import _NestedNoteModelSerializer
 from signals.apps.api.serializers.nested.priority import _NestedPriorityModelSerializer
-from signals.apps.api.serializers.nested.reporter import (
-    _NestedReporterModelListSerializer,
-    _NestedReporterModelSerializer
-)
+from signals.apps.api.serializers.nested.reporter import _NestedReporterModelSerializer
 from signals.apps.api.serializers.nested.status import (
     _NestedPublicStatusModelSerializer,
     _NestedStatusModelSerializer
@@ -29,7 +26,6 @@ __all__ = (
     '_NestedPublicStatusModelSerializer',
     '_NestedCategoryModelSerializer',
     '_NestedReporterModelSerializer',
-    '_NestedReporterModelListSerializer',
     '_NestedPriorityModelSerializer',
     '_NestedNoteModelSerializer',
     '_NestedAttachmentModelSerializer',

--- a/app/signals/apps/api/serializers/nested/__init__.py
+++ b/app/signals/apps/api/serializers/nested/__init__.py
@@ -14,8 +14,8 @@ from signals.apps.api.serializers.nested.location import _NestedLocationModelSer
 from signals.apps.api.serializers.nested.note import _NestedNoteModelSerializer
 from signals.apps.api.serializers.nested.priority import _NestedPriorityModelSerializer
 from signals.apps.api.serializers.nested.reporter import (
-    _NestedReporterModelSerializer,
-    _NestedReporterModelListSerializer
+    _NestedReporterModelListSerializer,
+    _NestedReporterModelSerializer
 )
 from signals.apps.api.serializers.nested.status import (
     _NestedPublicStatusModelSerializer,

--- a/app/signals/apps/api/serializers/nested/reporter.py
+++ b/app/signals/apps/api/serializers/nested/reporter.py
@@ -6,7 +6,9 @@ from signals.apps.api.generics.serializers import SIAModelSerializer
 from signals.apps.signals.models import Reporter
 
 
-class BaseNestedReporterModelSerializer(SIAModelSerializer):
+class _NestedReporterModelSerializer(SIAModelSerializer):
+    allows_contact = serializers.SerializerMethodField()
+
     class Meta:
         model = Reporter
         fields = (
@@ -43,10 +45,11 @@ class BaseNestedReporterModelSerializer(SIAModelSerializer):
 
         return super().to_internal_value(data)
 
+    def get_allows_contact(self, obj: Reporter) -> bool:
+        if hasattr(obj.signal, 'reporter__allows_contact'):
+            if obj.signal.reporter__allows_contact is None:
+                return True
 
-class _NestedReporterModelSerializer(BaseNestedReporterModelSerializer):
-    allows_contact = serializers.BooleanField(source='_signal.allows_contact', read_only=True)
+            return obj.signal.reporter__allows_contact
 
-
-class _NestedReporterModelListSerializer(BaseNestedReporterModelSerializer):
-    allows_contact = serializers.BooleanField(read_only=True)
+        return obj.signal.allows_contact

--- a/app/signals/apps/api/serializers/nested/reporter.py
+++ b/app/signals/apps/api/serializers/nested/reporter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2022 Gemeente Amsterdam
+from django.conf import settings
 from rest_framework import serializers
 
 from signals.apps.api.generics.serializers import SIAModelSerializer
@@ -46,6 +47,9 @@ class _NestedReporterModelSerializer(SIAModelSerializer):
         return super().to_internal_value(data)
 
     def get_allows_contact(self, obj: Reporter) -> bool:
+        if not settings.FEATURE_FLAGS.get('REPORTER_MAIL_CONTACT_FEEDBACK_ALLOWS_CONTACT_ENABLED', True):
+            return True
+
         if hasattr(obj.signal, 'reporter__allows_contact'):
             if obj.signal.reporter__allows_contact is None:
                 return True

--- a/app/signals/apps/api/serializers/nested/reporter.py
+++ b/app/signals/apps/api/serializers/nested/reporter.py
@@ -6,10 +6,7 @@ from signals.apps.api.generics.serializers import SIAModelSerializer
 from signals.apps.signals.models import Reporter
 
 
-class _NestedReporterModelSerializer(SIAModelSerializer):
-
-    allows_contact = serializers.BooleanField(source='_signal.allows_contact', read_only=True)
-
+class BaseNestedReporterModelSerializer(SIAModelSerializer):
     class Meta:
         model = Reporter
         fields = (
@@ -45,3 +42,11 @@ class _NestedReporterModelSerializer(SIAModelSerializer):
             data['phone'] = None
 
         return super().to_internal_value(data)
+
+
+class _NestedReporterModelSerializer(BaseNestedReporterModelSerializer):
+    allows_contact = serializers.BooleanField(source='_signal.allows_contact', read_only=True)
+
+
+class _NestedReporterModelListSerializer(BaseNestedReporterModelSerializer):
+    allows_contact = serializers.BooleanField(read_only=True)

--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -28,6 +28,7 @@ from signals.apps.api.serializers.nested import (
     _NestedPriorityModelSerializer,
     _NestedPublicStatusModelSerializer,
     _NestedReporterModelSerializer,
+    _NestedReporterModelListSerializer,
     _NestedStatusModelSerializer,
     _NestedTypeModelSerializer
 )
@@ -282,7 +283,7 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
         permission_classes=(SignalCreateInitialPermission,)
     )
 
-    reporter = _NestedReporterModelSerializer(
+    reporter = _NestedReporterModelListSerializer(
         permission_classes=(SIAPermissions,)
     )
 

--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -27,7 +27,6 @@ from signals.apps.api.serializers.nested import (
     _NestedNoteModelSerializer,
     _NestedPriorityModelSerializer,
     _NestedPublicStatusModelSerializer,
-    _NestedReporterModelListSerializer,
     _NestedReporterModelSerializer,
     _NestedStatusModelSerializer,
     _NestedTypeModelSerializer
@@ -283,7 +282,7 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
         permission_classes=(SignalCreateInitialPermission,)
     )
 
-    reporter = _NestedReporterModelListSerializer(
+    reporter = _NestedReporterModelSerializer(
         permission_classes=(SIAPermissions,)
     )
 
@@ -352,8 +351,6 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
 
     id_display = serializers.CharField(source='get_id_display', read_only=True)
 
-    reporter__allows_contact = serializers.BooleanField()
-
     class Meta:
         model = Signal
         list_serializer_class = _SignalListSerializer
@@ -388,7 +385,6 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
             'has_children',
             'assigned_user_email',
             'session',
-            'reporter__allows_contact',
         )
         read_only_fields = (
             'created_at',
@@ -531,14 +527,6 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
 
         signal.refresh_from_db()
         return signal
-
-    def to_representation(self, instance):
-        serialized = super().to_representation(instance)
-
-        allows_contact = serialized.pop('reporter__allows_contact')
-        serialized['reporter']['allows_contact'] = allows_contact if allows_contact else False
-
-        return serialized
 
 
 class PublicSignalSerializerDetail(HALSerializer):

--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -27,8 +27,8 @@ from signals.apps.api.serializers.nested import (
     _NestedNoteModelSerializer,
     _NestedPriorityModelSerializer,
     _NestedPublicStatusModelSerializer,
-    _NestedReporterModelSerializer,
     _NestedReporterModelListSerializer,
+    _NestedReporterModelSerializer,
     _NestedStatusModelSerializer,
     _NestedTypeModelSerializer
 )

--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -351,6 +351,8 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
 
     id_display = serializers.CharField(source='get_id_display', read_only=True)
 
+    reporter__allows_contact = serializers.BooleanField()
+
     class Meta:
         model = Signal
         list_serializer_class = _SignalListSerializer
@@ -384,7 +386,8 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
             'has_parent',
             'has_children',
             'assigned_user_email',
-            'session'
+            'session',
+            'reporter__allows_contact',
         )
         read_only_fields = (
             'created_at',
@@ -527,6 +530,14 @@ class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
 
         signal.refresh_from_db()
         return signal
+
+    def to_representation(self, instance):
+        serialized = super().to_representation(instance)
+
+        allows_contact = serialized.pop('reporter__allows_contact')
+        serialized['reporter']['allows_contact'] = allows_contact if allows_contact else False
+
+        return serialized
 
 
 class PublicSignalSerializerDetail(HALSerializer):

--- a/app/signals/apps/api/views/signals/private/signals.py
+++ b/app/signals/apps/api/views/signals/private/signals.py
@@ -4,8 +4,9 @@ import datetime
 import logging
 
 from datapunt_api.rest import DatapuntViewSet, HALPagination
+
 from django.contrib.postgres.aggregates import StringAgg
-from django.db.models import CharField, Q, Value, OuterRef, Subquery
+from django.db.models import CharField, OuterRef, Subquery, Value, Q
 from django.db.models.functions import JSONObject
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend

--- a/app/signals/apps/api/views/signals/private/signals.py
+++ b/app/signals/apps/api/views/signals/private/signals.py
@@ -4,10 +4,9 @@ import datetime
 import logging
 
 from datapunt_api.rest import DatapuntViewSet, HALPagination
-
 from django.conf import settings
 from django.contrib.postgres.aggregates import StringAgg
-from django.db.models import CharField, OuterRef, Subquery, Value, Q
+from django.db.models import CharField, OuterRef, Q, Subquery, Value
 from django.db.models.functions import JSONObject
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend


### PR DESCRIPTION
## Description

Get allows_contact value using a sub query on the signals list endpoint in order to reduce the total number of queries that are executed on requests on that endpoint.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
