### PR TITLE
Revert the latest query enhancments

### DIFF
--- a/app/signals/apps/api/serializers/nested/category.py
+++ b/app/signals/apps/api/serializers/nested/category.py
@@ -63,12 +63,6 @@ class _NestedCategoryModelSerializer(SIAModelSerializer):
         return super().validate(attrs=attrs)
 
     def get_departments(self, obj):
-        """
-        Get the annotated field from the signal that is related to this category_assignment
-        """
-        if hasattr(obj.signal, 'category_assignment__category__department_codes'):
-            return obj.signal.category_assignment__category__department_codes
-        else:
-            return ', '.join(
-                obj.category.departments.filter(categorydepartment__is_responsible=True).values_list('code', flat=True)
-            )
+        return ', '.join(
+            obj.category.departments.filter(categorydepartment__is_responsible=True).values_list('code', flat=True)
+        )

--- a/app/signals/apps/api/serializers/nested/reporter.py
+++ b/app/signals/apps/api/serializers/nested/reporter.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
-from django.conf import settings
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from rest_framework import serializers
 
 from signals.apps.api.generics.serializers import SIAModelSerializer
@@ -8,7 +7,7 @@ from signals.apps.signals.models import Reporter
 
 
 class _NestedReporterModelSerializer(SIAModelSerializer):
-    allows_contact = serializers.SerializerMethodField()
+    allows_contact = serializers.BooleanField(source='signal.allows_contact', read_only=True)
 
     class Meta:
         model = Reporter
@@ -45,15 +44,3 @@ class _NestedReporterModelSerializer(SIAModelSerializer):
             data['phone'] = None
 
         return super().to_internal_value(data)
-
-    def get_allows_contact(self, obj: Reporter) -> bool:
-        if not settings.FEATURE_FLAGS.get('REPORTER_MAIL_CONTACT_FEEDBACK_ALLOWS_CONTACT_ENABLED', True):
-            return True
-
-        if hasattr(obj.signal, 'reporter__allows_contact'):
-            if obj.signal.reporter__allows_contact is None:
-                return True
-
-            return obj.signal.reporter__allows_contact
-
-        return obj.signal.allows_contact

--- a/app/signals/apps/api/views/signals/private/signals.py
+++ b/app/signals/apps/api/views/signals/private/signals.py
@@ -4,9 +4,8 @@ import datetime
 import logging
 
 from datapunt_api.rest import DatapuntViewSet, HALPagination
-from django.conf import settings
 from django.contrib.postgres.aggregates import StringAgg
-from django.db.models import CharField, OuterRef, Q, Subquery, Value
+from django.db.models import CharField, Q, Value
 from django.db.models.functions import JSONObject
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend
@@ -37,7 +36,6 @@ from signals.apps.api.serializers.email_preview import (
 from signals.apps.api.serializers.signal_history import HistoryLogHalSerializer
 from signals.apps.api.serializers.stats import PastWeekSerializer, TotalSerializer
 from signals.apps.email_integrations.utils import trigger_mail_action_for_email_preview
-from signals.apps.feedback.models import Feedback
 from signals.apps.history.models import Log
 from signals.apps.services.domain.pdf import PDFSummaryService
 from signals.apps.signals.models import Signal
@@ -125,18 +123,6 @@ class PrivateSignalViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, Dat
     }
 
     http_method_names = ['get', 'post', 'patch', 'head', 'options', 'trace']
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        if settings.FEATURE_FLAGS.get('REPORTER_MAIL_CONTACT_FEEDBACK_ALLOWS_CONTACT_ENABLED', True):
-            feedback = Feedback.objects.filter(
-                _signal=OuterRef('pk'),
-                submitted_at__isnull=False
-            ).order_by('-submitted_at')
-            self.queryset = self.queryset.annotate(
-                reporter__allows_contact=Subquery(feedback.values('allows_contact')[:1])
-            )
 
     def get_queryset(self, *args, **kwargs):
         if self._is_request_to_detail_endpoint():

--- a/app/signals/apps/api/views/signals/private/signals.py
+++ b/app/signals/apps/api/views/signals/private/signals.py
@@ -4,8 +4,7 @@ import datetime
 import logging
 
 from datapunt_api.rest import DatapuntViewSet, HALPagination
-from django.contrib.postgres.aggregates import StringAgg
-from django.db.models import CharField, Q, Value
+from django.db.models import CharField, Value
 from django.db.models.functions import JSONObject
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend
@@ -63,12 +62,6 @@ class PrivateSignalViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, Dat
         'notes',
         'signal_departments',
         'user_assignment',
-    ).annotate(
-        category_assignment__category__department_codes=StringAgg(
-            'category_assignment__category__departments__code',
-            delimiter=', ',
-            filter=Q(category_assignment__category__categorydepartment__is_responsible=True)
-        )
     )
 
     # Geography queryset to reduce the complexity of the query


### PR DESCRIPTION
## Description

Reverted the latest 2 query enhancments. Unfortunately these changes had a negative effect.

Reverted changes:
- Nested reporter serializer, the "allows_contact" field
- Nested category serializer, the "departments" field

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
