### PR TITLE
Implemented the correct configuration for Categories

### DIFF
--- a/app/signals/apps/signals/models/category.py
+++ b/app/signals/apps/signals/models/category.py
@@ -208,24 +208,24 @@ class Category(TrackFields, models.Model):
         """
         Check if the given configuration is valid for a parent Category
         """
-        if self.configuration:
-            raise ValidationError({'configuration': ['No additional configuration allowed for parent categories']})
+        errors = []
+        if len(self.configuration) > 0 and 'show_children_in_filter' not in self.configuration:
+            errors.append('The "show_children_in_filter" is required for parent categories')
+        elif len(self.configuration) > 0 and not isinstance(self.configuration['show_children_in_filter'], bool):
+            errors.append('Value of "show_children_in_filter" is not a valid boolean')
+
+        if len(self.configuration) > 1:
+            errors.append('Only "show_children_in_filter" is allowed')
+
+        if errors:
+            raise ValidationError({'configuration': errors})
 
     def _clean_child_configuration(self):
         """
         Check if the given configuration is valid for a child Category
         """
-        errors = []
-        if len(self.configuration) > 0 and 'show_in_filter' not in self.configuration:
-            errors.append('The "show_in_filter" is required for child categories')
-        elif len(self.configuration) > 0 and not isinstance(self.configuration['show_in_filter'], bool):
-            errors.append('Value of "show_in_filter" is not a valid boolean')
-
-        if len(self.configuration) > 1:
-            errors.append('Only "show_in_filter" is allowed')
-
-        if errors:
-            raise ValidationError({'configuration': errors})
+        if self.configuration:
+            raise ValidationError({'configuration': ['No additional configuration allowed for child categories']})
 
     def save(self, *args, **kwargs):
         self.full_clean()


### PR DESCRIPTION
## Description

We implemented the show_in_filter on the child categories, this was incorrect. The correct implementation is show_children_in_filter on the parent category. This has now been fixed.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
