### PR TITLE
Set Access-Control-Allow-Credentials response header to true

### DIFF
--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -28,6 +28,7 @@ CORS_EXPOSE_HEADERS = [
     'X-API-Version',  # General API version
     'X-Total-Count',  # Added for the geography endpoints
 ]
+CORS_ALLOW_CREDENTIALS = True
 
 ORGANIZATION_NAME = os.getenv('ORGANIZATION_NAME', 'Gemeente Amsterdam')
 


### PR DESCRIPTION
## Description

Set Access-Control-Allow-Credentials response header to true in order for the FE to be allowed to send the session cookie.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
