### PR TITLE
Main category configuration in api

### DIFF
--- a/app/signals/apps/api/serializers/category.py
+++ b/app/signals/apps/api/serializers/category.py
@@ -106,6 +106,7 @@ class PrivateCategorySerializer(HALSerializer):
     new_sla = PrivateCategorySLASerializer(write_only=True)
 
     departments = _NestedPrivateCategoryDepartmentSerializer(source='categorydepartment_set', many=True, read_only=True)
+    configuration = serializers.JSONField(required=False)
 
     class Meta:
         model = Category
@@ -124,6 +125,7 @@ class PrivateCategorySerializer(HALSerializer):
             'note',
             'public_name',
             'is_public_accessible',
+            'configuration',
         )
         read_only_fields = (
             'slug',


### PR DESCRIPTION
## Description

Add api support for the new main category configuration object.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
