### PR TITLE
Override __str__ method to display the title in admin list

### DIFF
--- a/app/signals/apps/signals/models/status_message.py
+++ b/app/signals/apps/signals/models/status_message.py
@@ -44,6 +44,17 @@ class StatusMessage(CreatedUpdatedModel):
         verbose_name = 'Standaardtekst'
         verbose_name_plural = 'Standaardteksten'
 
+    def __str__(self) -> str:
+        """
+        Overridden method so that the title is used to display the status message in admin lists.
+
+        Returns
+        -------
+        str
+            The title of the status message
+        """
+        return self.title
+
 
 class StatusMessageCategory(models.Model):
     """


### PR DESCRIPTION
## Description

Override __str__ method to display the title in admin list

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
