### PR TITLE
Not all reporters are anonymized while they should be

### DIFF
--- a/app/signals/apps/signals/tasks.py
+++ b/app/signals/apps/signals/tasks.py
@@ -37,8 +37,6 @@ def anonymize_reporters(days=365):
 
     reporter_ids = Reporter.objects.filter(
         (Q(email__isnull=False) & ~Q(email__exact='')) | (Q(phone__isnull=False) & ~Q(phone__exact='')),
-        email_anonymized=False,
-        phone_anonymized=False,
         created_at__lt=created_before,
         _signal__status__state__in=allowed_signal_states,
     ).values_list(

--- a/app/signals/apps/signals/tasks.py
+++ b/app/signals/apps/signals/tasks.py
@@ -36,8 +36,7 @@ def anonymize_reporters(days=365):
     allowed_signal_states = [AFGEHANDELD, GEANNULEERD, GESPLITST, VERZOEK_TOT_AFHANDELING]
 
     reporter_ids = Reporter.objects.filter(
-        Q(email__isnull=False) & ~Q(email__exact=''),
-        Q(phone__isnull=False) & ~Q(phone__exact=''),
+        (Q(email__isnull=False) & ~Q(email__exact='')) | (Q(phone__isnull=False) & ~Q(phone__exact='')),
         email_anonymized=False,
         phone_anonymized=False,
         created_at__lt=created_before,
@@ -47,7 +46,6 @@ def anonymize_reporters(days=365):
     )
 
     reporter_count = reporter_ids.count()
-
     for reporter_id in reporter_ids:
         anonymize_reporter.delay(reporter_id=reporter_id)
 

--- a/app/signals/apps/signals/tests/test_task_anonymize_reporters.py
+++ b/app/signals/apps/signals/tests/test_task_anonymize_reporters.py
@@ -17,7 +17,7 @@ from signals.apps.signals.workflow import (
 )
 
 
-class TestTaskTranslateCategory(TransactionTestCase):
+class TestAnonymizeTasks(TransactionTestCase):
     def test_anonymize_reporter(self):
         signal = SignalFactory.create(status__state=AFGEHANDELD)
         reporter = signal.reporter

--- a/app/signals/apps/signals/tests/test_task_anonymize_reporters.py
+++ b/app/signals/apps/signals/tests/test_task_anonymize_reporters.py
@@ -163,9 +163,9 @@ class TestAnonymizeTasks(TransactionTestCase):
         reporter.refresh_from_db()
 
         self.assertIsNone(reporter.email)
-        self.assertIsNone(reporter.phone)
+        self.assertEqual('', reporter.phone)
         self.assertTrue(reporter.email_anonymized)
-        self.assertTrue(reporter.phone_anonymized)
+        self.assertFalse(reporter.phone_anonymized)
 
     def test_anonymize_reporters_that_has_null_email(self):
         with freeze_time(timezone.now() - timezone.timedelta(days=3)):
@@ -206,7 +206,7 @@ class TestAnonymizeTasks(TransactionTestCase):
 
         reporter.refresh_from_db()
 
-        self.assertIsNone(reporter.email)
+        self.assertEqual('', reporter.email)
         self.assertIsNone(reporter.phone)
-        self.assertTrue(reporter.email_anonymized)
+        self.assertFalse(reporter.email_anonymized)
         self.assertTrue(reporter.phone_anonymized)

--- a/app/signals/apps/signals/tests/test_task_anonymize_reporters.py
+++ b/app/signals/apps/signals/tests/test_task_anonymize_reporters.py
@@ -143,7 +143,7 @@ class TestAnonymizeTasks(TransactionTestCase):
         self.assertIsNone(reporter.email)
         self.assertIsNone(reporter.phone)
         self.assertTrue(reporter.email_anonymized)
-        self.assertTrue(reporter.phone_anonymized)
+        self.assertFalse(reporter.phone_anonymized)
 
     def test_anonymize_reporters_that_has_empty_phone(self):
         with freeze_time(timezone.now() - timezone.timedelta(days=3)):
@@ -186,7 +186,7 @@ class TestAnonymizeTasks(TransactionTestCase):
 
         self.assertIsNone(reporter.email)
         self.assertIsNone(reporter.phone)
-        self.assertTrue(reporter.email_anonymized)
+        self.assertFalse(reporter.email_anonymized)
         self.assertTrue(reporter.phone_anonymized)
 
     def test_anonymize_reporters_that_has_empty_email(self):

--- a/app/signals/apps/signals/tests/test_task_anonymize_reporters.py
+++ b/app/signals/apps/signals/tests/test_task_anonymize_reporters.py
@@ -122,3 +122,91 @@ class TestTaskTranslateCategory(TransactionTestCase):
         self.assertEqual(Reporter.objects.filter(email_anonymized=False, phone_anonymized=False).count(), 4)
 
         self.assertEqual(Reporter.objects.count(), 7)
+
+    def test_anonymize_reporters_that_has_null_phone(self):
+        with freeze_time(timezone.now() - timezone.timedelta(days=3)):
+            signal = SignalFactory.create(status__state=AFGEHANDELD)
+        reporter = signal.reporter
+        reporter.phone = None
+        reporter.save()
+
+        self.assertIsNotNone(reporter.email)
+        self.assertNotEqual('', reporter.email)
+        self.assertIsNone(reporter.phone)
+        self.assertFalse(reporter.email_anonymized)
+        self.assertFalse(reporter.phone_anonymized)
+
+        anonymize_reporters(days=1)
+
+        reporter.refresh_from_db()
+
+        self.assertIsNone(reporter.email)
+        self.assertIsNone(reporter.phone)
+        self.assertTrue(reporter.email_anonymized)
+        self.assertTrue(reporter.phone_anonymized)
+
+    def test_anonymize_reporters_that_has_empty_phone(self):
+        with freeze_time(timezone.now() - timezone.timedelta(days=3)):
+            signal = SignalFactory.create(status__state=AFGEHANDELD)
+        reporter = signal.reporter
+        reporter.phone = ''
+        reporter.save()
+
+        self.assertIsNotNone(reporter.email)
+        self.assertNotEqual('', reporter.email)
+        self.assertEqual('', reporter.phone)
+        self.assertFalse(reporter.email_anonymized)
+        self.assertFalse(reporter.phone_anonymized)
+
+        anonymize_reporters(days=1)
+
+        reporter.refresh_from_db()
+
+        self.assertIsNone(reporter.email)
+        self.assertIsNone(reporter.phone)
+        self.assertTrue(reporter.email_anonymized)
+        self.assertTrue(reporter.phone_anonymized)
+
+    def test_anonymize_reporters_that_has_null_email(self):
+        with freeze_time(timezone.now() - timezone.timedelta(days=3)):
+            signal = SignalFactory.create(status__state=AFGEHANDELD)
+        reporter = signal.reporter
+        reporter.email = None
+        reporter.save()
+
+        self.assertIsNone(reporter.email)
+        self.assertIsNotNone(reporter.phone)
+        self.assertNotEqual('', reporter.phone)
+        self.assertFalse(reporter.email_anonymized)
+        self.assertFalse(reporter.phone_anonymized)
+
+        anonymize_reporters(days=1)
+
+        reporter.refresh_from_db()
+
+        self.assertIsNone(reporter.email)
+        self.assertIsNone(reporter.phone)
+        self.assertTrue(reporter.email_anonymized)
+        self.assertTrue(reporter.phone_anonymized)
+
+    def test_anonymize_reporters_that_has_empty_email(self):
+        with freeze_time(timezone.now() - timezone.timedelta(days=3)):
+            signal = SignalFactory.create(status__state=AFGEHANDELD)
+        reporter = signal.reporter
+        reporter.email = ''
+        reporter.save()
+
+        self.assertEqual('', reporter.email)
+        self.assertIsNotNone(reporter.phone)
+        self.assertNotEqual('', reporter.phone)
+        self.assertFalse(reporter.email_anonymized)
+        self.assertFalse(reporter.phone_anonymized)
+
+        anonymize_reporters(days=1)
+
+        reporter.refresh_from_db()
+
+        self.assertIsNone(reporter.email)
+        self.assertIsNone(reporter.phone)
+        self.assertTrue(reporter.email_anonymized)
+        self.assertTrue(reporter.phone_anonymized)


### PR DESCRIPTION
## Description

There are several cases in which reporters should have been anonymized, but unfortunately they have not.
This PR aims to solve the issue.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
