### PR TITLE
Do not send assigned notifications for closed signals

### DIFF
--- a/app/signals/apps/email_integrations/tests/test_tasks.py
+++ b/app/signals/apps/email_integrations/tests/test_tasks.py
@@ -68,3 +68,17 @@ class TestTasks(TestCase):
             recipient=user_with_notification,
             assigned_to=user_with_notification
         )
+
+    @mock.patch('signals.apps.email_integrations.tasks.MailService.system_mail', autospec=True)
+    def test_send_no_mail_for_closed_signal(self, mocked_mail):
+        signal = SignalFactory.create()
+        signal.status = StatusFactory(_signal=signal, state=workflow.AFGEHANDELD)
+        signal.save()
+
+        user_with_notification = UserFactory.create()
+        user_with_notification.profile.notification_on_user_assignment = True
+        user_with_notification.profile.save()
+
+        tasks.send_mail_assigned_signal_user(signal_pk=signal.pk, user_pk=user_with_notification.pk)
+
+        mocked_mail.assert_not_called()


### PR DESCRIPTION
This change makes sure no assigned notifications are sent for closed signals.

Fixes [Teams issue](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:e201681cf65b453db9a98a67467c603a@thread.skype_p_dFQcO7x3vUWrWQ8CGTkI6ZcAD6mW_h_1670844429492?tenantId=6ef029ab-3fd7-4d98-9b0e-d1f5fedea6d1&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2Fmb03YzfF_0C5NATnsBZxtJcAIBQ-%22%2C%22channelId%22%3A%2219%3Ae201681cf65b453db9a98a67467c603a%40thread.skype%22%7D).
