### PR TITLE
Add case for presenting icon removal in history of category

### DIFF
--- a/app/signals/apps/api/serializers/category.py
+++ b/app/signals/apps/api/serializers/category.py
@@ -198,7 +198,10 @@ class PrivateCategoryHistoryHalSerializer(serializers.ModelSerializer):
             elif key == 'is_public_accessible':
                 action = f'Openbaar tonen gewijzigd naar:\n {"Aan" if value else "Uit"}'
             elif key == 'icon':
-                action = f'Icoon gewijzigd naar:\n {value[value.rindex("/")+1:]}'
+                if value == '':
+                    action = 'Icoon verwijderd'
+                else:
+                    action = f'Icoon gewijzigd naar:\n {value[value.rindex("/")+1:]}'
             else:
                 continue  # We do not show other tracked values, so on to the next one
 


### PR DESCRIPTION
## Description

When a category icon is removed the history endpoint for categories cannot currently handle that case.
This PR adds support for presenting icon removals in the category history endpoint.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
