### PR TITLE
Celery tasks "anonymize_reporters" and "anonymize_reporter" should run with the lowest priority

### DIFF
--- a/app/signals/apps/signals/tasks.py
+++ b/app/signals/apps/signals/tasks.py
@@ -32,7 +32,7 @@ def apply_routing(signal_id):
     dsl_service.process_routing_rules(signal)
 
 
-@app.task
+@app.task(priority=0)
 def anonymize_reporters(days=365):
     created_before = (timezone.now() - timezone.timedelta(days=days))
     allowed_signal_states = [AFGEHANDELD, GEANNULEERD, GESPLITST, VERZOEK_TOT_AFHANDELING]
@@ -47,12 +47,12 @@ def anonymize_reporters(days=365):
 
     reporter_count = reporter_ids.count()
     for reporter_id in reporter_ids:
-        anonymize_reporter.delay(reporter_id=reporter_id)
+        anonymize_reporter.apply_async(kwargs={'reporter_id': reporter_id}, priority=0)
 
     return reporter_count
 
 
-@app.task
+@app.task(priority=0)
 def anonymize_reporter(reporter_id):
     try:
         reporter = Reporter.objects.get(pk=reporter_id)

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -274,6 +274,7 @@ CELERY_RESULT_BACKEND = 'django-db'
 CELERY_RESULT_EXTENDED = True
 CELERY_TASK_RESULT_EXPIRES = 604800  # 7 days in seconds (7*24*60*60)
 CELERY_TASK_ALWAYS_EAGER = os.getenv('CELERY_TASK_ALWAYS_EAGER', False) in TRUE_VALUES
+CELERY_TASK_DEFAULT_PRIORITY = 5  # Make sure that all task are scheduled with a default priority of '5'
 
 # Celery Beat settings
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,9 +130,10 @@ services:
       retries: 5
 
   rabbit:
-    image: rabbitmq:3.8
+    image: rabbitmq:3.8-management
     ports:
       - "5672:5672"
+      - "15672:15672"
     environment:
       - RABBITMQ_ERLANG_COOKIE='secret cookie here'
       - RABBITMQ_DEFAULT_USER=signals


### PR DESCRIPTION
## Description

Set lowest priority for the `anonymize_reporters` and the `anonymize_reporter` tasks and updated rabbitmq image.

Added the `CELERY_TASK_DEFAULT_PRIORITY` setting with a default value of `5` to control the priority of tasks in Celery. Updated the `anonymize_reporters` and the `anonymize_reporter` tasks to run with priority `0` to prevent them from clogging up the queue. Also, changed the RabbitMQ image from 3.8 to 3.8-management to allow easier management and monitoring of the RabbitMQ server.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
