### PR TITLE
Add main category configuration field to public endpoint

### DIFF
--- a/app/signals/apps/api/serializers/category.py
+++ b/app/signals/apps/api/serializers/category.py
@@ -47,6 +47,7 @@ class ParentCategoryHALSerializer(HALSerializer):
     _display = DisplayField()
     sub_categories = CategoryHALSerializer(many=True, source='children')
     is_public_accessible = serializers.SerializerMethodField(method_name='get_is_public_accessible')
+    configuration = serializers.JSONField(required=False)
 
     class Meta:
         model = Category
@@ -58,6 +59,7 @@ class ParentCategoryHALSerializer(HALSerializer):
             'public_name',
             'is_public_accessible',
             'sub_categories',
+            'configuration',
         )
 
     def get_is_public_accessible(self, obj):

--- a/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -3429,6 +3429,15 @@ components:
           description: A list of child categories
           items:
             $ref: '#/components/schemas/publicCategoryChildResponse'
+        configuration:
+          type: object
+          nullable: true
+          properties:
+            show_children_in_filter:
+              type: boolean
+              description: >-
+                This should control whether or not the child categories of this category should be displayed in the
+                category filter.
 
     publicCategoryChildResponse:
       description: JSON data describing the public parent category response


### PR DESCRIPTION
## Description

Add main category configuration field to public endpoint

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
