### PR TITLE
Added list support to the StatusMessageViewSet

### DIFF
--- a/app/signals/apps/api/filters/status_messages.py
+++ b/app/signals/apps/api/filters/status_messages.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam
+from django_filters.rest_framework import FilterSet, filters
+
+from signals.apps.api.filters import category_choices, status_choices
+
+
+class StatusMessagesFilterSet(FilterSet):
+    active = filters.BooleanFilter()
+    category_id = filters.MultipleChoiceFilter(field_name='categories', choices=category_choices)
+    state = filters.MultipleChoiceFilter(choices=status_choices)

--- a/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -2187,6 +2187,57 @@ paths:
             - SIG/ALL
 
   /signals/v1/private/status-messages/:
+    get:
+      parameters:
+        - name: active
+          in: query
+          description: Filter is active
+          schema:
+            type: boolean
+          required: false
+        - name: state
+          in: query
+          description: Filter on specified state/states
+          schema:
+            $ref: '#/components/schemas/StatusStateChoices'
+          required: false
+        - name: category_id
+          description: Filter for specific category/categories
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: ordering
+          in: query
+          description: Order the result (ASC or DESC)
+          schema:
+            type: string
+            enum:
+              - active
+              - -active
+              - created_at
+              - -created_at
+              - state
+              - -state
+              - updated_at
+              - -updated_at
+          example: created_at
+          required: false
+      responses:
+        '200':
+          description: List response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1StatusMessageDetailList'
+        '400':
+          description: Bad request, see response body for the reason.
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Not authorized to access this endpoint.
+        '404':
+          description: Not found.
     post:
       description: Create a new status message
       requestBody:
@@ -2212,8 +2263,17 @@ paths:
 
   /signals/v1/private/status-messages/{id}:
     get:
+      parameters:
+        - name: id
+          in: path
+          description: ID of the status message template
+          required: true
+          schema:
+            type: integer
+            example: 1
       responses:
         '200':
+          description: The status message
           content:
             application/json:
               schema:
@@ -2227,6 +2287,14 @@ paths:
         '404':
           description: Not found.
     put:
+      parameters:
+        - name: id
+          in: path
+          description: ID of the status message template
+          required: true
+          schema:
+            type: integer
+            example: 1
       requestBody:
         description: Status message data.
         required: true
@@ -2236,6 +2304,7 @@ paths:
               $ref: '#/components/schemas/V1StatusMessage'
       responses:
         '200':
+          description: The status message
           content:
             application/json:
               schema:
@@ -2249,6 +2318,14 @@ paths:
         '404':
           description: Not found.
     patch:
+      parameters:
+        - name: id
+          in: path
+          description: ID of the status message template
+          required: true
+          schema:
+            type: integer
+            example: 1
       requestBody:
         description: Status message data.
         required: true
@@ -2258,6 +2335,7 @@ paths:
               $ref: '#/components/schemas/V1StatusMessage'
       responses:
         '200':
+          description: The status message
           content:
             application/json:
               schema:
@@ -2271,16 +2349,25 @@ paths:
         '404':
           description: Not found.
     delete:
-      '200':
-        description: Successfully deleted.
-      '400':
-        description: Bad request, see response body for the reason.
-      '401':
-        description: Not authenticated, may be caused by expired token.
-      '403':
-        description: Not authorized to access this endpoint.
-      '404':
-        description: Not found.
+      parameters:
+        - name: id
+          in: path
+          description: ID of the status message template
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        '200':
+          description: Successfully deleted.
+        '400':
+          description: Bad request, see response body for the reason.
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Not authorized to access this endpoint.
+        '404':
+          description: Not found.
 
 components:
   schemas:
@@ -5145,6 +5232,47 @@ components:
           example: true
         state:
           $ref: '#/components/schemas/StatusStateChoices'
+
+    V1StatusMessageDetailList:
+      description: List of status messages
+      type: object
+      properties:
+        _links:
+          type: object
+          properties:
+            self:
+              type: object
+              properties:
+                href:
+                  type: string
+                  description: URI of current page
+                  format: uri
+            next:
+              type: object
+              properties:
+                href:
+                  type: string
+                  description: URI of the next page
+                  format: uri
+                  nullable: true
+            previous:
+              type: object
+              properties:
+                href:
+                  type: string
+                  description: URI of the previous page
+                  format: uri
+                  nullable: true
+                  example: null
+        count:
+          type: integer
+          description: Total count of results for the request
+          example: 1
+        results:
+          type: array
+          description: A list of status messages, paginated
+          items:
+            $ref: '#/components/schemas/V1StatusMessageDetailGet'
 
     V1StatusMessageDetailGet:
       description: Status message

--- a/app/signals/apps/api/tests/test_status_message_endpoint.py
+++ b/app/signals/apps/api/tests/test_status_message_endpoint.py
@@ -850,3 +850,7 @@ class TestStatusMessageEndpointPermissions(SignalsBaseApiTestCase):
         response = self.client.delete(self.PATH + str(self.status_message.pk))
 
         self.assertEqual(403, response.status_code)
+
+    def test_cannot_list_without_permission(self):
+        response = self.client.get(self.PATH, format='json')
+        self.assertEqual(403, response.status_code)

--- a/app/signals/apps/api/views/status_message.py
+++ b/app/signals/apps/api/views/status_message.py
@@ -1,18 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2023 Gemeente Amsterdam
-from rest_framework import mixins, viewsets
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.filters import OrderingFilter
+from rest_framework.viewsets import ModelViewSet
 
+from signals.apps.api.filters.status_messages import StatusMessagesFilterSet
 from signals.apps.api.generics.permissions import ModelWritePermissions, SIAPermissions
 from signals.apps.api.serializers.status_message import StatusMessageSerializer
 from signals.apps.signals.models import StatusMessage
 from signals.auth.backend import JWTAuthBackend
 
 
-class StatusMessagesViewSet(mixins.CreateModelMixin,
-                            mixins.RetrieveModelMixin,
-                            mixins.UpdateModelMixin,
-                            mixins.DestroyModelMixin,
-                            viewsets.GenericViewSet):
+class StatusMessagesViewSet(ModelViewSet):
     """
     Endpoint to manage status messages.
 
@@ -28,3 +27,10 @@ class StatusMessagesViewSet(mixins.CreateModelMixin,
     serializer_class = StatusMessageSerializer
     authentication_classes = (JWTAuthBackend, )
     permission_classes = (SIAPermissions & ModelWritePermissions, )
+    filter_backends = (DjangoFilterBackend, OrderingFilter, )
+    filterset_class = StatusMessagesFilterSet
+    ordering = ('-created_at', )
+    ordering_fields = ('created_at',
+                       'updated_at',
+                       'active',
+                       'state', )

--- a/app/signals/apps/signals/factories/status_message.py
+++ b/app/signals/apps/signals/factories/status_message.py
@@ -10,7 +10,7 @@ from signals.apps.signals.workflow import STATUS_CHOICES_API
 class StatusMessageFactory(DjangoModelFactory):
     title = FuzzyText(length=100)
     text = FuzzyText(length=1000)
-    state = FuzzyChoice(STATUS_CHOICES_API)
+    state = FuzzyChoice([status_choice[0] for status_choice in STATUS_CHOICES_API])
     active = True
 
     class Meta:


### PR DESCRIPTION
## Description

In this PR the `StatusMessageViewSet` is updated to support the list functionality. 

The list is ordered by default using "-created_at" and can be ordered by giving the "order_by" query parameter for: "created_at", "updated_at", "active" and "state". Adding a "-" will invert the ordering. It is also possible to filter the results on: "state", "category_id" and "active". Both "state" and "category_id" are multiple choice.

Fixed a small bug in the `StatusMessageFactory`, the `FuzzyChoice` for `state` was giving tupples instead of the actual value that should be stored in the database.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
