### PR TITLE
Fix/sigmax triggered on ever status update

### DIFF
--- a/app/signals/apps/sigmax/signal_receivers.py
+++ b/app/signals/apps/sigmax/signal_receivers.py
@@ -1,12 +1,42 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2023 Gemeente Amsterdam
 from django.dispatch import receiver
 
 from signals.apps.sigmax import tasks
+from signals.apps.sigmax.tasks import is_signal_applicable
 from signals.apps.signals.managers import update_status
 
 
 @receiver(update_status, dispatch_uid='sigmax_update_status')
 def update_status_handler(sender, signal_obj, status, prev_status, **kwargs):
-    # call via Celery signal sending code
-    tasks.push_to_sigmax.delay(pk=signal_obj.id)
+    """
+    Update status handler for signals.
+
+    Parameters
+    ----------
+    sender : Any
+        The sender of the signal.
+    signal_obj : Signal
+        The signal object being updated.
+    status : Status
+        The new status of the signal.
+    prev_status : Status
+        The previous status of the signal.
+    **kwargs : dict
+        Additional keyword arguments.
+
+    Notes
+    -----
+    This function is a signal receiver for the `update_status` signal. It is triggered
+    whenever the status of a signal is updated. The function checks if the updated signal
+    is applicable for further processing using the `is_signal_applicable` function.
+    If applicable, it schedules the `push_to_sigmax` task to be executed asynchronously
+    using the `delay` method.
+
+    Examples
+    --------
+    This function is meant to be used as a signal receiver and is not called directly.
+    When a signal's status is updated, this function will handle the update accordingly.
+    """
+    if is_signal_applicable(signal_obj):
+        tasks.push_to_sigmax.delay(signal_id=signal_obj.id)

--- a/app/signals/apps/sigmax/tasks.py
+++ b/app/signals/apps/sigmax/tasks.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2023 Gemeente Amsterdam
 import logging
 from datetime import timedelta
 
@@ -14,32 +14,128 @@ from signals.celery import app
 logger = logging.getLogger(__name__)
 
 
-def is_signal_applicable(signal):
-    """Check that signal instance should be sent to Sigmax/CityControl."""
-    return signal.status.state == workflow.TE_VERZENDEN and \
-        signal.status.target_api == Status.TARGET_API_SIGMAX
+def _is_status_applicable(status: Status) -> bool:
+    """
+    Check if the given status is applicable for further processing in Sigmax.
+
+    Parameters
+    ----------
+    status : Status
+        The status object to be checked.
+
+    Returns
+    -------
+    bool
+        True if the status is applicable, False otherwise.
+
+    Notes
+    -----
+    The status is considered applicable if the following conditions are met:
+    - The state of the status is `workflow.TE_VERZENDEN`.
+    - The target API of the status is `Status.TARGET_API_SIGMAX`.
+
+    Examples
+    --------
+    >>> s = Status()
+    >>> s.state = workflow.TE_VERZENDEN
+    >>> s.target_api = Status.TARGET_API_SIGMAX
+    >>> _is_status_applicable(s)
+    True
+
+    >>> s.state = workflow.TE_VERZENDEN
+    >>> s.target_api = None
+    >>> _is_status_applicable(s)
+    False
+    """
+    return status.state == workflow.TE_VERZENDEN and status.target_api == Status.TARGET_API_SIGMAX
+
+
+def is_signal_applicable(signal: Signal) -> bool:
+    """
+    Check if the given signal is applicable for further processing.
+
+    Parameters
+    ----------
+    signal : Signal
+        The signal object to be checked.
+
+    Returns
+    -------
+    bool
+        True if the signal is applicable, False otherwise.
+
+    Notes
+    -----
+    The signal is considered applicable if the status of the signal is applicable based on
+    the `_is_status_applicable` function.
+
+    Examples
+    --------
+    >>> s = Signal()
+    >>> s.status = Status()
+    >>> s.status.state = workflow.TE_VERZENDEN
+    >>> s.status.target_api = Status.TARGET_API_SIGMAX
+    >>> is_signal_applicable(s)
+    True
+
+    >>> s.status.target_api = Status.TARGET_API_GISIB
+    >>> is_signal_applicable(s)
+    False
+    """
+    return _is_status_applicable(signal.status)
 
 
 @app.task
-def push_to_sigmax(pk):
+def push_to_sigmax(signal_id: int) -> None:
     """
-    Send signals to Sigmax if applicable
+    Push the signal with the given ID to Sigmax if applicable.
 
-    :param pk:
-    :return: Nothing
+    Parameters
+    ----------
+    signal_id : int
+        The ID of the signal to be pushed.
+
+    Notes
+    -----
+    This function attempts to retrieve the signal with the given ID from the database.
+    If the signal exists, it checks if the signal is applicable for further processing
+    using the `is_signal_applicable` function. If applicable, the signal is handled
+    by calling the `handle` function.
+
+    If the signal with the given ID does not exist, an exception is logged.
+
+    Examples
+    --------
+    >>> push_to_sigmax(123)
+    # If signal with ID 123 exists and is applicable, it will be handled
     """
     try:
-        signal = Signal.objects.get(pk=pk)
+        signal = Signal.objects.get(pk=signal_id)
     except Signal.DoesNotExist:
         logger.exception()
-        return None
-
-    if is_signal_applicable(signal):
-        handle(signal)
+    else:
+        if is_signal_applicable(signal):
+            handle(signal)
 
 
 @app.task
-def fail_stuck_sending_signals():
+def fail_stuck_sending_signals() -> None:
+    """
+    Fail signals that are stuck in the sending state for too long.
+
+    Notes
+    -----
+    This function identifies signals that are in the sending state (`workflow.TE_VERZENDEN`)
+    and have a target API of `Status.TARGET_API_SIGMAX`. It checks if the signals have been
+    in the sending state for longer than the specified timeout period (`settings.SIGMAX_SEND_FAIL_TIMEOUT_MINUTES`).
+    If such signals are found, their status is updated to `workflow.VERZENDEN_MISLUKT` and a failure message
+    is added to the status text.
+
+    Examples
+    --------
+    >>> fail_stuck_sending_signals()
+    # If there are signals stuck in the sending state for too long, they will be marked as failed
+    """
     before = timezone.now() - timedelta(minutes=settings.SIGMAX_SEND_FAIL_TIMEOUT_MINUTES)
     stuck_signals = Signal.objects.filter(status__state=workflow.TE_VERZENDEN,
                                           status__target_api=Status.TARGET_API_SIGMAX,

--- a/app/signals/apps/sigmax/tests/management/__init__.py
+++ b/app/signals/apps/sigmax/tests/management/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam

--- a/app/signals/apps/sigmax/tests/management/commands/__init__.py
+++ b/app/signals/apps/sigmax/tests/management/commands/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam

--- a/app/signals/apps/sigmax/tests/management/commands/test_fail_stuck_sending_signals.py
+++ b/app/signals/apps/sigmax/tests/management/commands/test_fail_stuck_sending_signals.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam
+from io import StringIO
+from typing import Any
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from signals.apps.signals.workflow import TE_VERZENDEN, VERZENDEN_MISLUKT
+from signals.settings import SIGMAX_SEND_FAIL_TIMEOUT_MINUTES
+
+
+class TestFailStuckSendingSignals(TestCase):
+    """
+    Unit tests for the fail_stuck_sending_signals management command.
+    """
+
+    @mock.patch('signals.apps.sigmax.management.commands.fail_stuck_sending_signals.fail_stuck_sending_signals',
+                autospec=True)
+    def test_call_command(self, mocked_fail_stuck_sending_signals: Any) -> None:
+        """
+        Test the call_command function for the fail_stuck_sending_signals command.
+
+        This test case ensures that the fail_stuck_sending_signals function is called
+        when the fail_stuck_sending_signals command is executed using call_command.
+
+        Mocked fail_stuck_sending_signals is used to assert its call.
+
+        """
+        buffer = StringIO()
+        call_command('fail_stuck_sending_signals', stdout=buffer)
+        output = buffer.getvalue()
+
+        mocked_fail_stuck_sending_signals.assert_called_once()
+
+        self.assertIn(f'Add status "{VERZENDEN_MISLUKT}" to Signals that are stuck in "{TE_VERZENDEN}" '
+                      f'for at least {SIGMAX_SEND_FAIL_TIMEOUT_MINUTES} minutes', output)
+        self.assertIn('Done!', output)

--- a/app/signals/apps/sigmax/tests/test_signal_receivers.py
+++ b/app/signals/apps/sigmax/tests/test_signal_receivers.py
@@ -1,17 +1,55 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2023 Gemeente Amsterdam
+from typing import Any
 from unittest import mock
 
 from django.test import TestCase
 
 from signals.apps.signals.factories import SignalFactory, StatusFactory
 from signals.apps.signals.managers import update_status
+from signals.apps.signals.models import Status
+from signals.apps.signals.workflow import TE_VERZENDEN
 
 
 class TestSignalReceivers(TestCase):
+    """
+    Unit tests for signal receivers.
+    """
 
     @mock.patch('signals.apps.sigmax.signal_receivers.tasks', autospec=True)
-    def test_status_update_handler(self, mocked_tasks):
+    def test_status_update_handler(self, mocked_tasks: Any) -> None:
+        """
+        Test the status update handler when the signal is applicable.
+
+        This test case ensures that when the status of a signal is updated to a
+        TE_VERZENDEN state with TARGET_API_SIGMAX target API, the push_to_sigmax
+        task is scheduled for execution.
+
+        Mocked tasks are used to assert the call to push_to_sigmax.delay.
+
+        """
+        signal = SignalFactory.create()
+        prev_status = signal.status
+
+        new_status = StatusFactory.create(_signal=signal, state=TE_VERZENDEN, target_api=Status.TARGET_API_SIGMAX)
+        signal.status = new_status
+        signal.save()
+
+        update_status.send_robust(sender=self.__class__, signal_obj=signal, status=new_status, prev_status=prev_status)
+        mocked_tasks.push_to_sigmax.delay.assert_called_once_with(signal_id=signal.id)
+
+    @mock.patch('signals.apps.sigmax.signal_receivers.tasks', autospec=True)
+    def test_status_update_handler_not_called(self, mocked_tasks: Any) -> None:
+        """
+        Test the status update handler when the signal is not applicable.
+
+        This test case ensures that when the status of a signal is updated to a
+        non-TE_VERZENDEN state or a non-TARGET_API_SIGMAX target API, the push_to_sigmax
+        task is not scheduled for execution.
+
+        Mocked tasks are used to assert that push_to_sigmax.delay is not called.
+
+        """
         signal = SignalFactory.create()
         prev_status = signal.status
 
@@ -19,11 +57,12 @@ class TestSignalReceivers(TestCase):
         signal.status = new_status
         signal.save()
 
-        update_status.send_robust(
-            sender=self.__class__,
-            signal_obj=signal,
-            status=new_status,
-            prev_status=prev_status,
-        )
+        update_status.send_robust(sender=self.__class__, signal_obj=signal, status=new_status, prev_status=prev_status)
+        mocked_tasks.push_to_sigmax.delay.assert_not_called()
 
-        mocked_tasks.push_to_sigmax.delay.assert_called_once_with(pk=signal.id)
+        new_status = StatusFactory.create(_signal=signal, state=TE_VERZENDEN, target_api=Status.TARGET_API_GISIB)
+        signal.status = new_status
+        signal.save()
+
+        update_status.send_robust(sender=self.__class__, signal_obj=signal, status=new_status, prev_status=prev_status)
+        mocked_tasks.push_to_sigmax.delay.assert_not_called()


### PR DESCRIPTION
## Description

The `update_status_handler` signal receiver that is defined in the sigmax app was scheduling the `push_to_sigmax` task on every status update. This caused too many task being scheduled and not executed because the Signal is not applicable for sending it to Sigmax. In this PR we refactored the signal receiver to check if the signal is applicable before scheduling the `push_to_sigmax` task.

Additionally we added typing and docstrings in the files that where touched in this PR.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
