### PR TITLE
Refactor PublicSignalViewSet to support signal creation and retrieval

### DIFF
--- a/app/signals/apps/api/tests/test_public_signal_endpoint.py
+++ b/app/signals/apps/api/tests/test_public_signal_endpoint.py
@@ -444,7 +444,7 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
 
     def test_get_list(self):
         response = self.client.get(f'{self.list_endpoint}')
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 405)
 
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation


### PR DESCRIPTION
## Description

Refactor PublicSignalViewSet to support signal creation and retrieval

- Modified PublicSignalViewSet to inherit from CreateModelMixin and RetrieveModelMixin
- Removed unnecessary code
- Updated method docstrings to provide clear explanations
- Added type hints for parameters and return values
- Updated one unit test

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
