### PR TITLE
Refactored the PublicAreasViewSet and PrivateAreasViewSet

### DIFF
--- a/app/signals/apps/api/tests/test_private_area_endpoint.py
+++ b/app/signals/apps/api/tests/test_private_area_endpoint.py
@@ -80,14 +80,14 @@ class TestPrivateAreaEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         response = self.client.get(f'{self.list_endpoint}{self.areas[self.area_types[0].code][0].id}')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_post_method_not_allowed(self):
+    def test_post_404(self):
         response = self.client.post(f'{self.list_endpoint}1', data={}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_patch_method_not_allowed(self):
+    def test_patch_404(self):
         response = self.client.patch(f'{self.list_endpoint}1', data={}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_delete_method_not_allowed(self):
+    def test_delete_404(self):
         response = self.client.delete(f'{self.list_endpoint}1')
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/app/signals/apps/api/tests/test_public_area_endpoint.py
+++ b/app/signals/apps/api/tests/test_public_area_endpoint.py
@@ -79,14 +79,14 @@ class TestPublicAreaEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         response = self.client.get(f'{self.list_endpoint}{self.areas[self.area_types[0].code][0].id}')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_post_method_not_allowed(self):
+    def test_post_404(self):
         response = self.client.post(f'{self.list_endpoint}1', data={}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_patch_method_not_allowed(self):
+    def test_patch_404(self):
         response = self.client.patch(f'{self.list_endpoint}1', data={}, format='json')
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_delete_method_not_allowed(self):
+    def test_delete_404(self):
         response = self.client.delete(f'{self.list_endpoint}1')
-        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## Description

Refactored the `PublicAreasViewSet` and `PrivateAreasViewSet` to use the standard DRF `ListModelMixin` and `GenericViewset` instead of the `DatapuntViewSet`.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
