### PR TITLE
Refactored the PrivateDepartmentViewSet

### DIFF
--- a/app/signals/apps/api/views/departments.py
+++ b/app/signals/apps/api/views/departments.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
-from datapunt_api.rest import DatapuntViewSet, HALPagination
-from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import mixins, status
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
+from rest_framework.mixins import CreateModelMixin, UpdateModelMixin
 from rest_framework.response import Response
+from rest_framework.status import HTTP_201_CREATED
+from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework_extensions.mixins import DetailSerializerMixin
 
 from signals.apps.api.filters import DepartmentFilterSet
 from signals.apps.api.generics.permissions import ModelWritePermissions, SIAPermissions
@@ -15,23 +16,16 @@ from signals.apps.signals.models import Department
 from signals.auth.backend import JWTAuthBackend
 
 
-class PrivateDepartmentViewSet(mixins.CreateModelMixin,
-                               mixins.UpdateModelMixin,
-                               DatapuntViewSet):
+class PrivateDepartmentViewSet(CreateModelMixin, DetailSerializerMixin, UpdateModelMixin, ReadOnlyModelViewSet):
     queryset = Department.objects.all()
+    filterset_class = DepartmentFilterSet
+    ordering = ('-code',)
 
     serializer_class = PrivateDepartmentSerializerList
     serializer_detail_class = PrivateDepartmentSerializerDetail
 
-    pagination_class = HALPagination
-
     authentication_classes = (JWTAuthBackend,)
     permission_classes = (SIAPermissions & ModelWritePermissions, )
-
-    filter_backends = (DjangoFilterBackend, )
-    filterset_class = DepartmentFilterSet
-
-    ordering = ('-code', )
 
     def create(self, request, *args, **kwargs):
         # If we create a department we want to use the detail serializer
@@ -40,4 +34,4 @@ class PrivateDepartmentViewSet(mixins.CreateModelMixin,
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         headers = self.get_success_headers(serializer.data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+        return Response(serializer.data, status=HTTP_201_CREATED, headers=headers)


### PR DESCRIPTION
## Description

Refactored the PrivateDepartmentViewSet to use the standard DRF mixins and ReadOnlyModelViewSet instead of the DatapuntViewSet.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
