### PR TITLE
Bumped django-storages from 1.12.3 to 1.13.2

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -39,7 +39,7 @@ django-markdownx==3.0.1
 django-o365mail==1.1.0
 django-rest-swagger==2.2.0
 django-silk==5.0.3
-django-storages==1.12.3
+django-storages==1.13.2
 django-timezone-field==5.0
 djangorestframework==3.13.1
 djangorestframework-csv==2.1.1


### PR DESCRIPTION
## Description

Bumped django-storages from 1.12.3 to 1.13.2

In version 1.13.2 an issue with uploading files and the use of `AZURE_CUSTOM_DOMAIN` has been fixed, more info about this bug can be found on https://github.com/jschneier/django-storages/issues/1116

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
