### PR TITLE
Fixing dependabot alerts

### DIFF
--- a/app/requirements/requirements.txt
+++ b/app/requirements/requirements.txt
@@ -285,7 +285,7 @@ pyjwt[crypto]==2.7.0
     # via msal
 pyopenssl==23.1.1
     # via josepy
-pypdf==3.8.1
+pypdf==3.9.0
     # via -r app/requirements/requirements.in
 pyphen==0.14.0
     # via weasyprint

--- a/app/requirements/requirements_dev.txt
+++ b/app/requirements/requirements_dev.txt
@@ -436,10 +436,6 @@ psycopg2-binary==2.9.6
     # via
     #   -r app/requirements/requirements_test.txt
     #   opencensus-ext-postgresql
-py==1.11.0
-    # via
-    #   -r app/requirements/requirements_test.txt
-    #   pytest-forked
 pyasn1==0.5.0
     # via
     #   -r app/requirements/requirements_test.txt
@@ -470,7 +466,7 @@ pyopenssl==23.1.1
     # via
     #   -r app/requirements/requirements_test.txt
     #   josepy
-pypdf==3.8.1
+pypdf==3.9.0
     # via -r app/requirements/requirements_test.txt
 pyphen==0.14.0
     # via
@@ -489,7 +485,6 @@ pytest==7.3.1
     #   -r app/requirements/requirements_test.txt
     #   pytest-cov
     #   pytest-django
-    #   pytest-forked
     #   pytest-subtests
     #   pytest-timeout
     #   pytest-xdist
@@ -497,13 +492,11 @@ pytest-cov==4.0.0
     # via -r app/requirements/requirements_test.txt
 pytest-django==4.5.2
     # via -r app/requirements/requirements_test.txt
-pytest-forked==1.6.0
-    # via -r app/requirements/requirements_test.txt
 pytest-subtests==0.11.0
     # via -r app/requirements/requirements_test.txt
 pytest-timeout==2.1.0
     # via -r app/requirements/requirements_test.txt
-pytest-xdist==3.3.0
+pytest-xdist==3.3.1
     # via -r app/requirements/requirements_test.txt
 python-crontab==2.7.1
     # via

--- a/app/requirements/requirements_test.in
+++ b/app/requirements/requirements_test.in
@@ -7,7 +7,6 @@ isort
 pytest
 pytest-cov
 pytest-django
-pytest-forked
 pytest-subtests
 pytest-timeout
 pytest-xdist

--- a/app/requirements/requirements_test.txt
+++ b/app/requirements/requirements_test.txt
@@ -413,8 +413,6 @@ psycopg2-binary==2.9.6
     # via
     #   -r app/requirements/requirements.txt
     #   opencensus-ext-postgresql
-py==1.11.0
-    # via pytest-forked
 pyasn1==0.5.0
     # via
     #   -r app/requirements/requirements.txt
@@ -443,7 +441,7 @@ pyopenssl==23.1.1
     # via
     #   -r app/requirements/requirements.txt
     #   josepy
-pypdf==3.8.1
+pypdf==3.9.0
     # via -r app/requirements/requirements.txt
 pyphen==0.14.0
     # via
@@ -460,7 +458,6 @@ pytest==7.3.1
     #   -r app/requirements/requirements_test.in
     #   pytest-cov
     #   pytest-django
-    #   pytest-forked
     #   pytest-subtests
     #   pytest-timeout
     #   pytest-xdist
@@ -468,13 +465,11 @@ pytest-cov==4.0.0
     # via -r app/requirements/requirements_test.in
 pytest-django==4.5.2
     # via -r app/requirements/requirements_test.in
-pytest-forked==1.6.0
-    # via -r app/requirements/requirements_test.in
 pytest-subtests==0.11.0
     # via -r app/requirements/requirements_test.in
 pytest-timeout==2.1.0
     # via -r app/requirements/requirements_test.in
-pytest-xdist==3.3.0
+pytest-xdist==3.3.1
     # via -r app/requirements/requirements_test.in
 python-crontab==2.7.1
     # via


### PR DESCRIPTION
## Description

Removed `pytest-forked` (it is not used) to fix the dependabot alerts about the `py` package (https://github.com/Amsterdam/signals/security/dependabot/39 and https://github.com/Amsterdam/signals/security/dependabot/40). The `py` package is not maintained and the last release is from november 2021.

This commit also updated a couple of other requirements:
- pypdf==3.9.0
- pytest-xdist==3.3.1

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
