### PR TITLE
Removed unit tests that are skipped or marked with expectedFailure

### DIFF
--- a/app/signals/apps/api/tests/test_private_category_endpoint.py
+++ b/app/signals/apps/api/tests/test_private_category_endpoint.py
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
-from unittest import skip
-
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from django.contrib.auth.models import Permission
 from rest_framework import status
 
-from signals.apps.signals.factories import CategoryFactory, DepartmentFactory, ParentCategoryFactory
+from signals.apps.signals.factories import CategoryFactory, ParentCategoryFactory
 from signals.apps.signals.models import CategoryDepartment
 from signals.test.utils import SIAReadWriteUserMixin, SignalsBaseApiTestCase
 
@@ -128,24 +126,6 @@ class TestPrivateCategoryEndpoint(SIAReadWriteUserMixin, SignalsBaseApiTestCase)
         self.client.force_authenticate(user=self.sia_read_write_user)
 
         category = self.parent_category.children.first()
-
-        url = f'/signals/v1/private/categories/{category.pk}'
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        self._assert_category_data(category=category, data=response.json())
-
-    @skip('TODO Fix failing test')
-    def test_get_second_child_category(self):
-        self.client.force_authenticate(user=self.sia_read_write_user)
-
-        category = self.parent_category.children.first()
-
-        department = DepartmentFactory.create(is_intern=False)
-        category.departments.add(department, through_defaults={'is_responsible': False, 'can_view': True})
-
-        department = DepartmentFactory.create(is_intern=True)
-        category.departments.add(department, through_defaults={'is_responsible': True, 'can_view': True})
 
         url = f'/signals/v1/private/categories/{category.pk}'
         response = self.client.get(url)

--- a/app/signals/apps/api/tests/test_private_signal_endpoint.py
+++ b/app/signals/apps/api/tests/test_private_signal_endpoint.py
@@ -4,7 +4,6 @@ import copy
 import json
 import os
 from datetime import timedelta
-from unittest import skip
 from unittest.mock import patch
 
 import dateutil
@@ -18,10 +17,7 @@ from django.utils.http import urlencode
 from freezegun import freeze_time
 from rest_framework import status
 
-from signals.apps.api.validation.address.base import (
-    AddressValidationUnavailableException,
-    NoResultsException
-)
+from signals.apps.api.validation.address.base import AddressValidationUnavailableException
 from signals.apps.history.models import Log
 from signals.apps.reporting.csv.utils import map_choices
 from signals.apps.signals import workflow
@@ -349,15 +345,6 @@ class TestPrivateSignalViewSet(SIAReadUserMixin, SIAReadWriteUserMixin, SignalsB
         self.assertEqual(response_json['location']['area_type_code'], 'district')
         self.assertEqual(response_json['location']['area_code'], 'centrum')
         self.assertEqual(response_json['location']['area_name'], 'Centrum')
-
-    @skip('Disabled for now, it no longer throws an error but logs a warning and stores the unvalidated address')
-    @patch("signals.apps.api.validation.address.base.BaseAddressValidation.validate_address",
-           side_effect=NoResultsException)
-    def test_create_initial_invalid_location(self, validate_address):
-        """ Tests that a 400 is returned when an invalid location is provided """
-        response = self.client.post(self.list_endpoint, self.create_initial_data, format='json')
-
-        self.assertEqual(response.status_code, 400)
 
     @patch("signals.apps.api.validation.address.base.BaseAddressValidation.validate_address")
     def test_create_initial_valid_location(self, validate_address):

--- a/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
+++ b/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
@@ -1,13 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import copy
 import os
-from unittest import expectedFailure, skip
 from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth.models import Permission
-from django.db.utils import IntegrityError
 from django.test import override_settings
 from django.utils import timezone
 from rest_framework import status
@@ -459,56 +457,6 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
             self.assertEqual(Signal.objects.filter(parent_id__isnull=True).count(), parent_signal_count)
             self.assertEqual(Signal.objects.filter(parent_id__isnull=False).count(), len(initial_data))
 
-    @expectedFailure
-    @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
-           side_effect=AddressValidationUnavailableException)
-    def test_signal_ids_cannot_be_skipped(self, validate_address):
-        SourceFactory.create(name='online', description='online', is_public=True)
-
-        with self.settings(FEATURE_FLAGS=self.prod_feature_flags_settings):
-            parent_signal = SignalFactory.create()
-
-            signal_count = Signal.objects.count()
-            parent_signal_count = Signal.objects.filter(parent_id__isnull=True).count()
-            child_signal_count = Signal.objects.filter(parent_id__isnull=False).count()
-
-            self.assertEqual(signal_count, 1)
-            self.assertEqual(parent_signal_count, 1)
-            self.assertEqual(child_signal_count, 0)
-
-            # bad data
-            initial_data = []
-            for _ in range(2):
-                data = copy.deepcopy(self.initial_data_base)
-                data['parent'] = parent_signal.pk
-                data['source'] = 'online'
-                data['category'] = {'subcategory': data['category']['category_url']}
-                initial_data.append(data)
-
-            with self.assertRaises(IntegrityError):
-                response = self.client.post(self.list_endpoint, initial_data, format='json')
-
-            # good data
-            initial_data = []
-            for _ in range(2):
-                data = copy.deepcopy(self.initial_data_base)
-                data['parent'] = parent_signal.pk
-                data['source'] = 'online'
-                initial_data.append(data)
-
-            response = self.client.post(self.list_endpoint, initial_data, format='json')
-            response_json = response.json()
-
-            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-            self.assertEqual(Signal.objects.count(), signal_count + len(initial_data))
-            self.assertEqual(Signal.objects.filter(parent_id__isnull=True).count(), parent_signal_count)
-            self.assertEqual(Signal.objects.filter(parent_id__isnull=False).count(), len(initial_data))
-
-            # check that we did not skip signal ids
-            ids = [entry['id'] for entry in response_json]
-            self.assertEqual(ids[0] - parent_signal.id, 1)
-            self.assertEqual(ids[1] - parent_signal.id, 2)
-
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation
     def test_create_initial_signal_public_source(self, validate_address):
@@ -589,82 +537,3 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
         self.assertEqual(response.json()['session'][0], 'Session already used')
         self.assertEqual(signal_count, Signal.objects.count())
-
-    @skip('Disbaled the check on the extra propeties, this causes an issue when creating "child" signals')
-    @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
-           side_effect=AddressValidationUnavailableException)  # Skip address validation
-    def test_create_and_validate_extra_properties_for_streetlights(self, validate_address):
-        """
-        Disabled the additional check. This check prevents the creation of a "child" signal in the
-        lantaarnpaal-straatverlichting category because there is no way to provide the streetlight
-
-        SIG-4382 [BE] Extra check op formaat en inhoud van extra_properties bij de verlichting sub categorien
-        (tbv koppeling Techview)
-
-        To make sure we accept the valid data in the extra properties when a Signal is created for the category
-        containing streetlights we are adding an additional check.
-        """
-        parent_category = ParentCategoryFactory.create(slug='wegen-verkeer-straatmeubilair')
-        link_main_category = f'/signals/v1/public/terms/categories/{parent_category.slug}'
-
-        child_category = CategoryFactory.create(slug='lantaarnpaal-straatverlichting', parent=parent_category)
-        link_sub_category = f'{link_main_category}/sub_categories/{child_category.slug}'
-
-        extra_properties_none = None
-        extra_properties_empty_list = []
-        extra_properties_not_on_map_simple = [
-            {
-                'id': 'extra_straatverlichting_nummer',
-                'label': 'Lichtpunt(en) op kaart',
-                'category_url': link_sub_category,
-                'answer': {'type': 'not-on-map'},
-            },
-        ]
-        extra_properties_not_on_map_complex = [
-            {
-                'id': 'extra_straatverlichting_nummer',
-                'label': 'Lichtpunt(en) op kaart',
-                'category_url': link_sub_category,
-                'answer': {
-                    'id': '345345433',
-                    'type': 'not-on-map',
-                    'label': 'De container staat niet op de kaart - 345345433',
-                },
-            },
-        ]
-        extra_properties = [
-            {
-                'id': 'extra_straatverlichting_nummer',
-                'label': 'Lichtpunt(en) op kaart',
-                'category_url': link_sub_category,
-                'answer': {
-                    'id': '115617',
-                    'type': '4',
-                    'description': 'Overig lichtpunt',
-                    'isReported': False,
-                    'label': 'Overig lichtpunt - 115617',
-                },
-            },
-        ]
-
-        create_initial_data = copy.deepcopy(self.initial_data_base)
-        create_initial_data.update({'category': {'category_url': link_sub_category}}),
-
-        for invalid_extra_properties in [extra_properties_none, extra_properties_empty_list]:
-            create_initial_data.update({'extra_properties': invalid_extra_properties})
-            response = self.client.post(self.list_endpoint, create_initial_data, format='json')
-
-            self.assertEqual(400, response.status_code)
-            self.assertEqual(response.json()['extra_properties'][0],
-                             'Extra properties not valid for category "lantaarnpaal-straatverlichting"')
-            self.assertEqual(0, Signal.objects.count())
-
-        signal_count = Signal.objects.count()
-        for valid_extra_properties in [extra_properties_not_on_map_simple, extra_properties_not_on_map_complex,
-                                       extra_properties]:
-            create_initial_data.update({'extra_properties': valid_extra_properties})
-            response = self.client.post(self.list_endpoint, create_initial_data, format='json')
-            self.assertEqual(201, response.status_code)
-
-            signal_count += 1
-            self.assertEqual(signal_count, Signal.objects.count())

--- a/app/signals/apps/api/tests/test_signal_context_view.py
+++ b/app/signals/apps/api/tests/test_signal_context_view.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
 from datetime import timedelta
-from unittest import skip
 
 from django.contrib.gis.geos import Point
 from django.db.models import Q
@@ -131,25 +130,6 @@ class TestSignalContextView(SuperUserMixin, APITestCase):
         response_data = response.json()
         self.assertEqual(response_data['count'], 5)
         self.assertEqual(len(response_data['results']), 5)
-
-    @skip('TODO Fix failing test')
-    def test_get_signal_context_geography_detail(self):
-        self.client.force_authenticate(user=self.superuser)
-
-        signal_id = self.reporter_1_signals[2].pk
-        response = self.client.get(f'/signals/v1/private/signals/{signal_id}/context/near/geography')
-        self.assertEqual(response.status_code, 200)
-
-        response_json = response.json()
-        self.assertEqual(len(response_json['features']), 2)
-
-        signal_id = self.reporter_1_signals[3].pk
-        response = self.client.get(f'/signals/v1/private/signals/{signal_id}/context/near/geography')
-        self.assertEqual(response.status_code, 200)
-
-        # TODO: Fix this test case
-        # response_json = response.json()
-        # self.assertEqual(len(response_json['features']), 0)
 
     def test_get_anonymous_signals_context(self):
         self.client.force_authenticate(user=self.superuser)

--- a/app/signals/apps/api/tests/test_stored_signal_filters_endpoint.py
+++ b/app/signals/apps/api/tests/test_stored_signal_filters_endpoint.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
-import unittest
-
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from signals.apps.signals.factories import StoredSignalFilterFactory
 from signals.apps.signals.models import StoredSignalFilter
 from signals.test.utils import SIAReadUserMixin, SignalsBaseApiTestCase
@@ -160,36 +158,6 @@ class TestStoredSignalFilters(SIAReadUserMixin, SignalsBaseApiTestCase):
         self.assertIn('i', response_data['options']['status'])
         self.assertTrue(response_data['refresh'])
         self.assertFalse(response_data['show_on_overview'])
-
-    @unittest.expectedFailure
-    def test_nonsense_store_and_retrieve(self):
-        """
-        Earlier versions of SIA accepted filters for storing that did not exist
-        in the SignalFilter. This test demonstrates that undesirable behavior
-        and is left here as documentation --- it should fail.
-        """
-        filter_name = 'Dit mag niet opgeslagen worden.'
-        data = {
-            'name': filter_name,
-            'options': {
-                'nonsense': ['none', 'email']
-            }
-        }
-
-        # Store our filter for later use
-        response = self.client.post(self.endpoint, data, format='json')
-        self.assertEqual(201, response.status_code)
-        response_data = response.json()
-        pk = response_data['id']
-
-        # Retrieve our filter and use it to filter signals
-        response = self.client.get(self.endpoint.format(pk=pk))
-        self.assertEqual(response.status_code, 200)
-        response_data = response.json()
-
-        self.assertEqual(response_data['name'], filter_name)
-        self.assertIn('nonsense', response_data['options'])
-        self.assertEqual(set(response_data['options']['nonsense']), set(['none', 'email']))
 
     def test_do_not_store_unknown_filters(self):
         filter_name = 'Dit mag niet opgeslagen worden.'

--- a/app/signals/apps/email_integrations/tests/test_utils.py
+++ b/app/signals/apps/email_integrations/tests/test_utils.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import re
-from unittest import expectedFailure
 from urllib.parse import quote
 
 from django.conf import settings
@@ -191,24 +190,6 @@ class TestUtils(TestCase):
                                                              title='{{ text|lower:"a" }}',  # TemplateSyntaxError
                                                              body='{{ created_at|date:"PO" }}')  # NotImplementedError
         result = validate_email_template(email_template_invalid)
-        self.assertFalse(result)
-
-    @expectedFailure
-    def test_validate_email_template_date_filter_tag(self):
-        # Django 3.2 has different behavior from Django 2.2, it no longer raises
-        # an exception on unsupported options to the date filter tag.
-        # This test is kept around (marked a expected failure) in case that this
-        # new behavior is regression in Django 3.2 and to document it.
-        self.assertFalse(validate_template('{{ created_at|date:"B" }}'))
-
-        email_template_invalid_title = EmailTemplateFactory.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_HEROPEND,
-                                                                   title='{{ created_at|date:"B" }}')  # noqa NotImplementedError
-        result = validate_email_template(email_template_invalid_title)
-        self.assertFalse(result)
-
-        email_template_invalid_body = EmailTemplateFactory.create(key=EmailTemplate.SIGNAL_STATUS_CHANGED_OPTIONAL,
-                                                                  body='{{ created_at|date:"B" }}')  # noqa NotImplementedError
-        result = validate_email_template(email_template_invalid_body)
         self.assertFalse(result)
 
     def test_validate_template(self):

--- a/app/signals/apps/users/tests/rest_framework/test_users.py
+++ b/app/signals/apps/users/tests/rest_framework/test_users.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
-import unittest
-
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from django.contrib.auth.models import Group, Permission
 
 from signals.apps.signals.factories import DepartmentFactory
@@ -218,14 +216,13 @@ class TestUsersViews(SIAReadWriteUserMixin, SignalsBaseApiTestCase):
         response_data = response.json()
         self.assertEqual(response_data['profile']['note'], 'note #2')
 
-    @unittest.expectedFailure  # SIG-2210 PUT is no longer allowed so this test should fail
     def test_put_user(self):
         self.client.force_authenticate(user=self.sia_read_write_user)
 
         response = self.client.put('/signals/v1/private/users/{}'.format(
             self.sia_read_write_user.pk
         ), data={}, format='json')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 405)
 
     def test_delete_users_forbidden(self):
         self.client.force_authenticate(user=self.sia_read_write_user)

--- a/app/signals/apps/users/tests/test_backend.py
+++ b/app/signals/apps/users/tests/test_backend.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
-from unittest import mock, skip
+# Copyright (C) 2018 - 2023 Gemeente Amsterdam
+from unittest import mock
 
 from django.conf import settings
 from django.test import TestCase
@@ -18,16 +18,6 @@ class TestJWTAuthBackend(TestCase):
             username='normie@example.com',
             email='normie@example.com',
         )
-
-    @skip("Scope test are not required")
-    def test_missing_scope(self):
-        jwt_auth_backend = backend.JWTAuthBackend()
-
-        mocked_request = mock.Mock()
-        mocked_request.is_authorized_for.return_value = False
-
-        with self.assertRaises(exceptions.AuthenticationFailed):
-            jwt_auth_backend.authenticate(mocked_request)
 
     @mock.patch('signals.auth.tokens.JWTAccessToken.token_data')
     @mock.patch('signals.auth.backend.cache')
@@ -91,23 +81,6 @@ class TestJWTAuthBackend(TestCase):
             user, scope = jwt_auth_backend.authenticate(mocked_request)
             self.assertEqual(user, self.normal_user)
             # self.assertEqual(scope, 'SIG/ALL')
-
-    @skip('TODO fix test')
-    @mock.patch('signals.auth.backend.cache')
-    def test_get_token_subject_is_none(self, mocked_cache):
-        # In case the subject is not set on the JWT token (as the `sub claim`).
-        # This test demonstrates the problem. See SIG-889 for next steps.
-
-        jwt_auth_backend = backend.JWTAuthBackend()
-
-        mocked_request = mock.Mock()
-        mocked_request.is_authorized_for.return_value = True
-        mocked_request.get_token_subject = None
-
-        mocked_cache.get.return_value = None  # Force database lookup
-
-        with self.assertRaises(AttributeError):
-            jwt_auth_backend.authenticate(mocked_request)
 
     # --- Note ---
     # For local development the "always_ok" user with email=settings.TEST_LOGIN


### PR DESCRIPTION
## Description

Removed unit tests that are skipped or marked with expectedFailure

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
