### PR TITLE
Make Elasticsearch CA configurable

### DIFF
--- a/app/signals/apps/search/apps.py
+++ b/app/signals/apps/search/apps.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2021 Gemeente Amsterdam
+from ssl import create_default_context
+
 from django.apps import AppConfig
 
 
@@ -13,5 +15,9 @@ class SearchConfig(AppConfig):
 
         from .settings import app_settings
 
+        ssl_context = None
+        if app_settings.CONNECTION['CA_BUNDLE']:
+            ssl_context = create_default_context(cafile=app_settings.CONNECTION['CA_BUNDLE'])
+
         host = app_settings.CONNECTION['HOST'] or 'localhost'
-        connections.create_connection(hosts=[host, ])
+        connections.create_connection(hosts=[host, ], ssl_context=ssl_context)

--- a/app/signals/apps/search/settings.py
+++ b/app/signals/apps/search/settings.py
@@ -8,6 +8,7 @@ DEFAULTS = dict(
     CONNECTION=dict(
         HOST='http://127.0.0.1:9200',
         INDEX='signals',
+        CA_BUNDLE=None,
     ),
 )
 
@@ -27,7 +28,7 @@ class APISettings(object):
 
     def __getattr__(self, attr):
         if attr not in self.defaults:
-            raise AttributeError('Invalid SEARCH setting: {}'.format(attr))
+            raise AttributeError('Cannot retrieve non-existing SEARCH setting: {}'.format(attr))
 
         try:
             val = self.user_settings[attr]

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -385,6 +385,7 @@ SEARCH = {
     'CONNECTION': {
         'HOST': os.getenv('ELASTICSEARCH_HOST', 'elastic-index.service.consul:9200'),
         'INDEX': os.getenv('ELASTICSEARCH_INDEX', 'signals'),
+        'CA_BUNDLE': os.getenv('ELASTICSEARCH_CA_BUNDLE', None)
     },
 }
 


### PR DESCRIPTION
This change makes the Elasticsearch CA configurable and adds the possibility to configure [Xpack security](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html). This improves the security of Signalen as it allows encryption between the backend and Elasticsearch and authentication on the Elasticsearch server.

To try this locally, use:

```bash
mkdir certs
docker run --name elastic-helm-charts-certs -i -w /app docker.elastic.co/elasticsearch/elasticsearch:7.17.3 /bin/sh -c "elasticsearch-certutil ca --out /app/elastic-stack-ca.p12 --pass '' && elasticsearch-certutil cert --name elasticsearch --dns elasticsearch --ca /app/elastic-stack-ca.p12 --pass '' --ca-pass '' --out /app/elastic-certificates.p12"
docker cp elastic-helm-charts-certs:/app/elastic-certificates.p12 ./certs
docker rm -f elastic-helm-charts-certs
openssl pkcs12 -nodes -passin pass:'' -in certs/elastic-certificates.p12 -out certs/elastic-certificate.pem
openssl x509 -outform der -in certs/elastic-certificate.pem -out certs/elastic-certificate.crt
```

Adjust the docker-compose.yml file:

```yaml
services:
  api:
    build:
      context: .
    ports:
      - "8000:8000"
    depends_on:
      dex:
        condition: service_started
      mailhog:
        condition: service_started
      database:
        condition: service_healthy
      elasticsearch:
        condition: service_started
      celery:
        condition: service_started
      celery_beat:
        condition: service_started
    env_file:
      - docker-compose/environments/.api
    volumes:
      - ./app:/app
      - ./dwh_media:/dwh_media
      - ./docker-compose/scripts/initialize.sh:/initialize.sh
      - ./certs:/certs
    command:
      - /initialize.sh

...

  elasticsearch:
    image: elasticsearch:7.17.9
    shm_size: '512m'
    command: elasticsearch
    environment:
      - http.host=0.0.0.0
      - transport.host=127.0.0.1
      - xpack.security.enabled=true
      - xpack.security.transport.ssl.enabled=true
      - xpack.security.transport.ssl.verification_mode=certificate
      - xpack.security.transport.ssl.keystore.path=/usr/share/elasticsearch/config/certs/elastic-certificates.p12
      - xpack.security.transport.ssl.truststore.path=/usr/share/elasticsearch/config/certs/elastic-certificates.p12
      - xpack.security.http.ssl.enabled=true
      - xpack.security.http.ssl.truststore.path=/usr/share/elasticsearch/config/certs/elastic-certificates.p12
      - xpack.security.http.ssl.keystore.path=/usr/share/elasticsearch/config/certs/elastic-certificates.p12
    ports:
      - "9200:9200"
      - "9300:9300"
    volumes:
      - es-data:/usr/share/elasticsearch/data
      - ./certs:/usr/share/elasticsearch/config/certs
```

And adjust the docker-compose/environments/.api file:

```
ELASTICSEARCH_HOST=https://signalen:something-secret@elasticsearch:9200/
ELASTICSEARCH_CA_BUNDLE=/certs/elastic-certificate.pem
```

Start the environment:

```
docker-compose up -d
```

And create the Elasticsearch user:

```
docker-compose exec elasticsearch sh
bin/elasticsearch-users useradd signalen
<enter password>
bin/elasticsearch-users roles -a superuser signalen
```
