### PR TITLE
status messages ordering

### DIFF
--- a/app/signals/apps/api/serializers/status_message.py
+++ b/app/signals/apps/api/serializers/status_message.py
@@ -1,11 +1,79 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2023 Gemeente Amsterdam
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+from rest_framework.fields import HiddenField
 
-from signals.apps.signals.models import StatusMessage
+from signals.apps.signals.models import Category, StatusMessage, StatusMessageCategory
 
 
 class StatusMessageSerializer(serializers.ModelSerializer):
     class Meta:
         model = StatusMessage
         fields = ['id', 'title', 'text', 'active', 'state', 'categories', 'updated_at', 'created_at']
+
+
+class CurrentCategoryDefault:
+    requires_context = True
+
+    def __call__(self, serializer_field):
+        category_id = serializer_field.context['view'].kwargs.get('category_id')
+        try:
+            category = Category.objects.get(id=category_id)
+        except Category.DoesNotExist:
+            raise ValidationError(f"Category with id {category_id} does not exist.")
+        return category
+
+
+class _StatusMessageCategoryPositionListSerializer(serializers.ListSerializer):
+    def validate(self, attrs):
+        errors = {}
+
+        # Check if there are no duplicate status messages in the request
+        status_messages = [attr['status_message'] for attr in attrs]
+        if len(status_messages) != len(set(status_messages)):
+            errors.update({'status_message': 'Duplicate status messages in request.'})
+
+        # Check if there are no duplicate positions in the request
+        positions = [attr['position'] for attr in attrs]
+        if len(positions) != len(set(positions)):
+            errors.update({'position': 'Duplicate positions in request.'})
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return super().validate(attrs)
+
+
+class StatusMessageCategoryPositionSerializer(serializers.Serializer):
+    """
+    Serializer for the StatusMessageCategory model used for ordering status messages.
+    """
+    status_message = serializers.IntegerField(min_value=1)
+    category = HiddenField(default=CurrentCategoryDefault())
+    position = serializers.IntegerField(min_value=0)
+
+    class Meta:
+        fields = ['status_message', 'category', 'position']
+        list_serializer_class = _StatusMessageCategoryPositionListSerializer
+
+    def validate(self, attrs):
+        status_message_id = attrs['status_message']
+        try:
+            status_message = StatusMessage.objects.get(id=status_message_id)
+        except StatusMessage.DoesNotExist:
+            raise ValidationError({'status_message': f"Status message with id {status_message_id} does not exist."})
+        else:
+            attrs['status_message'] = status_message
+
+        return super().validate(attrs)
+
+    def create(self, validated_data):
+        status_message = validated_data['status_message']
+        category = validated_data['category']
+        position = validated_data['position']
+
+        instance, _ = StatusMessageCategory.objects.update_or_create(status_message=status_message,
+                                                                     category=category,
+                                                                     defaults={'position': position})
+        return validated_data

--- a/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -2369,6 +2369,38 @@ paths:
         '404':
           description: Not found.
 
+  /signals/v1/private/status-messages/category/{id}:
+    post:
+      parameters:
+        - name: id
+          in: path
+          description: ID of the category
+          required: true
+          schema:
+            type: integer
+            example: 1
+      description: Set the position for one or all status messages connected to the given category
+      requestBody:
+        description: Status message data
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/V1StatusMessageCategoryPosition'
+      responses:
+        '201':
+          description: Status message data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/V1StatusMessageCategoryPosition'
+        '400':
+          description: Bad request, see response body for the reason.
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Not authorized to access this endpoint.
+
 components:
   schemas:
     StatusStateChoices:
@@ -5307,6 +5339,32 @@ components:
           type: string
           format: date-time
           example: "2020-01-01T00:00:00+00:00"
+
+    V1StatusMessageCategoryPosition:
+      description: Status message category position
+      oneOf:
+        - type: array
+          items:
+            type: object
+            properties:
+              status_message:
+                description: The id of the status message
+                type: integer
+                example: 1
+              position:
+                description: The position of the status message
+                type: integer
+                example: 1
+        - type: object
+          properties:
+            status_message:
+              description: The id of the status message
+              type: integer
+              example: 1
+            position:
+              description: The position of the status message
+              type: integer
+              example: 1
 
   securitySchemes:
     OAuth2:

--- a/app/signals/apps/api/urls.py
+++ b/app/signals/apps/api/urls.py
@@ -28,7 +28,10 @@ from signals.apps.api.views import (
     StatusMessageTemplatesViewSet,
     StoredSignalFilterViewSet
 )
-from signals.apps.api.views.status_message import StatusMessagesViewSet
+from signals.apps.api.views.status_message import (
+    StatusMessagesCategoryPositionViewSet,
+    StatusMessagesViewSet
+)
 from signals.apps.feedback.rest_framework.views import FeedbackViewSet, StandardAnswerViewSet
 from signals.apps.search.rest_framework.views import SearchView
 from signals.apps.users.rest_framework.views import (
@@ -70,7 +73,8 @@ private_router.register(r'private/expressions', PrivateExpressionViewSet, basena
 private_router.register(r'private/sources', PrivateSourcesViewSet, basename='private-sources')
 private_router.register(r'private/csv', PrivateCsvViewSet, basename='private-csv')
 private_router.register(r'private/status-messages', StatusMessagesViewSet, basename='status-message')
-
+private_router.register(r'private/status-messages/category/(?P<category_id>\d+)',
+                        StatusMessagesCategoryPositionViewSet, basename='status-message-category-position')
 
 # Combined API
 base_router = SignalsRouter()

--- a/app/signals/apps/api/views/status_message.py
+++ b/app/signals/apps/api/views/status_message.py
@@ -2,12 +2,18 @@
 # Copyright (C) 2023 Gemeente Amsterdam
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import OrderingFilter
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.mixins import CreateModelMixin
+from rest_framework.response import Response
+from rest_framework.status import HTTP_201_CREATED
+from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from signals.apps.api.filters.status_messages import StatusMessagesFilterSet
 from signals.apps.api.generics.permissions import ModelWritePermissions, SIAPermissions
-from signals.apps.api.serializers.status_message import StatusMessageSerializer
-from signals.apps.signals.models import StatusMessage
+from signals.apps.api.serializers.status_message import (
+    StatusMessageCategoryPositionSerializer,
+    StatusMessageSerializer
+)
+from signals.apps.signals.models import StatusMessage, StatusMessageCategory
 from signals.auth.backend import JWTAuthBackend
 
 
@@ -34,3 +40,21 @@ class StatusMessagesViewSet(ModelViewSet):
                        'updated_at',
                        'active',
                        'state', )
+
+
+class StatusMessagesCategoryPositionViewSet(CreateModelMixin, GenericViewSet):
+    queryset = StatusMessageCategory.objects.all()
+    serializer_class = StatusMessageCategoryPositionSerializer
+
+    authentication_classes = (JWTAuthBackend,)
+    permission_classes = (SIAPermissions & ModelWritePermissions,)
+    filter_backends = ()
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data, many=isinstance(request.data, (list, )))
+
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=HTTP_201_CREATED, headers=headers)


### PR DESCRIPTION
## Description

Added a new endpoint that allows a user to set the position for all status_messags connected to a specific category

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
