### PR TITLE
Fixed category filter and ordering for the status messages endpoint

### DIFF
--- a/app/signals/apps/api/filters/status_messages.py
+++ b/app/signals/apps/api/filters/status_messages.py
@@ -7,5 +7,5 @@ from signals.apps.api.filters import category_choices, status_choices
 
 class StatusMessagesFilterSet(FilterSet):
     active = filters.BooleanFilter()
-    category_id = filters.MultipleChoiceFilter(field_name='categories', choices=category_choices)
+    category_id = filters.ChoiceFilter(field_name='categories', choices=category_choices)
     state = filters.MultipleChoiceFilter(choices=status_choices)

--- a/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -2202,7 +2202,7 @@ paths:
             $ref: '#/components/schemas/StatusStateChoices'
           required: false
         - name: category_id
-          description: Filter for specific category/categories
+          description: Filter for specific category
           in: query
           required: false
           schema:
@@ -2213,12 +2213,10 @@ paths:
           schema:
             type: string
             enum:
-              - active
-              - -active
               - created_at
               - -created_at
-              - state
-              - -state
+              - statusmessagecategory__position
+              - -statusmessagecategory__position
               - updated_at
               - -updated_at
           example: created_at

--- a/app/signals/apps/api/views/status_message.py
+++ b/app/signals/apps/api/views/status_message.py
@@ -38,8 +38,7 @@ class StatusMessagesViewSet(ModelViewSet):
     ordering = ('-created_at', )
     ordering_fields = ('created_at',
                        'updated_at',
-                       'active',
-                       'state', )
+                       ('statusmessagecategory__position', 'position'),)
 
 
 class StatusMessagesCategoryPositionViewSet(CreateModelMixin, GenericViewSet):


### PR DESCRIPTION
## Description

The category filter should be a choice instead of multiplechoice + added ordering on position in the filtered category

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
