### PR TITLE
drf-spectacular private signals endpoint(s)

### DIFF
--- a/app/signals/apps/api/apps.py
+++ b/app/signals/apps/api/apps.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from django.apps import AppConfig
 
 
 class ApiConfig(AppConfig):
     name = 'signals.apps.api'
     verbose_name = 'REST API App'
+
+    def ready(self):
+        import signals.auth.schema  # noqa: F401

--- a/app/signals/apps/api/apps.py
+++ b/app/signals/apps/api/apps.py
@@ -8,4 +8,14 @@ class ApiConfig(AppConfig):
     verbose_name = 'REST API App'
 
     def ready(self):
+        """
+        This method is called after the app registry is fully populated and all
+        app configs are ready. It's safe to perform initialization tasks such as
+        registering signals.
+
+        See: https://docs.djangoproject.com/en/3.2/ref/applications/#django.apps.AppConfig.ready
+
+        In this case it is used to import the signals.auth.schema module. Which
+        is needed to register the auth drf-spectacular schema.
+        """
         import signals.auth.schema  # noqa: F401

--- a/app/signals/apps/api/fields/attachment.py
+++ b/app/signals/apps/api/fields/attachment.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from collections import OrderedDict
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.request import Request
 
@@ -22,6 +23,21 @@ class PublicSignalAttachmentLinksField(serializers.HyperlinkedIdentityField):
         return result
 
 
+@extend_schema_field({
+    'type': 'object',
+    'properties': {
+        'self': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/1/attachments/1'
+                }
+            }
+        }
+    }
+})
 class PrivateSignalAttachmentLinksField(serializers.HyperlinkedIdentityField):
     def to_representation(self, value: Attachment) -> OrderedDict:
         request = self.context.get('request')
@@ -35,6 +51,11 @@ class PrivateSignalAttachmentLinksField(serializers.HyperlinkedIdentityField):
         return result
 
 
+@extend_schema_field({
+    'type': 'string',
+    'format': 'uri',
+    'example': 'https://api.example.com/signals/v1/private/signals/1/attachments/1'
+})
 class PrivateSignalAttachmentRelatedField(serializers.HyperlinkedRelatedField):
     def get_url(self, obj: Attachment, view_name: str, request: Request, format: str) -> str:
         return self.reverse("private-signals-attachments-detail",

--- a/app/signals/apps/api/fields/category.py
+++ b/app/signals/apps/api/fields/category.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from collections import OrderedDict
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from rest_framework_extensions.settings import extensions_api_settings
@@ -43,6 +44,11 @@ class CategoryHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
         return result
 
 
+@extend_schema_field({
+    'type': 'string',
+    'format': 'uri',
+    'example': 'https://api.example.com/signals/v1/public/terms/categories/1/sub_categories/2/'
+})
 class CategoryHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
     view_name = 'public-subcategory-detail'
     queryset = Category.objects.all().select_related('parent')

--- a/app/signals/apps/api/fields/signal.py
+++ b/app/signals/apps/api/fields/signal.py
@@ -1,12 +1,102 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 from collections import OrderedDict
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from signals.apps.signals.models import Signal
 
 
+@extend_schema_field({
+    'type': 'object',
+    'properties': {
+        'curies': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/relations/'
+                }
+            }
+        },
+        'self': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/2'
+                }
+            }
+        },
+        'archives': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/2/history/'
+                }
+            }
+        },
+        'sia:attachments': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/2/attachments/'
+                }
+            }
+        },
+        'sia:pdf': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/2/pdf/'
+                }
+            }
+        },
+        'sia:context': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/2/context/'
+                }
+            }
+        },
+        'sia:parent': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/1'
+                }
+            }
+        },
+        'sia:children': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'href': {
+                        'type': 'string',
+                        'format': 'uri',
+                        'example': 'https://api.example.com/signals/v1/private/signals/3'
+                    }
+                }
+            },
+            'minItems': 0
+        },
+    }
+})
 class PrivateSignalLinksFieldWithArchives(serializers.HyperlinkedIdentityField):
     def to_representation(self, value: Signal) -> OrderedDict:
         request = self.context.get('request')
@@ -37,6 +127,21 @@ class PrivateSignalLinksFieldWithArchives(serializers.HyperlinkedIdentityField):
         return result
 
 
+@extend_schema_field({
+    'type': 'object',
+    'properties': {
+        'self': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/1'
+                }
+            }
+        }
+    }
+})
 class PrivateSignalLinksField(serializers.HyperlinkedIdentityField):
 
     def to_representation(self, value: Signal) -> OrderedDict:
@@ -49,6 +154,51 @@ class PrivateSignalLinksField(serializers.HyperlinkedIdentityField):
         return result
 
 
+@extend_schema_field({
+    'type': 'object',
+    'properties': {
+        'curies': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/relations/'
+                }
+            }
+        },
+        'self': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/1'
+                }
+            }
+        },
+        'sia:context-reporter-detail': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/1/context/reporter/'
+                }
+            }
+        },
+        'sia:context-geography-detail': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/1/context/near/geography/'
+                }
+            }
+        },
+    }
+})
 class PrivateSignalWithContextLinksField(serializers.HyperlinkedIdentityField):
 
     def to_representation(self, value: Signal) -> OrderedDict:

--- a/app/signals/apps/api/generics/pagination.py
+++ b/app/signals/apps/api/generics/pagination.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 
 
 class HALPagination(DataPuntHALPagination):
-    def get_paginated_response_schema(self, schema):
+    def get_paginated_response_schema(self, schema: dict) -> dict:
         return {
             'type': 'object',
             'properties': {

--- a/app/signals/apps/api/generics/pagination.py
+++ b/app/signals/apps/api/generics/pagination.py
@@ -1,9 +1,62 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
+from datapunt_api.pagination import HALPagination as DataPuntHALPagination
 from django.core.paginator import InvalidPage
 from rest_framework.exceptions import NotFound
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
+
+
+class HALPagination(DataPuntHALPagination):
+    def get_paginated_response_schema(self, schema):
+        return {
+            'type': 'object',
+            'properties': {
+                '_links': {
+                    'type': 'object',
+                    'properties': {
+                        'self': {
+                            'type': 'object',
+                            'properties': {
+                                'href': {
+                                    'type': 'string',
+                                    'nullable': True,
+                                    'format': 'uri',
+                                    'example': f'http://api.example.org/endpoint/?{self.page_query_param}=3'
+                                },
+                            },
+                        },
+                        'next': {
+                            'type': 'object',
+                            'properties': {
+                                'href': {
+                                    'type': 'string',
+                                    'nullable': True,
+                                    'format': 'uri',
+                                    'example': f'http://api.example.org/endpoint/?{self.page_query_param}=4'
+                                },
+                            },
+                        },
+                        'previous': {
+                            'type': 'object',
+                            'properties': {
+                                'href': {
+                                    'type': 'string',
+                                    'nullable': True,
+                                    'format': 'uri',
+                                    'example': f'http://api.example.org/endpoint/?{self.page_query_param}=2'
+                                },
+                            },
+                        }
+                    }
+                },
+                'count': {
+                    'type': 'integer',
+                    'example': 123,
+                },
+                'results': schema,
+            },
+        }
 
 
 class LinkHeaderPagination(PageNumberPagination):

--- a/app/signals/apps/api/urls.py
+++ b/app/signals/apps/api/urls.py
@@ -151,7 +151,7 @@ if not settings.DRF_SPECTACULAR_ENABLED:
                                                           extra_context={'schema_url': 'openapi-schema'})),
     ]
 
-if settings.FEATURE_FLAGS['MY_SIGNALS_ENABLED']:
+if 'MY_SIGNALS_ENABLED' in settings.FEATURE_FLAGS and settings.FEATURE_FLAGS['MY_SIGNALS_ENABLED']:
     urlpatterns += [
         # My Signals
         path('v1/', include('signals.apps.my_signals.urls')),

--- a/app/signals/apps/api/views/attachment.py
+++ b/app/signals/apps/api/views/attachment.py
@@ -1,17 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 """
 Views dealing with 'signals.Attachment' model directly.
 """
 import os
 
-from datapunt_api.rest import DatapuntViewSet
-from rest_framework import mixins, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
+from rest_framework.mixins import CreateModelMixin, DestroyModelMixin
 from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet
-from rest_framework_extensions.mixins import NestedViewSetMixin
+from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
+from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSetMixin
 
 from signals.apps.api.serializers import (
     PrivateSignalAttachmentSerializer,
@@ -22,7 +22,7 @@ from signals.apps.signals.models import Attachment, Signal
 from signals.auth.backend import JWTAuthBackend
 
 
-class PublicSignalAttachmentsViewSet(mixins.CreateModelMixin, GenericViewSet):
+class PublicSignalAttachmentsViewSet(CreateModelMixin, GenericViewSet):
     lookup_field = 'uuid'
     lookup_url_kwarg = 'uuid'
 
@@ -39,8 +39,8 @@ class PublicSignalAttachmentsViewSet(mixins.CreateModelMixin, GenericViewSet):
         return self.get_object()
 
 
-class PrivateSignalAttachmentsViewSet(
-        NestedViewSetMixin, mixins.CreateModelMixin, mixins.DestroyModelMixin, DatapuntViewSet):
+class PrivateSignalAttachmentsViewSet(NestedViewSetMixin, DetailSerializerMixin, CreateModelMixin, DestroyModelMixin,
+                                      ReadOnlyModelViewSet):
     queryset = Attachment.objects.all()
 
     serializer_class = PrivateSignalAttachmentSerializer
@@ -99,4 +99,4 @@ class PrivateSignalAttachmentsViewSet(
         Signal.actions.create_note({
             'text': f'Bijlage {att_filename} is verwijderd.', 'created_by': user
         }, signal=signal)
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return Response(status=HTTP_204_NO_CONTENT)

--- a/app/signals/apps/api/views/category_removed.py
+++ b/app/signals/apps/api/views/category_removed.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 """
 ViewSet that returns `signals.Signal` instance dropped out of a category.
 """
-from datapunt_api.rest import HALPagination
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
 
@@ -16,7 +15,6 @@ from signals.auth.backend import JWTAuthBackend
 
 class SignalCategoryRemovedAfterViewSet(viewsets.GenericViewSet, mixins.ListModelMixin):
     serializer_class = SignalIdListSerializer
-    pagination_class = HALPagination
 
     authentication_classes = (JWTAuthBackend,)
     permission_classes = (SIAPermissions,)

--- a/app/signals/apps/api/views/signals/private/signals_promoted_to_parent.py
+++ b/app/signals/apps/api/views/signals/private/signals_promoted_to_parent.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 import logging
 
-from datapunt_api.rest import HALPagination
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins
 from rest_framework.viewsets import GenericViewSet
@@ -18,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 class SignalPromotedToParentViewSet(GenericViewSet, mixins.ListModelMixin):
     serializer_class = SignalIdListSerializer
-    pagination_class = HALPagination
 
     authentication_classes = (JWTAuthBackend,)
     permission_classes = (SIAPermissions,)

--- a/app/signals/apps/my_signals/rest_framework/views/signals.py
+++ b/app/signals/apps/my_signals/rest_framework/views/signals.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Gemeente Amsterdam
-from datapunt_api.pagination import HALPagination
+# Copyright (C) 2022 - 2023 Gemeente Amsterdam
 from datapunt_api.rest import DEFAULT_RENDERERS
 from dateutil.relativedelta import relativedelta
 from django.contrib.contenttypes.models import ContentType
@@ -37,7 +36,6 @@ from signals.apps.signals.models import (
 
 class MySignalsViewSet(DetailSerializerMixin, ReadOnlyModelViewSet):
     renderer_classes = DEFAULT_RENDERERS
-    pagination_class = HALPagination
 
     authentication_classes = (MySignalsTokenAuthentication, )
 

--- a/app/signals/apps/search/rest_framework/pagination.py
+++ b/app/signals/apps/search/rest_framework/pagination.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
-from datapunt_api.pagination import HALPagination
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from django.core.paginator import InvalidPage, Page, Paginator
 from rest_framework.exceptions import NotFound
+
+from signals.apps.api.generics.pagination import HALPagination
 
 
 class ElasticPage(Page):

--- a/app/signals/auth/schema.py
+++ b/app/signals/auth/schema.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
+from drf_spectacular.plumbing import build_bearer_security_scheme_object
+
+
+class AccessTokenAuthenticationScheme(OpenApiAuthenticationExtension):
+    target_class = 'signals.auth.backend.JWTAuthBackend'
+    name = 'JWTAuthBackend'
+
+    def get_security_definition(self, auto_schema):
+        return build_bearer_security_scheme_object(header_name='AUTHORIZATION',
+                                                   token_prefix='Bearer',
+                                                   bearer_format='JWT')

--- a/app/signals/schema.py
+++ b/app/signals/schema.py
@@ -20,18 +20,6 @@ class ErrorSerializer(serializers.Serializer):
         """
         return instance
 
-    def update(self, instance, validated_data):
-        """
-        Perform update on the instance.
-        """
-        pass
-
-    def create(self, validated_data):
-        """
-        Create a new instance.
-        """
-        pass
-
 
 class ValidationErrorSerializer(ErrorSerializer):
     """
@@ -48,39 +36,11 @@ class GenericErrorSerializer(ErrorSerializer):
     detail = serializers.CharField()
 
 
-class UnauthenticatedErrorSerializer(GenericErrorSerializer):
-    """
-    Serializer for unauthenticated error responses.
-    """
-    pass
-
-
-class ForbiddenErrorSerializer(GenericErrorSerializer):
-    """
-    Serializer for forbidden error responses.
-    """
-    pass
-
-
-class NotFoundErrorSerializer(GenericErrorSerializer):
-    """
-    Serializer for not found error responses.
-    """
-    pass
-
-
-class InternalServerErrorSerializer(GenericErrorSerializer):
-    """
-    Serializer for internal server error responses.
-    """
-    pass
-
-
 class SIGAutoSchema(AutoSchema):
     """
     Custom AutoSchema for Swagger/OpenAPI documentation.
     """
-    def _get_error_response_bodies(self):
+    def _get_error_response_bodies(self) -> dict:
         """
         Get error response bodies based on the API method and authentication status.
         """
@@ -99,17 +59,17 @@ class SIGAutoSchema(AutoSchema):
 
         self.error_response_bodies = {
             '400': self._get_response_for_code(ValidationErrorSerializer, '400'),
-            '401': self._get_response_for_code(UnauthenticatedErrorSerializer, '401'),
-            '403': self._get_response_for_code(ForbiddenErrorSerializer, '403'),
-            '404': self._get_response_for_code(NotFoundErrorSerializer, '404'),
-            '500': self._get_response_for_code(InternalServerErrorSerializer, '500'),
+            '401': self._get_response_for_code(GenericErrorSerializer, '401'),
+            '403': self._get_response_for_code(GenericErrorSerializer, '403'),
+            '404': self._get_response_for_code(GenericErrorSerializer, '404'),
+            '500': self._get_response_for_code(GenericErrorSerializer, '500'),
         }
         return {
             code: self.error_response_bodies[code]
             for code in error_codes
         }
 
-    def _get_response_bodies(self, direction='response'):
+    def _get_response_bodies(self, direction: str = 'response') -> dict:
         """
         Get response bodies for the API method.
         """

--- a/app/signals/schema.py
+++ b/app/signals/schema.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam
+from drf_spectacular.openapi import AutoSchema
+from rest_framework import serializers
+
+
+class ErrorSerializer(serializers.Serializer):
+    """
+    Base serializer for error responses.
+    """
+    def to_internal_value(self, data):
+        """
+        Convert external representation to internal value.
+        """
+        return data
+
+    def to_representation(self, instance):
+        """
+        Convert internal value to external representation.
+        """
+        return instance
+
+    def update(self, instance, validated_data):
+        """
+        Perform update on the instance.
+        """
+        pass
+
+    def create(self, validated_data):
+        """
+        Create a new instance.
+        """
+        pass
+
+
+class ValidationErrorSerializer(ErrorSerializer):
+    """
+    Serializer for validation error responses.
+    """
+    errors = serializers.DictField(child=serializers.ListSerializer(child=serializers.CharField()))
+    non_field_errors = serializers.ListSerializer(child=serializers.CharField())
+
+
+class GenericErrorSerializer(ErrorSerializer):
+    """
+    Serializer for generic error responses.
+    """
+    detail = serializers.CharField()
+
+
+class UnauthenticatedErrorSerializer(GenericErrorSerializer):
+    """
+    Serializer for unauthenticated error responses.
+    """
+    pass
+
+
+class ForbiddenErrorSerializer(GenericErrorSerializer):
+    """
+    Serializer for forbidden error responses.
+    """
+    pass
+
+
+class NotFoundErrorSerializer(GenericErrorSerializer):
+    """
+    Serializer for not found error responses.
+    """
+    pass
+
+
+class InternalServerErrorSerializer(GenericErrorSerializer):
+    """
+    Serializer for internal server error responses.
+    """
+    pass
+
+
+class SIGAutoSchema(AutoSchema):
+    """
+    Custom AutoSchema for Swagger/OpenAPI documentation.
+    """
+    def _get_error_response_bodies(self):
+        """
+        Get error response bodies based on the API method and authentication status.
+        """
+        error_codes = ['500', ]
+        if not self.method == 'GET':
+            error_codes.append('400')
+
+        auth = self.get_auth()
+        if auth and not any(item == {} for item in auth):
+            error_codes.append('401')
+            error_codes.append('403')
+
+        if not (self.method == 'GET' and self._is_list_view()):
+            if len(list(filter(lambda _: _['in'] == 'path', self._get_parameters()))):
+                error_codes.append('404')
+
+        self.error_response_bodies = {
+            '400': self._get_response_for_code(ValidationErrorSerializer, '400'),
+            '401': self._get_response_for_code(UnauthenticatedErrorSerializer, '401'),
+            '403': self._get_response_for_code(ForbiddenErrorSerializer, '403'),
+            '404': self._get_response_for_code(NotFoundErrorSerializer, '404'),
+            '500': self._get_response_for_code(InternalServerErrorSerializer, '500'),
+        }
+        return {
+            code: self.error_response_bodies[code]
+            for code in error_codes
+        }
+
+    def _get_response_bodies(self, direction='response'):
+        """
+        Get response bodies for the API method.
+        """
+        responses = super()._get_response_bodies(direction=direction)
+        if len(list(filter(lambda _: _.startswith('4'), responses.keys()))):
+            return responses
+
+        responses.update(self._get_error_response_bodies())
+        return responses

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -333,7 +333,7 @@ REST_FRAMEWORK = dict(
     PAGE_SIZE=100,
     UNAUTHENTICATED_TOKEN={},
     DEFAULT_AUTHENTICATION_CLASSES=[],
-    DEFAULT_PAGINATION_CLASS='datapunt_api.pagination.HALPagination',
+    DEFAULT_PAGINATION_CLASS='signals.apps.api.generics.pagination.HALPagination',
     DEFAULT_FILTER_BACKENDS=(
         'django_filters.rest_framework.DjangoFilterBackend',
     ),
@@ -452,7 +452,7 @@ if DRF_SPECTACULAR_ENABLED:
     ]
 
     REST_FRAMEWORK.update(dict(
-        DEFAULT_SCHEMA_CLASS='drf_spectacular.openapi.AutoSchema',
+        DEFAULT_SCHEMA_CLASS='signals.schema.SIGAutoSchema',
     ))
 
     SPECTACULAR_SETTINGS = {
@@ -466,4 +466,5 @@ if DRF_SPECTACULAR_ENABLED:
         'SERVE_INCLUDE_SCHEMA': False,
         'SWAGGER_UI_DIST': 'SIDECAR',
         'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+        'GENERIC_ADDITIONAL_PROPERTIES': True,
     }


### PR DESCRIPTION
## Description

Add/Fix the OpenAPI specs generation for the `v1/private/signals` endpoints using drf-spectacular.

Introducing the necessary decorators, extend_schema_view, extend_schema, and extend_schema_field, to generate OpenAPI specifications correctly. The get_paginated_response_schema for HALPagination has been overridden to make sure the correct documentation is generated. Additionally, the JWTAuthBackend schema has been properly implemented to generate the correct authentication information for the API.

TODO:
- [X] Fix the context near (quickfix, define the response manually in the extend_schema decorator)

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
