### PR TITLE
Do not require highlights for both title and text fields

### DIFF
--- a/app/signals/apps/search/rest_framework/serializers.py
+++ b/app/signals/apps/search/rest_framework/serializers.py
@@ -5,8 +5,8 @@ from rest_framework import serializers
 
 
 class HighlightSerializer(serializers.Serializer):
-    title = serializers.ListField(child=serializers.CharField())
-    text = serializers.ListField(child=serializers.CharField())
+    title = serializers.ListField(child=serializers.CharField(), required=False)
+    text = serializers.ListField(child=serializers.CharField(), required=False)
 
 
 class MetaSerializer(serializers.Serializer):


### PR DESCRIPTION
## Description

Currently when Elasticsearch only returns a highlight for either a title or a text we get a 500 Internal Server Error.
Obviously it should be possible to only have a highlight in just one of the fields, but I missed that case when manually testing before.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code