### PR TITLE
Add/Fix the OpenAPI specs generation for the v1/public/signals endpoints using drf-spectacular

### DIFF
--- a/app/signals/apps/api/serializers/nested/status.py
+++ b/app/signals/apps/api/serializers/nested/status.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import MaxLengthValidator
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
@@ -105,12 +106,12 @@ class _NestedPublicStatusModelSerializer(serializers.ModelSerializer):
             'state_display',
         )
 
-    def get_public_state(self, obj):
+    def get_public_state(self, obj: Status) -> str:
         if obj.state in SIGNALS_API_CLOSED_STATES:
             return SIGNALS_API_STATE_CLOSED
         return SIGNAL_API_STATE_OPEN
 
-    def get_public_state_display(self, obj):
+    def get_public_state_display(self, obj: Status) -> str:
         if obj.state in SIGNALS_API_CLOSED_STATES:
             return SIGNALS_API_STATE_CLOSED_DISPLAY
         return SIGNAL_API_STATE_OPEN_DISPLAY

--- a/app/signals/apps/api/serializers/nested/status.py
+++ b/app/signals/apps/api/serializers/nested/status.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2019 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import MaxLengthValidator
-from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied, ValidationError
 

--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import os
 
 from datapunt_api.rest import DisplayField, HALSerializer
@@ -550,7 +550,7 @@ class PublicSignalSerializerDetail(HALSerializer):
             'incident_date_end',
         )
 
-    def get__display(self, obj):
+    def get__display(self, obj: Signal) -> str:
         return obj.get_id_display()
 
 

--- a/app/signals/apps/api/views/attachment.py
+++ b/app/signals/apps/api/views/attachment.py
@@ -5,6 +5,7 @@ Views dealing with 'signals.Attachment' model directly.
 """
 import os
 
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
 from rest_framework.mixins import CreateModelMixin, DestroyModelMixin
@@ -22,6 +23,14 @@ from signals.apps.signals.models import Attachment, Signal
 from signals.auth.backend import JWTAuthBackend
 
 
+@extend_schema_view(
+    create=extend_schema(
+        operation_id='upload_file',
+        request={
+            'multipart/form-data': PublicSignalAttachmentSerializer
+        }
+    )
+)
 class PublicSignalAttachmentsViewSet(CreateModelMixin, GenericViewSet):
     lookup_field = 'uuid'
     lookup_url_kwarg = 'uuid'

--- a/app/signals/apps/api/views/signals/public/signals_map.py
+++ b/app/signals/apps/api/views/signals/public/signals_map.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 import logging
 
 from django.db import connection
+from drf_spectacular.utils import extend_schema
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.response import Response
+from rest_framework.status import HTTP_200_OK
 from rest_framework.viewsets import ViewSet
 
 from signals.apps.api.renderers import SerializedJsonRenderer
@@ -26,6 +28,91 @@ class PublicSignalMapViewSet(ViewSet):
     # The downside is that this query has to be (potentially) maintained when changing one of the
     # following models: signal, categoryassignment, category, location, status
 
+    @extend_schema(
+        responses={
+            HTTP_200_OK: {
+                'type': 'object',
+                'properties': {
+                    'type': {
+                        'type': 'string',
+                        'enum': [
+                            'FeatureCollection'
+                        ],
+                        'example': 'FeatureCollection'
+                    },
+                    'features': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'type': {
+                                    'type': 'string',
+                                    'enum': [
+                                        'Feature'
+                                    ],
+                                    'example': 'Feature'
+                                },
+                                'geometry': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'type': {
+                                            'type': 'string',
+                                            'enum': [
+                                                'Point'
+                                            ]
+                                        },
+                                        'coordinates': {
+                                            'type': 'array',
+                                            'items': {
+                                                'type': 'number'
+                                            },
+                                            'example': [
+                                                4.890659,
+                                                52.373069
+                                            ]
+                                        }
+                                    }
+                                },
+                                'properties': {
+                                    'type': 'object',
+                                    'properties': {
+                                        'id': {
+                                            'type': 'integer',
+                                            'example': 1
+                                        },
+                                        'created_at': {
+                                            'type': 'string',
+                                            'format': 'date-time',
+                                            'example': '2023-06-01T00:00:00.000000+00:00'
+                                        },
+                                        'status': {
+                                            'type': 'string',
+                                            'example': 'm',
+                                        },
+                                        'category': {
+                                            'type': 'object',
+                                            'properties': {
+                                                'sub': {
+                                                    'type': 'string',
+                                                    'example': 'overig'
+                                                },
+                                                'main': {
+                                                    'type': 'string',
+                                                    'example': 'overig'
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        deprecated=True,
+        description='Deprecated GeoJSON of all signals that can be shown on a public map, used by \'s-Hertogenbosch.',
+    )
     def list(self, *args, **kwargs):
         fast_query = f"""
         select jsonb_build_object(


### PR DESCRIPTION
## Description

Add/Fix the OpenAPI specs generation for the v1/public/signals endpoints using drf-spectacular.

Adding the necessary decorators, extend_schema_view, extend_schema, and extend_schema_field, to generate the OpenAPI specifications correctly.


## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
