### PR TITLE
Add/Fix the OpenAPI specs generation for the public and private category endpoints using drf-spectacular

### DIFF
--- a/app/signals/apps/api/fields/category.py
+++ b/app/signals/apps/api/fields/category.py
@@ -19,6 +19,62 @@ def category_public_url(category, request, format=None):
     return reverse(viewname, kwargs=kwargs, request=request, format=format)
 
 
+@extend_schema_field({
+    'type': 'object',
+    'properties': {
+        'curies': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/relations/'
+                }
+            }
+        },
+        'self': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/categories/1'
+                }
+            }
+        },
+        'archives': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/1/history/'
+                }
+            }
+        },
+        'sia:questionnaire': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/public/qa/questionnaires/'
+                               '636aacb1-2813-423e-adbe-7ef84d4afc37',
+                }
+            }
+        },
+        'sia:icon': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/media/icons/1.png'
+                }
+            }
+        },
+    }
+})
 class CategoryHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
     def to_representation(self, value):
         request = self.context.get('request')
@@ -70,6 +126,51 @@ class CategoryHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
         return super().to_internal_value(data=data)
 
 
+@extend_schema_field({
+    'type': 'object',
+    'properties': {
+        'curies': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/relations/'
+                }
+            }
+        },
+        'self': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/categories/1'
+                }
+            }
+        },
+        'archives': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/signals/1/history/'
+                }
+            }
+        },
+        'sia:status-message-templates': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/status-messages/category/1'
+                }
+            }
+        },
+    }
+})
 class PrivateCategoryHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
     def _get_public_url(self, obj, request=None):
         return category_public_url(obj, request=request)

--- a/app/signals/apps/api/serializers/category.py
+++ b/app/signals/apps/api/serializers/category.py
@@ -133,7 +133,7 @@ class PrivateCategorySerializer(HALSerializer):
             'slug',
         )
 
-    def get_sla(self, obj):
+    def get_sla(self, obj: Category) -> PrivateCategorySLASerializer:
         return PrivateCategorySLASerializer(obj.slo.first()).data
 
     def update(self, instance, validated_data):
@@ -175,13 +175,13 @@ class PrivateCategoryHistoryHalSerializer(serializers.ModelSerializer):
             '_category',
         )
 
-    def get_identifier(self, log):
+    def get_identifier(self, log: Log) -> str:
         return f'{log.get_action_display().upper()}_CATEGORY_{log.id}'
 
-    def get_what(self, log):
+    def get_what(self, log: Log) -> str:
         return f'{log.get_action_display().upper()}_CATEGORY'
 
-    def get_action(self, log):  # noqa C901
+    def get_action(self, log: Log) -> str:  # noqa C901
         actions = []
         for key, value in log.data.items():
             if key == 'name':
@@ -210,5 +210,5 @@ class PrivateCategoryHistoryHalSerializer(serializers.ModelSerializer):
             actions.append(action)
         return '\n'.join(actions)
 
-    def get_description(self, log):
+    def get_description(self, log: Log) -> None:
         return None  # No description implemented yet


### PR DESCRIPTION
## Description

Add/Fix the OpenAPI specs generation for the public and private category endpoints using drf-spectacular.

Adding the necessary decorators, extend_schema_view, extend_schema, and extend_schema_field, to generate the OpenAPI specifications correctly.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
