### PR TITLE
Add/Fix the OpenAPI specs generation for the v1 private users/roles/permissions endpoints using drf-spectacular

### DIFF
--- a/app/signals/apps/users/rest_framework/fields/user.py
+++ b/app/signals/apps/users/rest_framework/fields/user.py
@@ -29,16 +29,6 @@ from rest_framework import serializers
                 }
             }
         },
-        # 'archives': {
-        #     'type': 'object',
-        #     'properties': {
-        #         'href': {
-        #             'type': 'string',
-        #             'format': 'uri',
-        #             'example': 'https://api.example.com/signals/v1/private/user/1/history/'
-        #         }
-        #     }
-        # },
     }
 })
 class UserHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
@@ -50,7 +40,6 @@ class UserHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
             ('self', dict(
                 href=self.get_url(value, 'user-detail', request, None),
              )),
-            # ('archives', dict(href=self.get_url(value, 'user-history', request, None))),
         ])
 
         return result

--- a/app/signals/apps/users/rest_framework/fields/user.py
+++ b/app/signals/apps/users/rest_framework/fields/user.py
@@ -1,10 +1,46 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2022 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from collections import OrderedDict
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 
+@extend_schema_field({
+    'type': 'object',
+    'properties': {
+        'curies': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/relations/'
+                }
+            }
+        },
+        'self': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/private/user/1'
+                }
+            }
+        },
+        # 'archives': {
+        #     'type': 'object',
+        #     'properties': {
+        #         'href': {
+        #             'type': 'string',
+        #             'format': 'uri',
+        #             'example': 'https://api.example.com/signals/v1/private/user/1/history/'
+        #         }
+        #     }
+        # },
+    }
+})
 class UserHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
     def to_representation(self, value):
         request = self.context.get('request')

--- a/app/signals/apps/users/rest_framework/serializers/profile.py
+++ b/app/signals/apps/users/rest_framework/serializers/profile.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from rest_framework import serializers
 
 from signals.apps.signals.models import Department
@@ -27,7 +27,7 @@ class ProfileListSerializer(serializers.ModelSerializer):
             'updated_at',
         )
 
-    def get_departments(self, obj):
+    def get_departments(self, obj) -> list[str]:
         return obj.departments.values_list('name', flat=True)
 
 
@@ -50,5 +50,5 @@ class ProfileDetailSerializer(serializers.ModelSerializer):
             'notification_on_department_assignment',
         )
 
-    def get_departments(self, obj):
+    def get_departments(self, obj: Profile) -> list[str]:
         return obj.departments.values_list('name', flat=True)

--- a/app/signals/apps/users/rest_framework/serializers/user.py
+++ b/app/signals/apps/users/rest_framework/serializers/user.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from datapunt_api.rest import HALSerializer
 from datapunt_api.serializers import DisplayField
 from django.contrib.auth.models import Group, User
@@ -50,7 +50,7 @@ class UserListHALSerializer(WriteOnceMixin, HALSerializer):
             'username',
         )
 
-    def get_roles(self, obj):
+    def get_roles(self, obj: User) -> list[str]:
         return [group.name for group in obj.groups.all()]
 
 
@@ -93,12 +93,12 @@ class UserDetailHALSerializer(WriteOnceMixin, HALSerializer):
             'username',
         )
 
-    def validate_username(self, value):
+    def validate_username(self, value: str) -> str:
         if User.objects.filter(username__iexact=value).exists():
             raise serializers.ValidationError(f'A user with username {value} already exists')
         return value
 
-    def create(self, validated_data):
+    def create(self, validated_data: dict) -> User:
         self.get_extra_kwargs()
 
         profile_data = validated_data.pop('profile', None)
@@ -115,7 +115,7 @@ class UserDetailHALSerializer(WriteOnceMixin, HALSerializer):
 
         return instance
 
-    def update(self, instance, validated_data):
+    def update(self, instance: User, validated_data: dict) -> User:
         profile_data = validated_data.pop('profile', None)
         if profile_data:
             profile_detail_serializer = ProfileDetailSerializer()
@@ -151,13 +151,13 @@ class PrivateUserHistoryHalSerializer(serializers.ModelSerializer):
             '_user',
         )
 
-    def get_identifier(self, log):
+    def get_identifier(self, log: Log) -> str:
         return f'{log.get_action_display().upper()}_USER_{log.id}'
 
-    def get_what(self, log):
+    def get_what(self, log: Log) -> str:
         return f'{log.get_action_display().upper()}_USER'
 
-    def get_action(self, log):
+    def get_action(self, log: Log) -> str:
         key_2_title = {
             'first_name': 'Voornaam gewijzigd',
             'last_name': 'Achternaam gewijzigd',
@@ -175,7 +175,7 @@ class PrivateUserHistoryHalSerializer(serializers.ModelSerializer):
             actions.append(f'{key_2_title[key]}:\n {value if value else "-"}')
         return '\n'.join(actions)
 
-    def get_description(self, log):
+    def get_description(self, log: Log) -> None:
         return None
 
 

--- a/app/signals/apps/users/rest_framework/views/permission.py
+++ b/app/signals/apps/users/rest_framework/views/permission.py
@@ -1,17 +1,23 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
-from datapunt_api.rest import DatapuntViewSet
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.db.models import Q
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.permissions import DjangoModelPermissions
+from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework_extensions.mixins import DetailSerializerMixin
 
 from signals.apps.api.generics.permissions import SIAPermissions
 from signals.apps.users.rest_framework.serializers import PermissionSerializer
 from signals.auth.backend import JWTAuthBackend
 
 
-class PermissionViewSet(DatapuntViewSet):
+@extend_schema_view(
+    list=extend_schema(description='List all permissions'),
+    retrieve=extend_schema(description='Retrieve a permission'),
+)
+class PermissionViewSet(DetailSerializerMixin, ReadOnlyModelViewSet):
     queryset = Permission.objects.prefetch_related(
         'content_type',
     ).filter(Q(codename__istartswith='sia_') | Q(codename='push_to_sigmax'))

--- a/app/signals/apps/users/rest_framework/views/role.py
+++ b/app/signals/apps/users/rest_framework/views/role.py
@@ -1,16 +1,26 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2022 Gemeente Amsterdam
-from datapunt_api.rest import DatapuntViewSetWritable
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from django.contrib.auth.models import Group
 from django.db.models.functions import Lower
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.permissions import DjangoModelPermissions
+from rest_framework.viewsets import ModelViewSet
+from rest_framework_extensions.mixins import DetailSerializerMixin
 
 from signals.apps.api.generics.permissions import SIAPermissions
 from signals.apps.users.rest_framework.serializers import RoleSerializer
 from signals.auth.backend import JWTAuthBackend
 
 
-class RoleViewSet(DatapuntViewSetWritable):
+@extend_schema_view(
+    list=extend_schema(description='List all roles'),
+    retrieve=extend_schema(description='Retrieve a role'),
+    partial_update=extend_schema(description='Update a role'),
+    update=extend_schema(description='Update a role'),
+    create=extend_schema(description='Create a role'),
+    destroy=extend_schema(description='Delete a role'),
+)
+class RoleViewSet(DetailSerializerMixin, ModelViewSet):
     queryset = Group.objects.prefetch_related(
         'permissions',
         'permissions__content_type',

--- a/app/signals/schema.py
+++ b/app/signals/schema.py
@@ -1,7 +1,29 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2023 Gemeente Amsterdam
+from drf_spectacular.extensions import OpenApiSerializerFieldExtension
 from drf_spectacular.openapi import AutoSchema
 from rest_framework import serializers
+
+
+class DatapuntLinksFieldFix(OpenApiSerializerFieldExtension):
+    target_class = 'datapunt_api.serializers.LinksField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        return {
+            'type': 'object',
+            'properties': {
+                'self': {
+                    'type': 'object',
+                    'properties': {
+                        'href': {
+                            'type': 'string',
+                            'format': 'uri',
+                            'example': 'http://api.example.org/endpoint/1',
+                        },
+                    },
+                },
+            },
+        }
 
 
 class ErrorSerializer(serializers.Serializer):


### PR DESCRIPTION
## Description

Add/Fix the OpenAPI specs generation for the v1 private users/roles/permissions endpoints using drf-spectacular.

Added the DatapuntLinksFieldFix that will fix the schema representation of the LinkField from the datapunt_api package.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
