### PR TITLE
Add/Fix the OpenAPI specs generation for the public and private my-signals endpoints using drf-spectacular

### DIFF
--- a/app/signals/apps/my_signals/rest_framework/fields/signals.py
+++ b/app/signals/apps/my_signals/rest_framework/fields/signals.py
@@ -1,12 +1,38 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Gemeente Amsterdam
+# Copyright (C) 2022 - 2023 Gemeente Amsterdam
 from collections import OrderedDict
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework.relations import HyperlinkedIdentityField
 
 from signals.apps.signals.models import Signal
 
 
+@extend_schema_field({
+    'type': 'object',
+    'properties': {
+        'curies': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/relations/'
+                }
+            }
+        },
+        'self': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/my/signals/358f6855-61b7-4a6e-b2b3-1737b63b93e9'
+                }
+            }
+        },
+    }
+})
 class MySignalListLinksField(HyperlinkedIdentityField):
     lookup_field = 'uuid'
 
@@ -20,6 +46,64 @@ class MySignalListLinksField(HyperlinkedIdentityField):
         ])
 
 
+@extend_schema_field({
+    'type': 'object',
+    'properties': {
+        'curies': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/relations/'
+                }
+            }
+        },
+        'self': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/my/signals/358f6855-61b7-4a6e-b2b3-1737b63b93e9'
+                }
+            }
+        },
+        'archives': {
+            'type': 'object',
+            'properties': {
+                'href': {
+                    'type': 'string',
+                    'format': 'uri',
+                    'example': 'https://api.example.com/signals/v1/my/signals/358f6855-61b7-4a6e-b2b3-1737b63b93e9'
+                               '/history'
+                }
+            }
+        },
+        'sia:attachments': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'properties': {
+                    'href': {
+                        'type': 'string',
+                        'format': 'uri',
+                        'example': 'https://api.example.com/media/1.png'
+                    },
+                    'created_by': {
+                        'type': 'string',
+                        'example': 'john.doe@example.com'
+                    },
+                    'created_at': {
+                        'type': 'string',
+                        'format': 'date-time',
+                        'example': '2023-06-01T00:00:00Z'
+                    }
+                }
+            }
+        },
+    }
+})
 class MySignalDetailLinksField(HyperlinkedIdentityField):
     lookup_field = 'uuid'
 

--- a/app/signals/apps/my_signals/rest_framework/views/me.py
+++ b/app/signals/apps/my_signals/rest_framework/views/me.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Gemeente Amsterdam
+# Copyright (C) 2022 - 2023 Gemeente Amsterdam
 from rest_framework.generics import RetrieveAPIView
 
 from signals.apps.my_signals.models import Token

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -464,4 +464,8 @@ if DRF_SPECTACULAR_ENABLED:
         'SWAGGER_UI_DIST': 'SIDECAR',
         'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
         'GENERIC_ADDITIONAL_PROPERTIES': True,
+        'AUTHENTICATION_WHITELIST': [
+            'signals.auth.backend.JWTAuthBackend',
+            'signals.apps.my_signals.rest_framework.authentication.MySignalsTokenAuthentication'
+        ],
     }


### PR DESCRIPTION
## Description

Add/Fix the OpenAPI specs generation for the public and private my-signals endpoints using drf-spectacular.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
