### PR TITLE
Use correct backend when saving and zipping CSV files for endpoint

### DIFF
--- a/app/signals/apps/reporting/csv/datawarehouse/tasks.py
+++ b/app/signals/apps/reporting/csv/datawarehouse/tasks.py
@@ -87,7 +87,7 @@ def save_and_zip_csv_files_endpoint(max_csv_amount: int = 30):
 
     :returns:
     """
-    created_files = save_csv_files_datawarehouse(using=None)
+    created_files = save_csv_files_datawarehouse(using='datawarehouse')
     zip_csv_files(files_to_zip=created_files, using='datawarehouse')
     rotate_zip_files(using='datawarehouse', max_csv_amount=max_csv_amount)
 


### PR DESCRIPTION
## Description

Currently the backend None is used which results in the following error when saving and zipping CSV files:

```
Arguments: {'hostname': 'celery@backend-celery-worker-547d5cdf5f-j8xgl', 'id': '6ea52e33-dccc-4256-84e6-aee79e01467c', 'name': 'signals.apps.reporting.csv.datawarehouse.tasks.save_and_zip_csv_files_endpoint', 'exc': "ImproperlyConfigured('None not present in the AZURE_CONTAINERS settings')"
```
