### PR TITLE
Make the PDOK suggest endpoint configurable with a default to the new URL

### DIFF
--- a/app/signals/apps/api/app_settings.py
+++ b/app/signals/apps/api/app_settings.py
@@ -3,7 +3,6 @@
 from signals.apps.signals import workflow
 
 SIGNALS_API_MAX_UPLOAD_SIZE = 20*1024*1024  # 20MB = 20*1024*1024
-SIGNALS_API_PDOK_API_URL = 'https://geodata.nationaalgeoregister.nl'
 
 SIGNALS_API_CLOSED_STATES = frozenset([
     workflow.AFGEHANDELD,

--- a/app/signals/apps/api/validation/address/pdok.py
+++ b/app/signals/apps/api/validation/address/pdok.py
@@ -1,19 +1,18 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from django.http import QueryDict
 from requests import get
 from requests.exceptions import RequestException
 
-from signals.apps.api.app_settings import SIGNALS_API_PDOK_API_URL
 from signals.apps.api.validation.address.base import (
     AddressValidationUnavailableException,
     BaseAddressValidation
 )
-from signals.settings import DEFAULT_PDOK_MUNICIPALITIES
+from signals.settings import DEFAULT_PDOK_MUNICIPALITIES, PDOK_LOCATIESERVER_SUGGEST_ENDPOINT
 
 
 class PDOKAddressValidation(BaseAddressValidation):
-    address_validation_url = f'{SIGNALS_API_PDOK_API_URL}/locatieserver/v3/suggest'
+    address_validation_url = PDOK_LOCATIESERVER_SUGGEST_ENDPOINT
 
     def _search_result_to_address(self, result):
         mapping = {

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -407,6 +407,8 @@ API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE = os.getenv(
 API_TRANSFORM_SOURCE_OF_CHILD_SIGNAL_TO = os.getenv('API_TRANSFORM_SOURCE_OF_CHILD_SIGNAL_TO', 'Interne melding')
 
 # Default pdok municipalities
+PDOK_LOCATIESERVER_SUGGEST_ENDPOINT = os.getenv('PDOK_LOCATIESERVER_SUGGEST_ENDPOINT',
+                                                'https://api.pdok.nl/bzk/locatieserver/search/v3_1/suggest')
 DEFAULT_PDOK_MUNICIPALITIES = os.getenv('DEFAULT_PDOK_MUNICIPALITIES',
                                         'Amsterdam,Amstelveen,Weesp,Ouder-Amstel').split(',')
 


### PR DESCRIPTION
## Description

The PDOK Locationservice has been migrated and is available on a new URL, the old URL will no longer work after the 1st of august 2023. More information can be fount at https://www.pdok.nl/-/migratie-pdok-locatieserver-naar-het-nieuwe-3g-platform-afgerond.

This PR makes the PDOK suggest endpoint configurable, and has the default value set to the new URL.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
