### PR TITLE
Set default retention to 7 days for datawarehouse

### DIFF
--- a/app/signals/apps/reporting/management/commands/clean_up_datawarehouse_disk.py
+++ b/app/signals/apps/reporting/management/commands/clean_up_datawarehouse_disk.py
@@ -8,7 +8,7 @@ from signals.apps.reporting.utils import _get_storage_backend
 
 class Command(BaseCommand):
     def add_arguments(self, parser) -> None:
-        parser.add_argument('--keep-n-days', dest='keep_n_days', type=int, default=30,
+        parser.add_argument('--keep-n-days', dest='keep_n_days', type=int, default=7,
                             help='Number of days to retain data for.')
         parser.add_argument('--dry-run', dest='dry_run', action='store_true', default=False,
                             help='Perform dry run without deleting data files.')

--- a/app/signals/apps/reporting/services/clean_up_datawarehouse.py
+++ b/app/signals/apps/reporting/services/clean_up_datawarehouse.py
@@ -63,7 +63,7 @@ class DataWarehouseDiskCleaner:
         return removed
 
     @staticmethod
-    def clean_up(data_root, keep_n_days=30, dry_run=False):
+    def clean_up(data_root, keep_n_days=7, dry_run=False):
         """
         Clean-up CSV dumps and Zip archives under the `data_root` directory.
         """


### PR DESCRIPTION
## Description

Keeping a history of 30 days can be quite expensive in terms of storage. Moreover, only the latest export is exposed through the API.

Therefore this proposal to set the default retention date to 7 days.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
