### PR TITLE
Isolate email template rendering

### DIFF
--- a/app/signals/apps/email_integrations/actions/feedback_received_action.py
+++ b/app/signals/apps/email_integrations/actions/feedback_received_action.py
@@ -1,26 +1,26 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import logging
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+import typing
 
 from django.conf import settings
 
 from signals.apps.email_integrations.actions.abstract import AbstractSystemAction
 from signals.apps.email_integrations.models import EmailTemplate
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class FeedbackReceivedAction(AbstractSystemAction):
-    _required_call_kwargs = ('feedback',)
+    _required_call_kwargs: list[str] = ('feedback',)
 
     # Rule must check if the feature flag for this system mail is enabled
-    rule = lambda self, signal: settings.FEATURE_FLAGS.get('SYSTEM_MAIL_FEEDBACK_RECEIVED_ENABLED', True)  # noqa: E731
+    rule: typing.Callable[[Signal], bool] = \
+        lambda self, signal: settings.FEATURE_FLAGS.get('SYSTEM_MAIL_FEEDBACK_RECEIVED_ENABLED', True)
 
-    key = EmailTemplate.SIGNAL_FEEDBACK_RECEIVED
-    subject = 'Bedankt voor uw feedback'
-    note = 'Automatische e-mail bij ontvangen van feedback is verzonden aan de melder.'
+    key: str = EmailTemplate.SIGNAL_FEEDBACK_RECEIVED
+    subject: str = 'Bedankt voor uw feedback'
+    note: str = 'Automatische e-mail bij ontvangen van feedback is verzonden aan de melder.'
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         return {
             'feedback_allows_contact': self.kwargs['feedback'].allows_contact,
             'feedback_is_satisfied': self.kwargs['feedback'].is_satisfied,

--- a/app/signals/apps/email_integrations/actions/forward_to_external_reaction_received.py
+++ b/app/signals/apps/email_integrations/actions/forward_to_external_reaction_received.py
@@ -1,24 +1,21 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
-import logging
-
+# Copyright (C) 2022 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 from signals.apps.email_integrations.actions.abstract import AbstractSystemAction
 from signals.apps.email_integrations.models import EmailTemplate
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class ForwardToExternalReactionReceivedAction(AbstractSystemAction):
-    _required_call_kwargs = ('reaction_text', 'email_override')
+    _required_call_kwargs: list[str] = ('reaction_text', 'email_override')
 
-    key = EmailTemplate.SIGNAL_FORWARD_TO_EXTERNAL_REACTION_RECEIVED
-    subject = 'Melding {formatted_signal_id}: reactie ontvangen'
+    key: str = EmailTemplate.SIGNAL_FORWARD_TO_EXTERNAL_REACTION_RECEIVED
+    subject: str = 'Melding {formatted_signal_id}: reactie ontvangen'
 
-    fallback_txt_template = 'email/forward_to_external_reaction_received.txt'
-    fallback_html_template = 'email/forward_to_external_reaction_received.html'
+    fallback_txt_template: str = 'email/forward_to_external_reaction_received.txt'
+    fallback_html_template: str = 'email/forward_to_external_reaction_received.html'
 
-    def get_recipient_list(self, signal):
+    def get_recipient_list(self, signal: Signal) -> list[str]:
         return [self.kwargs['email_override']]
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         return {'reaction_text': self.kwargs['reaction_text']}

--- a/app/signals/apps/email_integrations/actions/signal_created.py
+++ b/app/signals/apps/email_integrations/actions/signal_created.py
@@ -1,24 +1,23 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import logging
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+import typing
 
 from signals.apps.email_integrations.actions.abstract import AbstractAction
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.rules import SignalCreatedRule
 from signals.apps.services.domain.contact_details import ContactDetailsService
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class SignalCreatedAction(AbstractAction):
-    rule = SignalCreatedRule()
+    rule: typing.Callable[[Signal], bool] = SignalCreatedRule()
 
-    key = EmailTemplate.SIGNAL_CREATED
-    subject = 'Bedankt voor uw melding {formatted_signal_id}'
+    key: str = EmailTemplate.SIGNAL_CREATED
+    subject: str = 'Bedankt voor uw melding {formatted_signal_id}'
 
-    note = 'Automatische e-mail bij registratie van de melding is verzonden aan de melder.'
+    note: str = 'Automatische e-mail bij registratie van de melding is verzonden aan de melder.'
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         context = {'afhandelings_text': signal.category_assignment.category.handling_message, }
 
         if signal.reporter:
@@ -41,7 +40,7 @@ class SignalCreatedAction(AbstractAction):
 
         return context
 
-    def _extra_properties_context(self, extra_properties):
+    def _extra_properties_context(self, extra_properties: list) -> dict:
         """
         Renders the extra properties of the signals as a dict of key-value pairs so that they can be rendered in the
         email template.
@@ -59,7 +58,7 @@ class SignalCreatedAction(AbstractAction):
                 context[extra_property['label']].append(self._get_answer_from_extra_property(extra_property['answer']))
         return context
 
-    def _get_answer_from_extra_property(self, extra_property):  # noqa C901
+    def _get_answer_from_extra_property(self, extra_property: typing.Union[str, dict]) -> str: # noqa C901
         """
         Returns the first option that is available in the extra property and not empty as the answer.
         Defaults to '-' if no option is available.

--- a/app/signals/apps/email_integrations/actions/signal_forward_to_external.py
+++ b/app/signals/apps/email_integrations/actions/signal_forward_to_external.py
@@ -1,27 +1,26 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
-import logging
+# Copyright (C) 2022 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+import typing
 
 from signals.apps.email_integrations.actions.abstract import AbstractAction
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.rules import ForwardToExternalRule
 from signals.apps.email_integrations.utils import create_forward_to_external_and_mail_context
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class SignalForwardToExternalAction(AbstractAction):
-    rule = ForwardToExternalRule()
-    key = EmailTemplate.SIGNAL_STATUS_CHANGED_FORWARD_TO_EXTERNAL
-    subject = 'Verzoek tot behandeling van Signalen melding {formatted_signal_id}'  # TODO: check phrasing PS-261
+    rule: typing.Callable[[Signal], bool] = ForwardToExternalRule()
+    key: str = EmailTemplate.SIGNAL_STATUS_CHANGED_FORWARD_TO_EXTERNAL
+    subject: str = 'Verzoek tot behandeling van Signalen melding {formatted_signal_id}'
 
-    fallback_txt_template = 'email/signal_forward_to_external.txt'
-    fallback_html_template = 'email/signal_forward_to_external.html'
+    fallback_txt_template: str = 'email/signal_forward_to_external.txt'
+    fallback_html_template: str = 'email/signal_forward_to_external.html'
 
-    note = 'Automatische e-mail bij doorzetten is verzonden aan externe partij.'
+    note: str = 'Automatische e-mail bij doorzetten is verzonden aan externe partij.'
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         return create_forward_to_external_and_mail_context(signal, dry_run)
 
-    def get_recipient_list(self, signal):
+    def get_recipient_list(self, signal: Signal) -> list[str]:
         return [signal.status.email_override]

--- a/app/signals/apps/email_integrations/actions/signal_handeld.py
+++ b/app/signals/apps/email_integrations/actions/signal_handeld.py
@@ -1,22 +1,21 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import logging
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+import typing
 
 from signals.apps.email_integrations.actions.abstract import AbstractAction
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.rules import SignalHandledRule
 from signals.apps.email_integrations.utils import create_feedback_and_mail_context
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class SignalHandledAction(AbstractAction):
-    rule = SignalHandledRule()
+    rule: typing.Callable[[Signal], bool] = SignalHandledRule()
 
-    key = EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD
-    subject = 'Meer over uw melding {formatted_signal_id}'
+    key: str = EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD
+    subject: str = 'Meer over uw melding {formatted_signal_id}'
 
-    note = 'Automatische e-mail bij afhandelen is verzonden aan de melder.'
+    note: str = 'Automatische e-mail bij afhandelen is verzonden aan de melder.'
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         return create_feedback_and_mail_context(signal, dry_run)

--- a/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
+++ b/app/signals/apps/email_integrations/actions/signal_handeld_negative_contact.py
@@ -1,23 +1,22 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Gemeente Amsterdam
-import logging
+# Copyright (C) 2023 Gemeente Amsterdam
+import typing
 
 from signals.apps.email_integrations.actions.abstract import AbstractAction
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.rules import SignalHandledNegativeRule
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class SignalHandledNegativeAction(AbstractAction):
-    rule = SignalHandledNegativeRule()
+    rule: typing.Callable[[Signal], bool] = SignalHandledNegativeRule()
 
-    key = EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT
-    subject = 'Meer over uw melding {formatted_signal_id}'
+    key: str = EmailTemplate.SIGNAL_STATUS_CHANGED_AFGEHANDELD_KTO_NEGATIVE_CONTACT
+    subject: str = 'Meer over uw melding {formatted_signal_id}'
 
-    note = 'Automatische e-mail bij afhandelen heropenen negatieve feedback'
+    note: str = 'Automatische e-mail bij afhandelen heropenen negatieve feedback'
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         """
         Add the extra feedback essences to the email template
         """

--- a/app/signals/apps/email_integrations/actions/signal_optional.py
+++ b/app/signals/apps/email_integrations/actions/signal_optional.py
@@ -1,23 +1,22 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import logging
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+import typing
 
 from signals.apps.email_integrations.actions.abstract import AbstractAction
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.rules import SignalOptionalRule
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class SignalOptionalAction(AbstractAction):
-    rule = SignalOptionalRule()
+    rule: typing.Callable[[Signal], bool] = SignalOptionalRule()
 
-    key = EmailTemplate.SIGNAL_STATUS_CHANGED_OPTIONAL
-    subject = 'Meer over uw melding {formatted_signal_id}'
+    key: str = EmailTemplate.SIGNAL_STATUS_CHANGED_OPTIONAL
+    subject: str = 'Meer over uw melding {formatted_signal_id}'
 
-    note = 'De statusupdate is per e-mail verzonden aan de melder'
+    note: str = 'De statusupdate is per e-mail verzonden aan de melder'
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         return {
             'afhandelings_text': signal.status.text
         }

--- a/app/signals/apps/email_integrations/actions/signal_reaction_request.py
+++ b/app/signals/apps/email_integrations/actions/signal_reaction_request.py
@@ -1,22 +1,21 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import logging
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+import typing
 
 from signals.apps.email_integrations.actions.abstract import AbstractAction
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.rules import SignalReactionRequestRule
 from signals.apps.email_integrations.utils import create_reaction_request_and_mail_context
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class SignalReactionRequestAction(AbstractAction):
-    rule = SignalReactionRequestRule()
+    rule: typing.Callable[[Signal], bool] = SignalReactionRequestRule()
 
-    key = EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD
-    subject = 'Meer over uw melding {formatted_signal_id}'
+    key: str = EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_GEVRAAGD
+    subject: str = 'Meer over uw melding {formatted_signal_id}'
 
-    note = 'E-mail met vraag verstuurd aan melder'
+    note: str = 'E-mail met vraag verstuurd aan melder'
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         return create_reaction_request_and_mail_context(signal, dry_run)

--- a/app/signals/apps/email_integrations/actions/signal_reaction_request_received.py
+++ b/app/signals/apps/email_integrations/actions/signal_reaction_request_received.py
@@ -1,21 +1,20 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import logging
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+import typing
 
 from signals.apps.email_integrations.actions.abstract import AbstractAction
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.rules import SignalReactionRequestReceivedRule
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class SignalReactionRequestReceivedAction(AbstractAction):
-    rule = SignalReactionRequestReceivedRule()
+    rule: typing.Callable[[Signal], bool] = SignalReactionRequestReceivedRule()
 
-    key = EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN
-    subject = 'Meer over uw melding {formatted_signal_id}'
+    key: str = EmailTemplate.SIGNAL_STATUS_CHANGED_REACTIE_ONTVANGEN
+    subject: str = 'Meer over uw melding {formatted_signal_id}'
 
-    note = 'Automatische e-mail bij Reactie ontvangen is verzonden aan de melder.'
+    note: str = 'Automatische e-mail bij Reactie ontvangen is verzonden aan de melder.'
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         return {'reaction_request_answer': signal.status.text}

--- a/app/signals/apps/email_integrations/actions/signal_reopened.py
+++ b/app/signals/apps/email_integrations/actions/signal_reopened.py
@@ -1,23 +1,22 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import logging
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+import typing
 
 from signals.apps.email_integrations.actions.abstract import AbstractAction
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.rules import SignalReopenedRule
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class SignalReopenedAction(AbstractAction):
-    rule = SignalReopenedRule()
+    rule: typing.Callable[[Signal], bool] = SignalReopenedRule()
 
-    key = EmailTemplate.SIGNAL_STATUS_CHANGED_HEROPEND
-    subject = 'Meer over uw melding {formatted_signal_id}'
+    key: str = EmailTemplate.SIGNAL_STATUS_CHANGED_HEROPEND
+    subject: str = 'Meer over uw melding {formatted_signal_id}'
 
-    note = 'Automatische e-mail bij heropenen is verzonden aan de melder.'
+    note: str = 'Automatische e-mail bij heropenen is verzonden aan de melder.'
 
-    def get_additional_context(self, signal, dry_run=False):
+    def get_additional_context(self, signal: Signal, dry_run: bool = False) -> dict:
         feedback_qs = signal.feedback.filter(submitted_at__isnull=False)
         feedback_received = feedback_qs.exists()
 

--- a/app/signals/apps/email_integrations/actions/signal_scheduled.py
+++ b/app/signals/apps/email_integrations/actions/signal_scheduled.py
@@ -1,18 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import logging
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+import typing
 
 from signals.apps.email_integrations.actions.abstract import AbstractAction
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.rules import SignalScheduledRule
-
-logger = logging.getLogger(__name__)
+from signals.apps.signals.models import Signal
 
 
 class SignalScheduledAction(AbstractAction):
-    rule = SignalScheduledRule()
+    rule: typing.Callable[[Signal], bool] = SignalScheduledRule()
 
-    key = EmailTemplate.SIGNAL_STATUS_CHANGED_INGEPLAND
-    subject = 'Meer over uw melding {formatted_signal_id}'
+    key: str = EmailTemplate.SIGNAL_STATUS_CHANGED_INGEPLAND
+    subject: str = 'Meer over uw melding {formatted_signal_id}'
 
-    note = 'Automatische e-mail bij inplannen is verzonden aan de melder.'
+    note: str = 'Automatische e-mail bij inplannen is verzonden aan de melder.'

--- a/app/signals/apps/email_integrations/renderers/__init__.py
+++ b/app/signals/apps/email_integrations/renderers/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam

--- a/app/signals/apps/email_integrations/renderers/email_template_renderer.py
+++ b/app/signals/apps/email_integrations/renderers/email_template_renderer.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam
+from django.template import Context, Template, loader
+
+from signals.apps.email_integrations.models import EmailTemplate
+
+
+class EmailTemplateRenderer:
+    def __call__(self, key: str, context: dict) -> tuple[str, str, str]:
+        email_template = EmailTemplate.objects.get(key=key)
+
+        rendered_context = {
+            'subject': Template(email_template.title).render(Context(context)),
+            'body': Template(email_template.body).render(Context(context, autoescape=False))
+        }
+
+        subject = Template(email_template.title).render(Context(context, autoescape=False))
+        message = loader.get_template('email/_base.txt').render(rendered_context)
+        html_message = loader.get_template('email/_base.html').render(rendered_context)
+
+        return subject, message, html_message

--- a/app/signals/apps/email_integrations/tests/test_action_signal_created_extra_properties.py
+++ b/app/signals/apps/email_integrations/tests/test_action_signal_created_extra_properties.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Gemeente Amsterdam
+# Copyright (C) 2022 - 2023 Gemeente Amsterdam
 from django.conf import settings
 from django.core import mail
 from django.test import TestCase
 
 from signals.apps.email_integrations.actions import SignalCreatedAction
 from signals.apps.email_integrations.models import EmailTemplate
+from signals.apps.email_integrations.renderers.email_template_renderer import EmailTemplateRenderer
 from signals.apps.signals import workflow
 from signals.apps.signals.factories import SignalFactory
 from signals.apps.signals.models import Note
@@ -13,7 +14,7 @@ from signals.apps.signals.models import Note
 
 class TestSignalCreatedActionExtraProperties(TestCase):
     state = workflow.GEMELD
-    action = SignalCreatedAction()
+    action = SignalCreatedAction(EmailTemplateRenderer())
 
     def setUp(self):
         EmailTemplate.objects.create(key=EmailTemplate.SIGNAL_CREATED,

--- a/app/signals/apps/my_signals/mail.py
+++ b/app/signals/apps/my_signals/mail.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Gemeente Amsterdam
+# Copyright (C) 2022 - 2023 Gemeente Amsterdam
 from django.conf import settings
 from django.core.mail import send_mail
-from django.template import Context, Template, loader
+from django.template import loader
 from django.utils.timezone import now
 
 from signals.apps.email_integrations.models import EmailTemplate
+from signals.apps.email_integrations.renderers.email_template_renderer import EmailTemplateRenderer
 from signals.apps.my_signals.app_settings import MY_SIGNALS_URL
 from signals.apps.my_signals.models import Token
 
@@ -21,16 +22,8 @@ def send_token_mail(token: Token) -> int:
     context = {'my_signals_url': f'{MY_SIGNALS_URL}/{token.key}', 'ORGANIZATION_NAME': settings.ORGANIZATION_NAME}
 
     try:
-        email_template = EmailTemplate.objects.get(key=EmailTemplate.MY_SIGNAL_TOKEN)
-
-        rendered_context = {
-            'subject': Template(email_template.title).render(Context(context)),
-            'body': Template(email_template.body).render(Context(context, autoescape=False))
-        }
-
-        subject = Template(email_template.title).render(Context(context, autoescape=False))
-        message = loader.get_template('email/_base.txt').render(rendered_context)
-        html_message = loader.get_template('email/_base.html').render(rendered_context)
+        render = EmailTemplateRenderer()
+        subject, message, html_message = render(EmailTemplate.MY_SIGNAL_TOKEN, context)
     except EmailTemplate.DoesNotExist:
         subject = 'My Signals Token'
         message = loader.get_template('email/signal_default.txt').render(context)


### PR DESCRIPTION
## Description

Isolate the email template rendering logic and re-use it. Refactor to include type hints.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations


## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
