### PR TITLE
Add email template support for sending confirmation mail

### DIFF
--- a/app/signals/apps/email_integrations/models.py
+++ b/app/signals/apps/email_integrations/models.py
@@ -24,6 +24,7 @@ class EmailTemplate(CreatedUpdatedModel):
     SIGNAL_ASSIGNED: typing.Final[str] = 'signal_assigned'
     VERIFY_EMAIL_REPORTER: typing.Final[str] = 'verify_email_reporter'
     NOTIFY_CURRENT_REPORTER: typing.Final[str] = 'notify_current_reporter'
+    CONFIRM_REPORTER_UPDATED: typing.Final[str] = 'confirm_reporter_updated'
 
     KEYS_CHOICES: typing.Final = [
         (SIGNAL_CREATED, 'Send mail signal created'),
@@ -41,6 +42,10 @@ class EmailTemplate(CreatedUpdatedModel):
         (MY_SIGNAL_TOKEN, 'Send mail when a My Signals token has been requested'),
         (VERIFY_EMAIL_REPORTER, 'Send mail to verify the email address of a reporter'),
         (NOTIFY_CURRENT_REPORTER, 'Send mail to current reporter that a change of contact information is requested'),
+        (
+            CONFIRM_REPORTER_UPDATED,
+            'Send mail to new reporter stating that contact information was successfully updated'
+        ),
     ]
 
     key = models.CharField(max_length=100, choices=KEYS_CHOICES, db_index=True, unique=True)

--- a/app/signals/apps/email_integrations/tests/test_email_templates.py
+++ b/app/signals/apps/email_integrations/tests/test_email_templates.py
@@ -443,7 +443,17 @@ neem dan z.s.m. contact met ons op.
 
 Indien dit wel correct is, gebruik dan de link die wij u naar uw nieuwe e-mailadres hebben verstuurd om uw nieuwe e-mailadres te bevestigen.
 
-Met vriendelijk groet,
+Met vriendelijke groet,
+
+{{ ORGANIZATION_NAME }}""" # noqa
+        ),
+        (
+            EmailTemplate.CONFIRM_REPORTER_UPDATED,
+            """Beste melder,
+
+Bij deze bevestigen wij dat uw verzoek om uw contact gegevens te wijzigen succesvol is uitgevoerd.
+
+Met vriendelijke groet,
 
 {{ ORGANIZATION_NAME }}""" # noqa
         ),
@@ -1308,7 +1318,7 @@ neem dan z.s.m. contact met ons op.
 
 Indien dit wel correct is, gebruik dan de link die wij u naar uw nieuwe e-mailadres hebben verstuurd om uw nieuwe e-mailadres te bevestigen.
 
-Met vriendelijk groet,
+Met vriendelijke groet,
 
 Gemeente Amsterdam""" # noqa
 
@@ -1327,8 +1337,43 @@ Gemeente Amsterdam""" # noqa
 <p>Er is een wijziging van uw contact gegevens aangevraagd. Mocht dat niet correct zijn of heeft u deze wijziging niet aangevraagd,
 neem dan z.s.m. contact met ons op.</p>
 <p>Indien dit wel correct is, gebruik dan de link die wij u naar uw nieuwe e-mailadres hebben verstuurd om uw nieuwe e-mailadres te bevestigen.</p>
-<p>Met vriendelijk groet,</p>
+<p>Met vriendelijke groet,</p>
 <p>Gemeente Amsterdam</p>
 </body>
 </html>
 """ # noqa
+
+    def test_confirm_reporter_updated(self):
+        email = 'caleb.bradham@pepsi.com'
+        reporter = ReporterFactory.create(email=email)
+
+        mail_reporter = ReporterMailer(EmailTemplateRenderer())
+
+        mail_reporter(reporter, EmailTemplate.CONFIRM_REPORTER_UPDATED)
+
+        assert mail.outbox[0].body == """Beste melder,
+
+Bij deze bevestigen wij dat uw verzoek om uw contact gegevens te wijzigen succesvol is uitgevoerd.
+
+Met vriendelijke groet,
+
+Gemeente Amsterdam""" # noqa
+
+        body, mime_type = mail.outbox[0].alternatives[0]
+        self.assertEqual(mime_type, 'text/html')
+
+        assert body == """
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>Uw melding </title>
+</head>
+<body>
+    <p>Beste melder,</p>
+<p>Bij deze bevestigen wij dat uw verzoek om uw contact gegevens te wijzigen succesvol is uitgevoerd.</p>
+<p>Met vriendelijke groet,</p>
+<p>Gemeente Amsterdam</p>
+</body>
+</html>
+"""  # noqa


### PR DESCRIPTION
## Description

Adding support for sending an email when the reporter was successfully updated.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
