### PR TITLE
Moved the 'to_jsonb' functionallity into Feedback query within 'create_kto_feedback_csv'

### DIFF
--- a/app/signals/apps/reporting/csv/datawarehouse/kto_feedback.py
+++ b/app/signals/apps/reporting/csv/datawarehouse/kto_feedback.py
@@ -2,11 +2,10 @@
 # Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import os
 
-from django.db.models import CharField, TextField, Value
+from django.db.models import CharField, F, Func, TextField, Value
 from django.db.models.functions import Cast, Coalesce, NullIf
 
 from signals.apps.feedback.models import Feedback
-from signals.apps.reporting.csv.datawarehouse.utils import ToJsonB
 from signals.apps.reporting.csv.utils import map_choices, queryset_to_csv_file, reorder_csv
 
 
@@ -37,7 +36,8 @@ def create_kto_feedback_csv(location: str) -> str:
                        Value('', output_field=CharField())),
         _is_satisfied=map_choices('is_satisfied', [(True, 'True'), (False, 'False')]),
         _allows_contact=map_choices('allows_contact', [(True, 'True'), (False, 'False')]),
-        _text_list=ToJsonB('text_list', output_field=TextField(), function_kwargs={'indent': 4, 'ensure_ascii': False}),
+        _text_list=Func(F('text_list'), function='to_jsonb', output_field=TextField(),
+                        function_kwargs={'indent': 4, 'ensure_ascii': False}),
     ).filter(submitted_at__isnull=False)
 
     csv_file = queryset_to_csv_file(queryset, os.path.join(location, file_name))

--- a/app/signals/apps/reporting/csv/datawarehouse/utils.py
+++ b/app/signals/apps/reporting/csv/datawarehouse/utils.py
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2023 Gemeente Amsterdam
-from django.db.models import Func
-
-
-class ToJsonB(Func):
-    # TODO: Find a better place for this code
-    function = 'to_jsonb'


### PR DESCRIPTION
## Description

Moved the 'to_jsonb' functionallity into Feedback query within 'create_kto_feedback_csv', remove unused 'utils.py' file for improved code organization and clarity

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
