### PR TITLE
Allow setting cookie domain

### DIFF
--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -110,6 +110,7 @@ MIDDLEWARE = [
 if os.getenv('SESSION_SUPPORT_ON_TOKEN_AUTHENTICATION', False) in TRUE_VALUES:
     MIDDLEWARE.append('signals.apps.api.middleware.SessionLoginMiddleware')
     SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+    SESSION_COOKIE_DOMAIN = os.getenv('SESSION_COOKIE_DOMAIN', None)
     SESSION_COOKIE_SAMESITE = 'None'
     CORS_ALLOW_CREDENTIALS = True
 


### PR DESCRIPTION
## Description

Allow setting cookie domain, in order for our session cookie to be valid for subdomains.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations
