### PR TITLE
Implement reporter cancel transition

### DIFF
--- a/app/signals/apps/signals/models/reporter.py
+++ b/app/signals/apps/signals/models/reporter.py
@@ -52,14 +52,14 @@ class Reporter(ConcurrentTransitionMixin, CreatedUpdatedModel):
         )
 
     @property
-    def is_anonymized(self):
+    def is_anonymized(self) -> bool:
         """
         Checks if an anonymous reporter is anonymized?
         """
         return self.is_anonymous and (self.email_anonymized or self.phone_anonymized)
 
     @property
-    def is_anonymous(self):
+    def is_anonymous(self) -> bool:
         """
         Checks if a reporter is anonymous
         """
@@ -88,7 +88,7 @@ class Reporter(ConcurrentTransitionMixin, CreatedUpdatedModel):
         Use this method to transition to the 'cancelled' state.
         """
 
-    def anonymize(self, always_call_save=False):
+    def anonymize(self, always_call_save: bool = False) -> None:
         call_save = False
         if not self.email_anonymized and self.email:
             self.email_anonymized = True
@@ -101,7 +101,7 @@ class Reporter(ConcurrentTransitionMixin, CreatedUpdatedModel):
         if call_save or always_call_save:
             self.save()
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs) -> None:
         """
         Make sure that the email and phone are set to none while saving the Reporter
         """

--- a/app/signals/apps/signals/models/reporter.py
+++ b/app/signals/apps/signals/models/reporter.py
@@ -87,6 +87,7 @@ class Reporter(ConcurrentTransitionMixin, CreatedUpdatedModel):
         """
         Use this method to transition to the 'cancelled' state.
         """
+        self.email_verification_token = None
 
     def anonymize(self, always_call_save: bool = False) -> None:
         call_save = False

--- a/app/signals/apps/signals/tests/test_reporter_state_machine.py
+++ b/app/signals/apps/signals/tests/test_reporter_state_machine.py
@@ -22,6 +22,9 @@ class TestReporterStateMachine(TestCase):
         new.save()
 
         new.cancel()
+        new.save()
+
+        self.assertEqual(new.state, Reporter.REPORTER_STATE_CANCELLED)
 
     def test_cannot_transition_from_new_to_cancelled_when_original_reporter(self) -> None:
         new = Reporter()
@@ -36,6 +39,10 @@ class TestReporterStateMachine(TestCase):
         new = ReporterFactory.create(state=Reporter.REPORTER_STATE_VERIFICATION_EMAIL_SENT, _signal=original._signal)
 
         new.cancel()
+        new.save()
+
+        self.assertEqual(new.state, Reporter.REPORTER_STATE_CANCELLED)
+        self.assertIsNone(new.email_verification_token)
 
     def test_cannot_transition_from_approved_to_cancelled(self) -> None:
         original = ReporterFactory.create(state=Reporter.REPORTER_STATE_APPROVED, email=self.EMAIL, phone=self.PHONE)

--- a/app/signals/apps/signals/tests/test_reporter_state_machine.py
+++ b/app/signals/apps/signals/tests/test_reporter_state_machine.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam
+import typing
+
+import pytest
+from django.test import TestCase
+from django_fsm import TransitionNotAllowed
+
+from signals.apps.signals.factories import ReporterFactory, SignalFactory
+from signals.apps.signals.models import Reporter
+
+
+class TestReporterStateMachine(TestCase):
+    EMAIL: typing.Final[str] = 'test@example.com'
+    PHONE: typing.Final[str] = '0123456789'
+
+    # transitions to cancelled
+    def test_can_transition_from_new_to_cancelled_when_not_original_reporter(self) -> None:
+        original = ReporterFactory.create(state=Reporter.REPORTER_STATE_APPROVED)
+        new = Reporter()
+        new._signal = original._signal
+        new.save()
+
+        new.cancel()
+
+    def test_cannot_transition_from_new_to_cancelled_when_original_reporter(self) -> None:
+        new = Reporter()
+        new._signal = SignalFactory.create(reporter=new)
+        new.save()
+
+        with pytest.raises(TransitionNotAllowed):
+            new.cancel()
+
+
+    def test_can_transition_from_verification_email_sent_to_cancelled(self) -> None:
+        original = ReporterFactory.create(state=Reporter.REPORTER_STATE_APPROVED, email=self.EMAIL, phone=self.PHONE)
+        new = ReporterFactory.create(state=Reporter.REPORTER_STATE_VERIFICATION_EMAIL_SENT, _signal=original._signal)
+
+        new.cancel()
+
+    def test_cannot_transition_from_approved_to_cancelled(self) -> None:
+        original = ReporterFactory.create(state=Reporter.REPORTER_STATE_APPROVED, email=self.EMAIL, phone=self.PHONE)
+        new = ReporterFactory.create(state=Reporter.REPORTER_STATE_APPROVED, _signal=original._signal)
+
+        with pytest.raises(TransitionNotAllowed) as e_info:
+            new.cancel()
+
+        self.assertEqual(str(e_info.value), "Can't switch from state 'approved' using method 'cancel'")
+
+    def test_cannot_transition_from_cancelled_to_cancelled(self) -> None:
+        original = ReporterFactory.create(state=Reporter.REPORTER_STATE_APPROVED, email=self.EMAIL, phone=self.PHONE)
+        new = ReporterFactory.create(state=Reporter.REPORTER_STATE_CANCELLED, _signal=original._signal)
+
+        with pytest.raises(TransitionNotAllowed) as e_info:
+            new.cancel()
+
+        self.assertEqual(str(e_info.value), "Can't switch from state 'cancelled' using method 'cancel'")

--- a/app/signals/apps/signals/tests/test_reporter_state_machine.py
+++ b/app/signals/apps/signals/tests/test_reporter_state_machine.py
@@ -31,7 +31,6 @@ class TestReporterStateMachine(TestCase):
         with pytest.raises(TransitionNotAllowed):
             new.cancel()
 
-
     def test_can_transition_from_verification_email_sent_to_cancelled(self) -> None:
         original = ReporterFactory.create(state=Reporter.REPORTER_STATE_APPROVED, email=self.EMAIL, phone=self.PHONE)
         new = ReporterFactory.create(state=Reporter.REPORTER_STATE_VERIFICATION_EMAIL_SENT, _signal=original._signal)


### PR DESCRIPTION
## Description

Implementation of the cancel transition in the state machine for updating the reporter information.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
