### PR TITLE
Introducing a new endpoint "signals/v1/private/categories/{category_id}/icon"

### DIFF
--- a/app/signals/apps/api/serializers/category.py
+++ b/app/signals/apps/api/serializers/category.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
+# Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from datapunt_api.rest import DisplayField, HALSerializer
 from rest_framework import serializers
 
@@ -128,6 +128,7 @@ class PrivateCategorySerializer(HALSerializer):
             'public_name',
             'is_public_accessible',
             'configuration',
+            'icon',
         )
         read_only_fields = (
             'slug',
@@ -212,3 +213,11 @@ class PrivateCategoryHistoryHalSerializer(serializers.ModelSerializer):
 
     def get_description(self, log: Log) -> None:
         return None  # No description implemented yet
+
+
+class PrivateCategoryIconSerializer(serializers.ModelSerializer):
+    icon = serializers.FileField(allow_empty_file=False, required=True)
+
+    class Meta:
+        model = Category
+        fields = ('icon', )

--- a/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -1368,6 +1368,91 @@ paths:
         - OAuth2:
           - SIG/ALL
 
+  /signals/v1/private/categories/{id}/icon/:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the category
+        required: true
+        schema:
+          type: integer
+    get:
+      responses:
+        '200':
+          description: The current icon set for the category
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  icon:
+                    type: string
+                    format: uri
+                    example: /signals/media/images/2023/07/24/icon.jpg
+
+        '401':
+          description: Not authenticated, may be caused by expired token
+        '403':
+          description: Forbidden, user not authorized
+        '404':
+          description: Category not found
+    patch:
+      description: Update the category icon
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                icon:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Updated the category icon
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden, user not authorized
+      security:
+        - OAuth2:
+            - SIG/ALL
+    put:
+      description: Update the category icon
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                icon:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Updated the category icon
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden, user not authorized
+      security:
+        - OAuth2:
+            - SIG/ALL
+    delete:
+      description: Delete the category icon
+      responses:
+        '200':
+          description: Deleted the category icon
+        '401':
+          description: Not authenticated, may be caused by expired token.
+        '403':
+          description: Forbidden, user not authorized
+      security:
+        - OAuth2:
+            - SIG/ALL
+
   /signals/v1/private/terms/categories/{main_slug}/status-message-templates/:
     parameters:
       - name: main_slug

--- a/app/signals/apps/api/urls.py
+++ b/app/signals/apps/api/urls.py
@@ -28,6 +28,7 @@ from signals.apps.api.views import (
     StatusMessageTemplatesViewSet,
     StoredSignalFilterViewSet
 )
+from signals.apps.api.views.category import PrivateCategoryIconViewSet
 from signals.apps.api.views.email_verification import EmailVerificationView
 from signals.apps.api.views.signals.private.signal_reporters import PrivateSignalReporterViewSet
 from signals.apps.api.views.status_message import (
@@ -138,6 +139,13 @@ urlpatterns = [
                 name='private-signal-context-reporter'),
         re_path(r'signals/(?P<pk>\d+)/context/near/geography/?$', SignalContextViewSet.as_view({'get': 'near'}),
                 name='private-signal-context-near-geography'),
+
+        re_path(r'categories/(?P<category_id>\d+)/icon',
+                PrivateCategoryIconViewSet.as_view({'get': 'retrieve',
+                                                    'put': 'update',
+                                                    'patch': 'update',
+                                                    'delete': 'destroy'}),
+                name='private-category-icon')
     ])),
 
     # Feedback

--- a/app/signals/apps/signals/factories/category.py
+++ b/app/signals/apps/signals/factories/category.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from django.utils.text import slugify
 from factory import LazyAttribute, Sequence, SubFactory, post_generation
-from factory.django import DjangoModelFactory
+from factory.django import DjangoModelFactory, ImageField
 from factory.fuzzy import FuzzyChoice
 
 from signals.apps.signals.models import Category
@@ -70,3 +70,7 @@ class CategoryFactory(DjangoModelFactory):
         if extracted:
             for question in extracted:
                 self.questions.add(question)
+
+
+class CategoryWithIconFactory(CategoryFactory):
+    icon = ImageField()


### PR DESCRIPTION
## Description

Introducing a new endpoint "signals/v1/private/categories/{category_id}/icon" for (C)RUD operations on the icon FileField of a Category

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
