### PR TITLE
Send confirmation email when not original reporter and when email address is available

### DIFF
--- a/app/signals/apps/signals/models/reporter.py
+++ b/app/signals/apps/signals/models/reporter.py
@@ -168,6 +168,12 @@ class Reporter(ConcurrentTransitionMixin, CreatedUpdatedModel):
         """
         Use this method to transition to the 'approved' state.
         """
+        if self.is_not_original() and self.email:
+            from signals.apps.email_integrations.email_verification.reporter_mailer import (
+                ReporterMailer
+            )
+            mail_reporter = ReporterMailer(EmailTemplateRenderer())
+            mail_reporter(self, EmailTemplate.CONFIRM_REPORTER_UPDATED)
 
     def anonymize(self, always_call_save: bool = False) -> None:
         call_save = False

--- a/app/signals/apps/signals/tests/test_reporter_state_machine.py
+++ b/app/signals/apps/signals/tests/test_reporter_state_machine.py
@@ -161,6 +161,7 @@ class TestReporterStateMachine(TestCase):
             new.approve()
 
     def test_can_transition_from_new_to_approved_when_email_included_but_not_changed_and_phone_changed(self):
+        EmailTemplateFactory.create(key=EmailTemplate.CONFIRM_REPORTER_UPDATED)
         original = ReporterFactory.create(state=Reporter.REPORTER_STATE_APPROVED, email=self.EMAIL, phone=self.PHONE)
         new = Reporter()
         new._signal = original._signal
@@ -182,6 +183,7 @@ class TestReporterStateMachine(TestCase):
             new.approve()
 
     def test_can_transition_from_verification_email_sent_to_approved(self):
+        EmailTemplateFactory.create(key=EmailTemplate.CONFIRM_REPORTER_UPDATED)
         original = ReporterFactory.create(state=Reporter.REPORTER_STATE_APPROVED, email=self.EMAIL, phone=self.PHONE)
         new = ReporterFactory.create(
             state=Reporter.REPORTER_STATE_VERIFICATION_EMAIL_SENT,


### PR DESCRIPTION
## Description

Send confirmation email when not original reporter and when email address is available

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
