### PR TITLE
Make token expires field available in api response

### DIFF
--- a/app/signals/apps/api/serializers/signal_reporter.py
+++ b/app/signals/apps/api/serializers/signal_reporter.py
@@ -22,6 +22,7 @@ class SignalReporterSerializer(ModelSerializer):
             'allows_contact',
             'sharing_allowed',
             'state',
+            'email_verification_token_expires',
             'created_at',
             'updated_at',
         )
@@ -30,6 +31,7 @@ class SignalReporterSerializer(ModelSerializer):
             'email_verified',
             'allows_contact',
             'state',
+            'email_verification_token_expires',
             'created_at',
             'updated_at',
         )

--- a/app/signals/apps/api/templates/api/swagger/openapi.yaml
+++ b/app/signals/apps/api/templates/api/swagger/openapi.yaml
@@ -947,6 +947,10 @@ paths:
                 phone:
                   description: The phone number of the reporter
                   type: string
+                sharing_allowed:
+                  description: Reporter allows their contact information to be shared (true) or not (false).
+                  type: boolean
+                  example: true
       responses:
         '400':
           description: Bad request
@@ -5738,6 +5742,11 @@ components:
             - cancelled
             - approved
           example: approved
+        email_verification_token_expires:
+          description: When the email verification expires
+          type: string
+          example: "2023-07-27T12:37:15.104Z"
+          nullable: true
 
     V1VerifyEmail:
       description: The email verification token


### PR DESCRIPTION
## Description

Make token expires field available in api response

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
