### PR TITLE
Make create() atomic so that cancellation of previous reporter is rolled back in case transitions fail

### DIFF
--- a/app/signals/apps/api/serializers/signal_reporter.py
+++ b/app/signals/apps/api/serializers/signal_reporter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2023 Gemeente Amsterdam
+from django.db import transaction
 from django.utils import timezone
 from django_fsm import TransitionNotAllowed
 from rest_framework.fields import BooleanField
@@ -72,6 +73,7 @@ class SignalReporterSerializer(ModelSerializer):
 
         return serialized
 
+    @transaction.atomic()
     def create(self, validated_data: dict) -> Reporter:
         signal_id = self.context['view'].kwargs.get('parent_lookup__signal_id')
         signal = Signal.objects.get(pk=signal_id)


### PR DESCRIPTION
## Description

Make create() atomic so that cancellation of previous reporter is rolled back in case transitions fail due to the optimistic locking protection: https://github.com/viewflow/django-fsm#optimistic-locking.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
