### PR TITLE
Refactored the "PrivateReportViewSet" into 2 separate viewsets so tha…

### DIFF
--- a/app/signals/apps/reporting/rest_framework/views.py
+++ b/app/signals/apps/reporting/rest_framework/views.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C)2021 Gemeente Amsterdam
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
 from django.db.models import Count
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import viewsets
-from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
 
 from signals.apps.api.generics.permissions import SIAPermissions
 from signals.apps.reporting.filters import (
@@ -16,23 +15,16 @@ from signals.apps.signals.models import Signal
 from signals.auth.backend import JWTAuthBackend
 
 
-class PrivateReportViewSet(viewsets.GenericViewSet):
+class _PrivateReportViewSet(GenericViewSet):
     authentication_classes = (JWTAuthBackend,)
     permission_classes = (SIAPermissions,)
-
+    queryset = Signal.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    serializer_class = ReportSignalsPerCategory
     pagination_class = None
 
-    queryset = Signal.objects.all()
-
-    filter_backends = (DjangoFilterBackend, )
-    filterset_class = None
-
-    def annotate_queryset(self, queryset):
-        """
-        This will make sure the queryset contains all the information needed to generate the report
-        A count of all Signals per category, ordered by the total Signals in a category
-        """
-        return queryset.values(
+    def get_queryset(self):
+        return self.filter_queryset(super().get_queryset()).values(
             'category_assignment__category_id',
         ).annotate(
             per_category_count=Count('category_assignment__category_id')
@@ -40,27 +32,15 @@ class PrivateReportViewSet(viewsets.GenericViewSet):
             '-per_category_count'
         )
 
-    @action(detail=False, url_path=r'signals/open', methods=['GET', ],
-            filterset_class=SignalsOpenPerCategoryCountFilterSet, serializer_class=ReportSignalsPerCategory)
-    def signals_open_per_category(self, *args, **kwargs):
-        """
-        Count all Signals that have a "open" state and return a summary per Category.
-
-        It is also possible to filter on a period using the "start_date" and "end_date" filters (query params)
-        """
-        queryset = self.annotate_queryset(self.filter_queryset(self.get_queryset()))
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
         serializer = self.get_serializer(queryset)
         return Response(serializer.data)
 
-    @action(detail=False, url_path=r'signals/reopen-requested', methods=['GET', ],
-            filterset_class=SignalsReopenRequestedPerCategoryCountFilterSet, serializer_class=ReportSignalsPerCategory)
-    def signals_reopen_requested_per_category(self, *args, **kwargs):
-        """
-        Count all Signals that are in the "reopen requested" state and return a summary per Category.
 
-        It is also possible to filter on the period the state change was made using the "start_date" and
-        "end_date" filters (query params)
-        """
-        queryset = self.annotate_queryset(self.filter_queryset(self.get_queryset()))
-        serializer = self.get_serializer(queryset)
-        return Response(serializer.data)
+class PrivateReportSignalsOpenPerCategoryView(_PrivateReportViewSet):
+    filterset_class = SignalsOpenPerCategoryCountFilterSet
+
+
+class PrivateReportSignalsReopenRequestedPerCategory(_PrivateReportViewSet):
+    filterset_class = SignalsReopenRequestedPerCategoryCountFilterSet

--- a/app/signals/apps/reporting/rest_framework/views.py
+++ b/app/signals/apps/reporting/rest_framework/views.py
@@ -39,8 +39,19 @@ class _PrivateReportViewSet(GenericViewSet):
 
 
 class PrivateReportSignalsOpenPerCategoryView(_PrivateReportViewSet):
+    """
+    Count all Signals that have an "open" state and return a summary per Category.
+
+    It is also possible to filter on a period using the "start" and "end" filters (query params)
+    """
     filterset_class = SignalsOpenPerCategoryCountFilterSet
 
 
 class PrivateReportSignalsReopenRequestedPerCategory(_PrivateReportViewSet):
+    """
+    Count all Signals that are in the "reopen requested" state and return a summary per Category.
+
+    It is also possible to filter on the period the state change was made using the "start" and
+    "end" filters (query params)
+    """
     filterset_class = SignalsReopenRequestedPerCategoryCountFilterSet

--- a/app/signals/apps/reporting/urls.py
+++ b/app/signals/apps/reporting/urls.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
-from django.urls import include, path
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+from django.urls import re_path
 
-from signals.apps.api.generics.routers import SignalsRouter
-from signals.apps.reporting.rest_framework.views import PrivateReportViewSet
-
-router = SignalsRouter()
-
-router.register(r'private/reports', PrivateReportViewSet, basename='private-reports')
-
+from signals.apps.reporting.rest_framework.views import (
+    PrivateReportSignalsOpenPerCategoryView,
+    PrivateReportSignalsReopenRequestedPerCategory
+)
 
 urlpatterns = [
-    path('', include((router.urls, 'signals.apps.reporting'), namespace='reporting')),
+    re_path(r'private/reports/signals/open/?',
+            PrivateReportSignalsOpenPerCategoryView.as_view({'get': 'list'}),
+            name='reporting-signals-open-per-category-view'),
+    re_path(r'private/reports/signals/reopen-requested/?',
+            PrivateReportSignalsReopenRequestedPerCategory.as_view({'get': 'list'}),
+            name='reporting-signals-reopen-requested-per-category-view'),
 ]


### PR DESCRIPTION
## Description

Refactored the "PrivateReportViewSet" into 2 separate viewsets so that drf-spectacular can render the openapi spec correctly.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
