### PR TITLE
Add schema extension to fix/improve API documentation

### DIFF
--- a/app/signals/apps/reporting/rest_framework/serializers.py
+++ b/app/signals/apps/reporting/rest_framework/serializers.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2021 - 2023 Gemeente Amsterdam
 from django.db.models import QuerySet
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from signals.apps.signals.models import Category
@@ -10,7 +11,7 @@ class _SimpleCategorySerializer(serializers.Serializer):
     name = serializers.CharField()
     departments = serializers.SerializerMethodField(method_name='get_departments')
 
-    def get_departments(self, obj: Category) -> tuple:
+    def get_departments(self, obj: Category) -> tuple[str, str]:
         return obj.categorydepartment_set.filter(
             is_responsible=True
         ).values_list(
@@ -23,6 +24,7 @@ class _SignalsPerCategoryCount(serializers.Serializer):
     category = serializers.SerializerMethodField()
     signal_count = serializers.IntegerField(source='per_category_count')
 
+    @extend_schema_field(_SimpleCategorySerializer)
     def get_category(self, obj: QuerySet) -> dict:
         category = Category.objects.get(id=obj['category_assignment__category_id'])
         serializer = _SimpleCategorySerializer(category, context=self.context)
@@ -33,6 +35,7 @@ class ReportSignalsPerCategory(serializers.Serializer):
     total_signal_count = serializers.SerializerMethodField()
     results = serializers.SerializerMethodField()
 
+    @extend_schema_field(_SignalsPerCategoryCount)
     def get_results(self, obj: QuerySet) -> dict:
         serializer = _SignalsPerCategoryCount(obj, many=True, context=self.context)
         return serializer.data


### PR DESCRIPTION
## Description

Add schema extension to fix/improve API documentation for the category-related data in the reporting endpoints


## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
