### PR TITLE
Add drf-spectacular schema extension to improve API documentation for private and public Area endpoints

### DIFF
--- a/app/signals/apps/api/serializers/area.py
+++ b/app/signals/apps/api/serializers/area.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from datapunt_api.serializers import HALSerializer
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework_gis.fields import GeometryField
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
@@ -34,6 +35,17 @@ class AreaSerializer(HALSerializer):
         model = Area
         fields = ('name', 'code', 'type', 'bbox', )
 
-    def get_bbox(self, obj):
+    @extend_schema_field({
+        'type': 'array',
+        'minItems': 4,
+        'maxItems': 4,
+        'items': {
+            'type': 'number',
+            'format': 'float',
+        },
+        'example': [4.728764, 52.278987, 5.068003, 52.431229],
+        'description': 'Bounding box as [min_x, min_y, max_x, max_y]',
+    })
+    def get_bbox(self, obj: Area) -> tuple[float, float, float, float]:
         if obj.geometry:
             return obj.geometry.extent

--- a/app/signals/apps/api/views/area.py
+++ b/app/signals/apps/api/views/area.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2020 - 2023 Gemeente Amsterdam
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.decorators import action
 from rest_framework.mixins import ListModelMixin
 from rest_framework.response import Response
@@ -21,8 +22,17 @@ class PublicAreasViewSet(ListModelMixin, GenericViewSet):
     serializer_class = AreaSerializer
     filterset_class = AreaFilterSet
 
-    @action(detail=False, url_path=r'geography/?$')
-    def geography(self, request):
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name='geopage', location=OpenApiParameter.QUERY,
+                             description='A page number within the paginated result set.', required=False, type=int),
+            OpenApiParameter(name='page_size', location=OpenApiParameter.QUERY,
+                             description='Number of results to return per page.', required=False, type=int),
+        ],
+    )
+    @action(detail=False, url_path='geography', serializer_class=AreaGeoSerializer,
+            pagination_class=LinkHeaderPagination)
+    def geography(self, *args: list, **kwargs: dict) -> Response:
         """
         Retrieve a paginated list of area geographies.
 


### PR DESCRIPTION
Add drf-spectacular schema extension to improve API documentation for private and public Area endpoints:

- /signals/v1/public/areas/
- /signals/v1/public/areas/geography
- /signals/v1/private/areas/
- /signals/v1/private/areas/geography

## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
