### PR TITLE
Add drf-spectacular schema extension to improve API documentation for private Department endpoint

### DIFF
--- a/app/signals/apps/api/views/departments.py
+++ b/app/signals/apps/api/views/departments.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2023 Gemeente Amsterdam
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.mixins import CreateModelMixin, UpdateModelMixin
 from rest_framework.response import Response
-from rest_framework.status import HTTP_201_CREATED
+from rest_framework.status import HTTP_200_OK, HTTP_201_CREATED
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from rest_framework_extensions.mixins import DetailSerializerMixin
 
@@ -16,6 +17,14 @@ from signals.apps.signals.models import Department
 from signals.auth.backend import JWTAuthBackend
 
 
+@extend_schema_view(
+    retrieve=extend_schema(description='Retrieve a department',
+                           responses={HTTP_200_OK: PrivateDepartmentSerializerDetail}),
+    update=extend_schema(responses={HTTP_200_OK: PrivateDepartmentSerializerDetail},
+                         description='Update a department'),
+    partial_update=extend_schema(responses={HTTP_200_OK: PrivateDepartmentSerializerDetail},
+                                 description='Partial update a department'),
+)
 class PrivateDepartmentViewSet(CreateModelMixin, DetailSerializerMixin, UpdateModelMixin, ReadOnlyModelViewSet):
     queryset = Department.objects.all()
     filterset_class = DepartmentFilterSet
@@ -25,10 +34,12 @@ class PrivateDepartmentViewSet(CreateModelMixin, DetailSerializerMixin, UpdateMo
     serializer_detail_class = PrivateDepartmentSerializerDetail
 
     authentication_classes = (JWTAuthBackend,)
-    permission_classes = (SIAPermissions & ModelWritePermissions, )
+    permission_classes = (SIAPermissions & ModelWritePermissions,)
 
-    def create(self, request, *args, **kwargs):
-        # If we create a department we want to use the detail serializer
+    @extend_schema(responses={HTTP_201_CREATED: PrivateDepartmentSerializerDetail},
+                   description='Create a department')
+    def create(self, request, *args: list, **kwargs: dict):
+        # If we create a department, we want to use the detail serializer
         serializer = self.serializer_detail_class(data=request.data,
                                                   context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
## Description

Add drf-spectacular schema extension to improve API documentation for private Department (CRU) endpoint


## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
