### PR TITLE
Refactored: No longer use DataPuntViewSet and DataPuntViewSetWritable

### DIFF
--- a/app/signals/apps/api/views/questions.py
+++ b/app/signals/apps/api/views/questions.py
@@ -1,18 +1,16 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
-from datapunt_api.rest import DatapuntViewSet, HALPagination
+# Copyright (C) 2020 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from signals.apps.api.filters import QuestionFilterSet
 from signals.apps.api.serializers import PublicQuestionSerializerDetail
 from signals.apps.signals.models import Question
 
 
-class PublicQuestionViewSet(DatapuntViewSet):
+class PublicQuestionViewSet(ReadOnlyModelViewSet):
     queryset = Question.objects.all()
 
     serializer_class = PublicQuestionSerializerDetail
-    serializer_detail_class = PublicQuestionSerializerDetail
-    pagination_class = HALPagination
-    filter_backends = (DjangoFilterBackend, )
+    filter_backends = (DjangoFilterBackend,)
     filterset_class = QuestionFilterSet

--- a/app/signals/apps/search/rest_framework/views.py
+++ b/app/signals/apps/search/rest_framework/views.py
@@ -2,13 +2,14 @@
 # Copyright (C) 2019 - 2023 Gemeente Amsterdam
 from typing import Optional
 
-from datapunt_api.rest import DatapuntViewSet
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from elasticsearch_dsl.query import MultiMatch
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework_extensions.mixins import DetailSerializerMixin
 
 from signals.apps.api.generics.exceptions import GatewayTimeoutException
 from signals.apps.api.generics.permissions import SIAPermissions
@@ -21,7 +22,7 @@ from signals.apps.signals.models import Signal
 from signals.auth.backend import JWTAuthBackend
 
 
-class SearchView(DatapuntViewSet):
+class SearchView(DetailSerializerMixin, ReadOnlyModelViewSet):
     authentication_classes = (JWTAuthBackend,)
     permission_classes = (SIAPermissions,)
 


### PR DESCRIPTION
## Description

Refactored DataPuntViewSet and DataPuntViewSetWritable to the correct DRF and DRF extensions classes

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
