### PR TITLE
Fixed issue in storing the Feedback text_list

### DIFF
--- a/app/signals/apps/feedback/rest_framework/serializers.py
+++ b/app/signals/apps/feedback/rest_framework/serializers.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2019 - 2023 Gemeente Amsterdam
+from collections import OrderedDict
+
 from django.db.models import Q
 from django.utils import timezone
 from rest_framework import serializers
@@ -51,7 +53,10 @@ class FeedbackSerializer(serializers.ModelSerializer):
         text_list = attrs.get('text_list', [])
         if text:
             text_list.append(text)
-        attrs['text_list'] = list(set(text_list))
+
+        # Remove duplicate answers but keep the order intact
+        ordered_text_dict = OrderedDict.fromkeys(text_list)
+        attrs['text_list'] = list(ordered_text_dict.keys())
 
         # Call the super validate method
         return super().validate(attrs)


### PR DESCRIPTION
## Description

Fixed issue in storing the Feedback text_list in the order it was provided

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
