### PR TITLE
Replace 'raven' with 'sentry-sdk' for modern error tracking in Django.

### DIFF
--- a/app/logs/config.py
+++ b/app/logs/config.py
@@ -25,7 +25,7 @@ BASE_LOGGING = {
     'handlers': {
         'sentry': {
             'level': 'WARNING',
-            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+            'class': 'sentry_sdk.integrations.logging.EventHandler',
         },
         'colorize': {
             'class': 'logs.handlers.ColoredHandler',

--- a/app/requirements/requirements.in
+++ b/app/requirements/requirements.in
@@ -44,8 +44,8 @@ psycopg2-binary
 pypdf
 python-dateutil
 python-magic
-raven
 requests
+sentry-sdk
 textX
 types-cryptography
 uWSGI

--- a/app/requirements/requirements.txt
+++ b/app/requirements/requirements.txt
@@ -55,6 +55,7 @@ certifi==2023.7.22
     # via
     #   elasticsearch
     #   requests
+    #   sentry-sdk
 cffi==1.15.1
     # via
     #   cairocffi
@@ -331,8 +332,6 @@ pyyaml==6.0.1
     # via
     #   drf-spectacular
     #   flex
-raven==6.10.0
-    # via -r requirements/requirements.in
 referencing==0.30.0
     # via
     #   jsonschema
@@ -361,6 +360,8 @@ rpds-py==0.9.2
     #   referencing
 rsa==4.9
     # via google-auth
+sentry-sdk==1.29.2
+    # via -r requirements/requirements.in
 simplejson==3.19.1
     # via django-rest-swagger
 six==1.16.0
@@ -417,6 +418,7 @@ urllib3==1.26.16
     #   elasticsearch
     #   google-auth
     #   requests
+    #   sentry-sdk
 uwsgi==2.0.22
     # via -r requirements/requirements.in
 validate-email==1.3

--- a/app/requirements/requirements_dev.txt
+++ b/app/requirements/requirements_dev.txt
@@ -72,6 +72,7 @@ certifi==2023.7.22
     #   -r requirements/requirements_test.txt
     #   elasticsearch
     #   requests
+    #   sentry-sdk
 cffi==1.15.1
     # via
     #   -r requirements/requirements_test.txt
@@ -545,8 +546,6 @@ pyyaml==6.0.1
     #   -r requirements/requirements_test.txt
     #   drf-spectacular
     #   flex
-raven==6.10.0
-    # via -r requirements/requirements_test.txt
 referencing==0.30.0
     # via
     #   -r requirements/requirements_test.txt
@@ -586,6 +585,8 @@ rsa==4.9
     # via
     #   -r requirements/requirements_test.txt
     #   google-auth
+sentry-sdk==1.29.2
+    # via -r requirements/requirements_test.txt
 simplejson==3.19.1
     # via
     #   -r requirements/requirements_test.txt
@@ -667,6 +668,7 @@ urllib3==1.26.16
     #   elasticsearch
     #   google-auth
     #   requests
+    #   sentry-sdk
 uwsgi==2.0.22
     # via -r requirements/requirements_test.txt
 validate-email==1.3

--- a/app/requirements/requirements_test.txt
+++ b/app/requirements/requirements_test.txt
@@ -72,6 +72,7 @@ certifi==2023.7.22
     #   -r requirements/requirements.txt
     #   elasticsearch
     #   requests
+    #   sentry-sdk
 cffi==1.15.1
     # via
     #   -r requirements/requirements.txt
@@ -518,8 +519,6 @@ pyyaml==6.0.1
     #   -r requirements/requirements.txt
     #   drf-spectacular
     #   flex
-raven==6.10.0
-    # via -r requirements/requirements.txt
 referencing==0.30.0
     # via
     #   -r requirements/requirements.txt
@@ -559,6 +558,8 @@ rsa==4.9
     # via
     #   -r requirements/requirements.txt
     #   google-auth
+sentry-sdk==1.29.2
+    # via -r requirements/requirements.txt
 simplejson==3.19.1
     # via
     #   -r requirements/requirements.txt
@@ -639,6 +640,7 @@ urllib3==1.26.16
     #   elasticsearch
     #   google-auth
     #   requests
+    #   sentry-sdk
 uwsgi==2.0.22
     # via -r requirements/requirements.txt
 validate-email==1.3

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -2,6 +2,9 @@
 # Copyright (C) 2018 - 2023 Gemeente Amsterdam
 import os
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
 from signals import __version__
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -84,7 +87,6 @@ INSTALLED_APPS = [
     'django_filters',
     'djcelery_email',
     'markdownx',
-    'raven.contrib.django.raven_compat',
     'rest_framework',
     'rest_framework_gis',
     'storages',
@@ -323,9 +325,10 @@ CELERY_EMAIL_TASK_CONFIG = {
 }
 
 # Sentry logging
-RAVEN_CONFIG = {
-    'dsn': os.getenv('SENTRY_RAVEN_DSN'),
-}
+sentry_sdk.init(
+    dsn=os.getenv('SENTRY_RAVEN_DSN'),
+    integrations=[DjangoIntegration()],
+)
 
 # Azure Application insights logging
 AZURE_APPLICATION_INSIGHTS_ENABLED = os.getenv('AZURE_APPLICATION_INSIGHTS_ENABLED', False) in TRUE_VALUES


### PR DESCRIPTION
## Description

Replace 'raven' with 'sentry-sdk' for modern error tracking in Django.

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
