### PR TITLE
url('') is deprecated changed to re_path('')

### DIFF
--- a/app/signals/urls.py
+++ b/app/signals/urls.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2018 - 2023 Gemeente Amsterdam
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from signals.admin.oidc import views as admin_oidc_views
@@ -22,7 +21,7 @@ urlpatterns = [
 
     # The Django admin
     path('signals/admin/', admin.site.urls),
-    url(r'^signals/markdownx/', include('markdownx.urls')),
+    re_path(r'^signals/markdownx/', include('markdownx.urls')),
 
     # SOAP stand-in endpoints
     path('signals/sigmax/', include('signals.apps.sigmax.urls')),


### PR DESCRIPTION
## Description

the use of url('') is deprecated changed to re_path('') when declaring the endpoint for the markdownx urls

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
