### PR TITLE
assertEquals is deprecated, changed the remainig assertEquals into assertEqual

### DIFF
--- a/app/signals/apps/signals/tests/test_models.py
+++ b/app/signals/apps/signals/tests/test_models.py
@@ -648,9 +648,9 @@ class TestCategory(TestCase):
                     parent_category.save()
 
                 validation_error = e.exception
-                self.assertEquals(len(validation_error.error_dict['configuration']), 1)
-                self.assertEquals(validation_error.error_dict['configuration'][0].message,
-                                  'Value of "show_children_in_filter" is not a valid boolean')
+                self.assertEqual(len(validation_error.error_dict['configuration']), 1)
+                self.assertEqual(validation_error.error_dict['configuration'][0].message,
+                                 'Value of "show_children_in_filter" is not a valid boolean')
 
     def test_only_show_in_filter_parent_category_configuration(self):
         """
@@ -666,8 +666,8 @@ class TestCategory(TestCase):
             parent_category.save()
 
         validation_error = e.exception
-        self.assertEquals(validation_error.error_dict['configuration'][0].message,
-                          'The "show_children_in_filter" is required for parent categories')
+        self.assertEqual(validation_error.error_dict['configuration'][0].message,
+                         'The "show_children_in_filter" is required for parent categories')
 
         parent_category.configuration = {'show_children_in_filter': True, 'not': 'allowed'}
 
@@ -675,9 +675,9 @@ class TestCategory(TestCase):
             parent_category.save()
 
         validation_error = e.exception
-        self.assertEquals(len(validation_error.error_dict['configuration']), 1)
-        self.assertEquals(validation_error.error_dict['configuration'][0].message,
-                          'Only "show_children_in_filter" is allowed')
+        self.assertEqual(len(validation_error.error_dict['configuration']), 1)
+        self.assertEqual(validation_error.error_dict['configuration'][0].message,
+                         'Only "show_children_in_filter" is allowed')
 
     def test_invalid_show_in_filter_and_additional_config_parent_category_configuration(self):
         """
@@ -703,7 +703,7 @@ class TestCategory(TestCase):
                     parent_category.save()
 
                 validation_error = e.exception
-                self.assertEquals(len(validation_error.error_dict['configuration']), 2)
+                self.assertEqual(len(validation_error.error_dict['configuration']), 2)
                 messages = [ve.message for ve in validation_error.error_dict['configuration']]
                 self.assertIn('Value of "show_children_in_filter" is not a valid boolean', messages)
                 self.assertIn('Only "show_children_in_filter" is allowed', messages)


### PR DESCRIPTION
## Description

assertEquals is deprecated, changed the remainig assertEquals into assertEqual

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
