### PR TITLE
Make retries and retry delay configurable

### DIFF
--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -320,6 +320,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 CELERY_EMAIL_CHUNK_SIZE = 1
 CELERY_EMAIL_TASK_CONFIG = {
     'ignore_result': False,
+    'max_retries': os.getenv('CELERY_EMAIL_TASK_CONFIG_MAX_RETRIES', 3),
+    'default_retry_delay': os.getenv('CELERY_EMAIL_TASK_CONFIG_DEFAULT_RETRY_DELAY', 60 * 3)
 }
 
 # Sentry logging


### PR DESCRIPTION
## Description

Currently Signalen only attempts to deliver an e-mail 3 times with a retry delay of 3 minutes. So when an e-mailserver is not available for 9 minutes, e-mails get lost.

This PR makes these settings configurable.

Open question: there is currently no way of knowing if an e-mail was actually sent or not. Maybe we can store this somewhere, so there is a way to manually retry.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
