### PR TITLE
Fix FactoryBoy DeprecationWarning on postgeneration

### DIFF
--- a/app/signals/apps/email_integrations/factories.py
+++ b/app/signals/apps/email_integrations/factories.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
@@ -9,7 +9,8 @@ from signals.apps.email_integrations.models import EmailTemplate
 class EmailTemplateFactory(DjangoModelFactory):
     class Meta:
         model = EmailTemplate
-        django_get_or_create = ('key', )
+        django_get_or_create = ('key',)
+        skip_postgeneration_save = True
 
     key = EmailTemplate.SIGNAL_CREATED
     title = 'Uw melding {{ signal_id }}'

--- a/app/signals/apps/feedback/factories.py
+++ b/app/signals/apps/feedback/factories.py
@@ -22,6 +22,8 @@ REASONS = [
 class StandardAnswerTopicFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = StandardAnswerTopic
+        skip_postgeneration_save = True
+
     name = factory.Sequence(lambda n: 'topic name: {}'.format(n))
     description = factory.Sequence(lambda n: 'topic text: {}'.format(n))
     order = fuzzy.FuzzyChoice([0, 1, 2, 3, 4, 5])
@@ -30,6 +32,7 @@ class StandardAnswerTopicFactory(factory.django.DjangoModelFactory):
 class StandardAnswerFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = StandardAnswer
+        skip_postgeneration_save = True
 
     text = factory.Sequence(lambda n: 'Unieke klaag tekst nummer: {}'.format(n))
     is_visible = fuzzy.FuzzyChoice([True, False])
@@ -41,6 +44,7 @@ class StandardAnswerFactory(factory.django.DjangoModelFactory):
 class FeedbackFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Feedback
+        skip_postgeneration_save = True
 
     _signal = factory.SubFactory('signals.apps.signals.factories.SignalFactory')
     created_at = factory.LazyFunction(timezone.now)

--- a/app/signals/apps/my_signals/factories.py
+++ b/app/signals/apps/my_signals/factories.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Gemeente Amsterdam
+# Copyright (C) 2022 - 2023 Gemeente Amsterdam
 import factory
 import faker
 from factory.django import DjangoModelFactory
@@ -12,6 +12,7 @@ fake = faker.Faker()
 class TokenFactory(DjangoModelFactory):
     class Meta:
         model = Token
+        skip_postgeneration_save = True
 
     reporter_email = factory.LazyAttribute(
         lambda o: fake.email()

--- a/app/signals/apps/questionnaires/factories.py
+++ b/app/signals/apps/questionnaires/factories.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 Gemeente Amsterdam
+# Copyright (C) 2021 - 2023 Gemeente Amsterdam
 from factory import LazyFunction, SelfAttribute, Sequence, SubFactory
 from factory.django import DjangoModelFactory
 from faker import Faker
@@ -32,6 +32,7 @@ class QuestionFactory(DjangoModelFactory):
 
     class Meta:
         model = Question
+        skip_postgeneration_save = True
 
 
 class QuestionGraphFactory(DjangoModelFactory):
@@ -40,6 +41,7 @@ class QuestionGraphFactory(DjangoModelFactory):
 
     class Meta:
         model = QuestionGraph
+        skip_postgeneration_save = True
 
 
 class ChoiceFactory(DjangoModelFactory):
@@ -47,6 +49,7 @@ class ChoiceFactory(DjangoModelFactory):
 
     class Meta:
         model = Choice
+        skip_postgeneration_save = True
 
 
 class EdgeFactory(DjangoModelFactory):
@@ -57,6 +60,7 @@ class EdgeFactory(DjangoModelFactory):
 
     class Meta:
         model = Edge
+        skip_postgeneration_save = True
 
 
 class TriggerFactory(DjangoModelFactory):
@@ -65,6 +69,7 @@ class TriggerFactory(DjangoModelFactory):
 
     class Meta:
         model = Trigger
+        skip_postgeneration_save = True
 
 
 class QuestionnaireFactory(DjangoModelFactory):
@@ -78,6 +83,7 @@ class QuestionnaireFactory(DjangoModelFactory):
 
     class Meta:
         model = Questionnaire
+        skip_postgeneration_save = True
 
 
 class SessionFactory(DjangoModelFactory):
@@ -88,6 +94,7 @@ class SessionFactory(DjangoModelFactory):
 
     class Meta:
         model = Session
+        skip_postgeneration_save = True
 
 
 class AnswerFactory(DjangoModelFactory):
@@ -97,3 +104,4 @@ class AnswerFactory(DjangoModelFactory):
 
     class Meta:
         model = Answer
+        skip_postgeneration_save = True

--- a/app/signals/apps/sigmax/factories.py
+++ b/app/signals/apps/sigmax/factories.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import factory
 from django.utils import timezone
 from factory import fuzzy
@@ -10,6 +10,7 @@ from signals.apps.sigmax.models import CityControlRoundtrip
 class CityControlRoundtripFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = CityControlRoundtrip
+        skip_postgeneration_save = True
 
     _signal = factory.SubFactory('signals.apps.signals.factories.SignalFactory')
     when = fuzzy.FuzzyDateTime(timezone.now())

--- a/app/signals/apps/signals/factories/area.py
+++ b/app/signals/apps/signals/factories/area.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import random
 
 from django.contrib.gis.geos import MultiPolygon, Polygon
@@ -32,6 +32,7 @@ def get_random_bbox(bbox=BBOX, n_lon_subdiv=10, n_lat_subdiv=10):
 class AreaTypeFactory(DjangoModelFactory):
     class Meta:
         model = AreaType
+        skip_postgeneration_save = True
 
     name = Sequence(lambda n: f'Gebied type {n}')
     code = Sequence(lambda n: f'gebied-type-code-{n}')
@@ -41,6 +42,7 @@ class AreaTypeFactory(DjangoModelFactory):
 class AreaFactory(DjangoModelFactory):
     class Meta:
         model = Area
+        skip_postgeneration_save = True
 
     name = Sequence(lambda n: f'Gebied type {n}')
     code = Sequence(lambda n: f'gebied-type-code-{n}')

--- a/app/signals/apps/signals/factories/attachment.py
+++ b/app/signals/apps/signals/factories/attachment.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import Sequence, SubFactory, post_generation
 from factory.django import DjangoModelFactory, FileField, ImageField
 
@@ -9,6 +9,7 @@ from signals.apps.signals.models import Attachment
 class AttachmentFactory(DjangoModelFactory):
     class Meta:
         model = Attachment
+        skip_postgeneration_save = True
 
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory')
     created_by = Sequence(lambda n: 'veelmelder{}@example.com'.format(n))

--- a/app/signals/apps/signals/factories/buurt.py
+++ b/app/signals/apps/signals/factories/buurt.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
@@ -9,6 +9,7 @@ from signals.apps.signals.models import Buurt
 class BuurtFactory(DjangoModelFactory):
     class Meta:
         model = Buurt
+        skip_postgeneration_save = True
 
     id = FuzzyText(length=14)
     vollcode = FuzzyText(length=4)

--- a/app/signals/apps/signals/factories/category.py
+++ b/app/signals/apps/signals/factories/category.py
@@ -20,7 +20,8 @@ class ParentCategoryFactory(DjangoModelFactory):
 
     class Meta:
         model = Category
-        django_get_or_create = ('slug', )
+        django_get_or_create = ('slug',)
+        skip_postgeneration_save = True
 
     @post_generation
     def questions(self, create, extracted, **kwargs):
@@ -30,6 +31,7 @@ class ParentCategoryFactory(DjangoModelFactory):
         if extracted:
             for question in extracted:
                 self.questions.add(question)
+            self.save()
 
 
 class CategoryFactory(DjangoModelFactory):
@@ -45,7 +47,8 @@ class CategoryFactory(DjangoModelFactory):
 
     class Meta:
         model = Category
-        django_get_or_create = ('parent', 'slug', )
+        django_get_or_create = ('parent', 'slug',)
+        skip_postgeneration_save = True
 
     @post_generation
     def departments(self, create, extracted, **kwargs):
@@ -61,6 +64,7 @@ class CategoryFactory(DjangoModelFactory):
                         'can_view': True
                     }
                 )
+            self.save()
 
     @post_generation
     def questions(self, create, extracted, **kwargs):
@@ -70,6 +74,7 @@ class CategoryFactory(DjangoModelFactory):
         if extracted:
             for question in extracted:
                 self.questions.add(question)
+            self.save()
 
 
 class CategoryWithIconFactory(CategoryFactory):

--- a/app/signals/apps/signals/factories/category_assignment.py
+++ b/app/signals/apps/signals/factories/category_assignment.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import SubFactory, post_generation
 from factory.django import DjangoModelFactory
 
@@ -9,6 +9,7 @@ from signals.apps.signals.models import CategoryAssignment
 class CategoryAssignmentFactory(DjangoModelFactory):
     class Meta:
         model = CategoryAssignment
+        skip_postgeneration_save = True
 
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory', category_assignment=None)
     category = SubFactory('signals.apps.signals.factories.category.CategoryFactory')
@@ -16,3 +17,4 @@ class CategoryAssignmentFactory(DjangoModelFactory):
     @post_generation
     def set_one_to_one_relation(self, create, extracted, **kwargs):
         self.signal = self._signal
+        self.save()

--- a/app/signals/apps/signals/factories/category_departments.py
+++ b/app/signals/apps/signals/factories/category_departments.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
@@ -10,6 +10,7 @@ from signals.apps.signals.models import CategoryDepartment
 class CategoryDepartmentFactory(DjangoModelFactory):
     class Meta:
         model = CategoryDepartment
+        skip_postgeneration_save = True
 
     category = SubFactory('signals.apps.signals.factories.category.CategoryFactory')
     department = SubFactory('signals.apps.signals.factories.department.DepartmentFactory')

--- a/app/signals/apps/signals/factories/category_question.py
+++ b/app/signals/apps/signals/factories/category_question.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import Sequence, SubFactory
 from factory.django import DjangoModelFactory
 
@@ -9,6 +9,7 @@ from signals.apps.signals.models import CategoryQuestion
 class CategoryQuestionFactory(DjangoModelFactory):
     class Meta:
         model = CategoryQuestion
+        skip_postgeneration_save = True
 
     category = SubFactory('signals.apps.signals.factories.category.CategoryFactory')
     question = SubFactory('signals.apps.signals.factories.question.QuestionFactory')

--- a/app/signals/apps/signals/factories/department.py
+++ b/app/signals/apps/signals/factories/department.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from string import ascii_uppercase
 
 from factory import LazyFunction
@@ -20,3 +20,4 @@ class DepartmentFactory(DjangoModelFactory):
 
     class Meta:
         model = Department
+        skip_postgeneration_save = True

--- a/app/signals/apps/signals/factories/expression.py
+++ b/app/signals/apps/signals/factories/expression.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import Sequence, SubFactory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText
@@ -10,6 +10,7 @@ from signals.apps.signals.models import Expression, ExpressionContext, Expressio
 class ExpressionTypeFactory(DjangoModelFactory):
     class Meta:
         model = ExpressionType
+        skip_postgeneration_save = True
 
     name = Sequence(lambda n: f'type_{n}')
     description = Sequence(lambda n: f'Omschrijving voor expressie type_{n}')
@@ -22,11 +23,13 @@ class ExpressionFactory(DjangoModelFactory):
 
     class Meta:
         model = Expression
+        skip_postgeneration_save = True
 
 
 class ExpressionContextFactory(DjangoModelFactory):
     class Meta:
         model = ExpressionContext
+        skip_postgeneration_save = True
 
     identifier = Sequence(lambda n: f'ident_{n}')
     identifier_type = FuzzyChoice(choices=list(dict(ExpressionContext.CTX_TYPE_CHOICES).keys()))

--- a/app/signals/apps/signals/factories/location.py
+++ b/app/signals/apps/signals/factories/location.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import copy
 import random
 
@@ -25,6 +25,7 @@ class LocationFactory(DjangoModelFactory):
 
     class Meta:
         model = Location
+        skip_postgeneration_save = True
 
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory', location=None)
 
@@ -39,6 +40,7 @@ class LocationFactory(DjangoModelFactory):
     @post_generation
     def set_one_to_one_relation(self, create, extracted, **kwargs):
         self.signal = self._signal
+        self.save()
 
 
 class ValidLocationFactory(LocationFactory):
@@ -52,3 +54,4 @@ class ValidLocationFactory(LocationFactory):
         self.buurt_code = valid_location.pop('buurt_code')
         self.stadsdeel = valid_location.pop('stadsdeel')
         self.address = valid_location
+        self.save()

--- a/app/signals/apps/signals/factories/note.py
+++ b/app/signals/apps/signals/factories/note.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import Sequence, SubFactory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
@@ -14,3 +14,4 @@ class NoteFactory(DjangoModelFactory):
 
     class Meta:
         model = Note
+        skip_postgeneration_save = True

--- a/app/signals/apps/signals/factories/priority.py
+++ b/app/signals/apps/signals/factories/priority.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import SubFactory, post_generation
 from factory.django import DjangoModelFactory
 
@@ -10,9 +10,11 @@ class PriorityFactory(DjangoModelFactory):
 
     class Meta:
         model = Priority
+        skip_postgeneration_save = True
 
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory', priority=None)
 
     @post_generation
     def set_one_to_one_relation(self, create, extracted, **kwargs):
         self.signal = self._signal
+        self.save()

--- a/app/signals/apps/signals/factories/question.py
+++ b/app/signals/apps/signals/factories/question.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText
 
@@ -14,3 +14,4 @@ class QuestionFactory(DjangoModelFactory):
 
     class Meta:
         model = Question
+        skip_postgeneration_save = True

--- a/app/signals/apps/signals/factories/reporter.py
+++ b/app/signals/apps/signals/factories/reporter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from string import digits
 
 from factory import Sequence, SubFactory, post_generation
@@ -13,6 +13,7 @@ class ReporterFactory(DjangoModelFactory):
 
     class Meta:
         model = Reporter
+        skip_postgeneration_save = True
 
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory', reporter=None)
 
@@ -25,3 +26,4 @@ class ReporterFactory(DjangoModelFactory):
     @post_generation
     def set_one_to_one_relation(self, create, extracted, **kwargs):
         self.signal = self._signal
+        self.save()

--- a/app/signals/apps/signals/factories/routing_expression.py
+++ b/app/signals/apps/signals/factories/routing_expression.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 from factory import Sequence, SubFactory
 from factory.django import DjangoModelFactory
 
@@ -9,6 +9,7 @@ from signals.apps.signals.models import RoutingExpression
 class RoutingExpressionFactory(DjangoModelFactory):
     class Meta:
         model = RoutingExpression
+        skip_postgeneration_save = True
 
     _expression = SubFactory('signals.apps.signals.factories.expression.ExpressionFactory')
     _department = SubFactory('signals.apps.signals.factories.expression.DepartmentFactory')

--- a/app/signals/apps/signals/factories/signal.py
+++ b/app/signals/apps/signals/factories/signal.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import uuid
 from datetime import timedelta
 
@@ -62,6 +62,17 @@ class SignalFactory(DjangoModelFactory):
         self.reporter = self.reporters.last()
         self.priority = self.priorities.last()
         self.type_assignment = self.types.last()
+
+    @classmethod
+    def _after_postgeneration(cls, instance, create, results=None):
+        """Save again the instance if creating and at least one hook ran.
+
+        Deprecated: https://factoryboy.readthedocs.io/en/stable/changelog.html
+        To fix this warning, we override _after_postgeneration to save() the instance.
+        """
+        if create:
+            # Some post-generation hooks ran, and may have modified us.
+            instance.save()
 
 
 class SignalFactoryWithImage(SignalFactory):

--- a/app/signals/apps/signals/factories/signal_departments.py
+++ b/app/signals/apps/signals/factories/signal_departments.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import Sequence, SubFactory, post_generation
 from factory.django import DjangoModelFactory
 
@@ -9,6 +9,7 @@ from signals.apps.signals.models import SignalDepartments
 class SignalDepartmentsFactory(DjangoModelFactory):
     class Meta:
         model = SignalDepartments
+        skip_postgeneration_save = True
 
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory', category_assignment=None)
     created_by = Sequence(lambda n: 'beheerder{}@example.com'.format(n))
@@ -17,6 +18,7 @@ class SignalDepartmentsFactory(DjangoModelFactory):
     @post_generation
     def set_one_to_one_relation(self, create, extracted, **kwargs):
         self.signal = self._signal
+        self.save()
 
     @post_generation
     def departments(self, create, extracted, **kwargs):
@@ -27,3 +29,4 @@ class SignalDepartmentsFactory(DjangoModelFactory):
             # A list of groups were passed in, use them
             for department in extracted:
                 self.departments.add(department)
+            self.save()

--- a/app/signals/apps/signals/factories/signal_user.py
+++ b/app/signals/apps/signals/factories/signal_user.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 from factory import Sequence, SubFactory, post_generation
 from factory.django import DjangoModelFactory
 
@@ -9,6 +9,7 @@ from signals.apps.signals.models.signal_user import SignalUser
 class SignalUserFactory(DjangoModelFactory):
     class Meta:
         model = SignalUser
+        skip_postgeneration_save = True
 
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory')
     created_by = Sequence(lambda n: 'beheerder{}@example.com'.format(n))
@@ -17,3 +18,4 @@ class SignalUserFactory(DjangoModelFactory):
     @post_generation
     def set_one_to_one_relation(self, create, extracted, **kwargs):
         self.signal = self._signal
+        self.save()

--- a/app/signals/apps/signals/factories/slo.py
+++ b/app/signals/apps/signals/factories/slo.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from django.utils import timezone
 from factory import Sequence, SubFactory
 from factory.django import DjangoModelFactory
@@ -11,6 +11,7 @@ from signals.apps.signals.models import ServiceLevelObjective
 class ServiceLevelObjectiveFactory(DjangoModelFactory):
     class Meta:
         model = ServiceLevelObjective
+        skip_postgeneration_save = True
 
     category = SubFactory('signals.apps.signals.factories.category.CategoryFactory')
     n_days = FuzzyInteger(3, 7)

--- a/app/signals/apps/signals/factories/source.py
+++ b/app/signals/apps/signals/factories/source.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import Sequence
 from factory.django import DjangoModelFactory
 
@@ -9,6 +9,7 @@ from signals.apps.signals.models import Source
 class SourceFactory(DjangoModelFactory):
     class Meta:
         model = Source
+        skip_postgeneration_save = True
 
     name = Sequence(lambda n: f'Bron {n}')
     description = Sequence(lambda n: f'Beschrijving bron {n}')

--- a/app/signals/apps/signals/factories/status.py
+++ b/app/signals/apps/signals/factories/status.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import Sequence, SubFactory, post_generation
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText
@@ -12,6 +12,7 @@ class StatusFactory(DjangoModelFactory):
 
     class Meta:
         model = Status
+        skip_postgeneration_save = True
 
     _signal = SubFactory('signals.apps.signals.factories.signal.SignalFactory', status=None)
 
@@ -23,3 +24,4 @@ class StatusFactory(DjangoModelFactory):
     @post_generation
     def set_one_to_one_relation(self, create, extracted, **kwargs):
         self.signal = self._signal
+        self.save()

--- a/app/signals/apps/signals/factories/status_message.py
+++ b/app/signals/apps/signals/factories/status_message.py
@@ -15,6 +15,7 @@ class StatusMessageFactory(DjangoModelFactory):
 
     class Meta:
         model = StatusMessage
+        skip_postgeneration_save = True
 
 
 class StatusMessageCategoryFactory(DjangoModelFactory):

--- a/app/signals/apps/signals/factories/status_message_template.py
+++ b/app/signals/apps/signals/factories/status_message_template.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2022 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText
@@ -18,3 +18,4 @@ class StatusMessageTemplateFactory(DjangoModelFactory):
 
     class Meta:
         model = StatusMessageTemplate
+        skip_postgeneration_save = True

--- a/app/signals/apps/signals/factories/stored_signal_filter.py
+++ b/app/signals/apps/signals/factories/stored_signal_filter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText
@@ -15,3 +15,4 @@ class StoredSignalFilterFactory(DjangoModelFactory):
 
     class Meta:
         model = StoredSignalFilter
+        skip_postgeneration_save = True

--- a/app/signals/apps/signals/factories/type.py
+++ b/app/signals/apps/signals/factories/type.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2020 - 2021 Gemeente Amsterdam
+# Copyright (C) 2020 - 2023 Gemeente Amsterdam
 from factory import SubFactory
 from factory.django import DjangoModelFactory
 
@@ -12,3 +12,4 @@ class TypeFactory(DjangoModelFactory):
 
     class Meta:
         model = Type
+        skip_postgeneration_save = True

--- a/app/signals/apps/users/factories.py
+++ b/app/signals/apps/users/factories.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2023 Gemeente Amsterdam
 import factory
 import faker
 from django.conf import settings
@@ -14,6 +14,7 @@ class UserFactory(DjangoModelFactory):
     class Meta:
         model = settings.AUTH_USER_MODEL
         django_get_or_create = ('username', )
+        skip_postgeneration_save = True
 
     first_name = factory.LazyAttribute(
         lambda o: fake.first_name()
@@ -50,6 +51,7 @@ class GroupFactory(DjangoModelFactory):
     class Meta:
         model = Group
         django_get_or_create = ('name',)
+        skip_postgeneration_save = True
 
     name = factory.LazyAttribute(
         lambda o: fake.word()


### PR DESCRIPTION
## Description

In this commit, we addressed the DeprecationWarning that arose due to changes in Factory Boy (release 3.3.0). The warning was triggered when using `RelatedFactory` and `Post-generation hooks`. We made 3 changes for now:

- Added `skip_postgeneration_save = True` to the Meta class of the factories
- For methods decorated with `@post_generation`, we added calls to `self.save()` after any modifications to the instance, ensuring it gets saved
- We encountered an issue with the SignalFactory/SignalFactoryWithImage/SignalFactoryValidLocation, where the previous two approaches did not work as expected. We override the `_after_postgeneration` classmethod in the SignalFactory to remove the DeprecationWarning

More information about the deprecation see: https://factoryboy.readthedocs.io/en/stable/changelog.html

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
