### PR TITLE
Also export slug of main- and subcategory

### DIFF
--- a/app/signals/apps/reporting/csv/datawarehouse/categories.py
+++ b/app/signals/apps/reporting/csv/datawarehouse/categories.py
@@ -26,6 +26,8 @@ def create_category_assignments_csv(location: str) -> str:
         '_signal_id',
         main=F('category__parent__name'),
         sub=F('category__name'),
+        main_slug=F('category__parent__slug'),
+        sub_slug=F('category__slug'),
         _departments=StringAgg('category__departments__name', delimiter=', ',
                                filter=Q(category__categorydepartment__is_responsible=True)),
         _extra_properties=Coalesce(Cast('extra_properties', output_field=CharField()),
@@ -36,8 +38,9 @@ def create_category_assignments_csv(location: str) -> str:
 
     csv_file = queryset_to_csv_file(queryset, os.path.join(location, 'categories.csv'))
 
-    ordered_field_names = ['id', 'main', 'sub', 'departments', 'created_at', 'updated_at', 'extra_properties',
-                           '_signal_id', 'deadline', 'deadline_factor_3', ]
+    ordered_field_names = ['id', 'main', 'sub', 'main_slug', 'sub_slug', 'departments',
+                           'created_at', 'updated_at', 'extra_properties', '_signal_id',
+                           'deadline', 'deadline_factor_3', ]
     reorder_csv(csv_file.name, ordered_field_names)
 
     return csv_file.name

--- a/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
+++ b/app/signals/apps/reporting/tests/csv/test_datawarehouse.py
@@ -282,6 +282,8 @@ class TestDatawarehouse(testcases.TestCase):
                 self.assertEqual(row['_signal_id'], str(category_assignment._signal_id))
                 self.assertEqual(row['main'], str(category_assignment.category.parent.name))
                 self.assertEqual(row['sub'], str(category_assignment.category.name))
+                self.assertEqual(row['main_slug'], str(category_assignment.category.parent.slug))
+                self.assertEqual(row['sub_slug'], str(category_assignment.category.slug))
                 self.assertEqual(row['departments'],
                                  ', '.join(category_assignment.category.departments.values_list('name', flat=True)))
 


### PR DESCRIPTION
## Description

When administrators change the name of a category in Signalen, the slug is not updated accordingly. This is by design, so administrators can make minor textual changes in the name of the category, without breaking the contract with the machine learning model. 

The mismatch between the category name and category slug becomes a problem when a machine learning model is retrained. Currently for retraining the machine learning model, the datawarehouse export is used. This export only includes the main category name, sub category name and text. The machine learning model again runs the slugify function on the category names and this results in a different slug then registered in the Signalen backend.

To fix this problem, I propose to export the main- and subcategory slug as well. The category slugs can then be used as input for re-training the machine learning model.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
