### PR TITLE
Make email max retries and retry delay configurable

### DIFF
--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -320,9 +320,14 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 CELERY_EMAIL_CHUNK_SIZE = 1
 CELERY_EMAIL_TASK_CONFIG = {
     'ignore_result': False,
-    'max_retries': os.getenv('CELERY_EMAIL_TASK_CONFIG_MAX_RETRIES', 3),
-    'default_retry_delay': os.getenv('CELERY_EMAIL_TASK_CONFIG_DEFAULT_RETRY_DELAY', 60 * 3)
 }
+celery_email_task_config_max_retries = os.getenv('CELERY_EMAIL_TASK_CONFIG_MAX_RETRIES')
+if celery_email_task_config_max_retries:
+    CELERY_EMAIL_TASK_CONFIG['max_retries'] = celery_email_task_config_max_retries
+
+celery_email_task_config_default_retry_delay = os.getenv('CELERY_EMAIL_TASK_CONFIG_DEFAULT_RETRY_DELAY')
+if celery_email_task_config_default_retry_delay:
+    CELERY_EMAIL_TASK_CONFIG['default_retry_delay'] = celery_email_task_config_default_retry_delay
 
 # Sentry logging
 RAVEN_CONFIG = {

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -320,6 +320,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 CELERY_EMAIL_CHUNK_SIZE = 1
 CELERY_EMAIL_TASK_CONFIG = {
     'ignore_result': False,
+    'max_retries': os.getenv('CELERY_EMAIL_TASK_CONFIG_MAX_RETRIES', 3),
+    'default_retry_delay': os.getenv('CELERY_EMAIL_TASK_CONFIG_DEFAULT_RETRY_DELAY', 60 * 3)
 }
 
 # Sentry logging


### PR DESCRIPTION
## Description

Make email max retries and retry delay configurable. Instead of the proposed change in https://github.com/Amsterdam/signals/pull/1328 prefer not setting the configuration values unless explicitly overridden by the env vars.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code