### PR TITLE
Reporter cancel endpoint

### DIFF
--- a/app/signals/apps/api/generics/permissions.py
+++ b/app/signals/apps/api/generics/permissions.py
@@ -159,5 +159,4 @@ class ReporterPermission(BasePermission):
         ) or SignalPermissionService.has_permission(
             user=request.user,
             permission='signals.sia_can_view_all_categories',
-            signal=obj._signal
         )

--- a/app/signals/apps/api/serializers/signal_reporter.py
+++ b/app/signals/apps/api/serializers/signal_reporter.py
@@ -3,14 +3,14 @@
 from django.db import transaction
 from django.utils import timezone
 from django_fsm import TransitionNotAllowed
-from rest_framework.fields import BooleanField
-from rest_framework.serializers import ModelSerializer
+from rest_framework import serializers
+from rest_framework.fields import BooleanField, CharField
 
 from signals.apps.history.models import Log
 from signals.apps.signals.models import Reporter, Signal
 
 
-class SignalReporterSerializer(ModelSerializer):
+class SignalReporterSerializer(serializers.ModelSerializer):
     allows_contact = BooleanField(source='_signal.allows_contact', read_only=True)
     sharing_allowed = BooleanField(required=True)
 
@@ -116,3 +116,7 @@ class SignalReporterSerializer(ModelSerializer):
                 )
 
         return reporter
+
+
+class CancelSignalReporterSerializer(serializers.Serializer):
+    reason = CharField(required=False)

--- a/app/signals/apps/api/tests/test_private_signal_reporters.py
+++ b/app/signals/apps/api/tests/test_private_signal_reporters.py
@@ -9,7 +9,7 @@ from rest_framework.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
     HTTP_400_BAD_REQUEST,
-    HTTP_401_UNAUTHORIZED
+    HTTP_401_UNAUTHORIZED, HTTP_204_NO_CONTENT
 )
 from rest_framework.test import APITestCase
 
@@ -78,3 +78,11 @@ class TestPrivateSignalReportersEndpoint(SIAReadWriteUserMixin, APITestCase):
 
         reporter = response.json()
         self.assertEqual(reporter.get('state'), Reporter.REPORTER_STATE_VERIFICATION_EMAIL_SENT)
+
+    def test_can_cancel(self) -> None:
+        signal = SignalFactory.create(reporter__state=Reporter.REPORTER_STATE_APPROVED)
+        reporter = ReporterFactory.create(_signal=signal, state=Reporter.REPORTER_STATE_VERIFICATION_EMAIL_SENT)
+
+        response = self.client.delete(f'/signals/v1/private/signals/{signal.pk}/reporters/{reporter.pk}')
+
+        self.assertEqual(response.status_code, HTTP_204_NO_CONTENT)

--- a/app/signals/apps/api/tests/test_private_signal_reporters.py
+++ b/app/signals/apps/api/tests/test_private_signal_reporters.py
@@ -9,7 +9,7 @@ from rest_framework.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
     HTTP_400_BAD_REQUEST,
-    HTTP_401_UNAUTHORIZED,
+    HTTP_401_UNAUTHORIZED
 )
 from rest_framework.test import APITestCase
 

--- a/app/signals/apps/api/views/signals/private/signal_reporters.py
+++ b/app/signals/apps/api/views/signals/private/signal_reporters.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2023 Gemeente Amsterdam
 from django.db import transaction
+from django.utils import timezone
 from django_fsm import TransitionNotAllowed
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.mixins import CreateModelMixin, ListModelMixin
 from rest_framework.request import Request
@@ -12,7 +15,11 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from signals.apps.api.filters.signal_reporter import ReporterFilterSet
 from signals.apps.api.generics.permissions import ReporterPermission
-from signals.apps.api.serializers.signal_reporter import SignalReporterSerializer
+from signals.apps.api.serializers.signal_reporter import (
+    CancelSignalReporterSerializer,
+    SignalReporterSerializer
+)
+from signals.apps.history.models import Log
 from signals.apps.signals.models import Reporter, Signal
 from signals.auth.backend import JWTAuthBackend
 
@@ -38,25 +45,45 @@ class PrivateSignalReporterViewSet(CreateModelMixin, ListModelMixin, NestedViewS
 
         return reporter._signal
 
-    def destroy(self, request: Request, *args, **kwargs):
+    @extend_schema(request=CancelSignalReporterSerializer)
+    @action(methods=['post'], detail=True, url_path='cancel', url_name='private-signal-reporter-cancel')
+    def cancel(self, request: Request, *args, **kwargs):
         """
         Cancel a reporter, this allows cancelling a reporter update.
         Cancelling is allowed, when the state of the reporter is "new" or "verification_email_sent"
         and the reporter is not the original/first reporter of the signal.
+        Optionally a reason for the cancellation can be provided using the reason field.
         """
         instance = self.get_object()
+        cancel_serializer = CancelSignalReporterSerializer(data=request.data)
+        cancel_serializer.is_valid(raise_exception=True)
+        description = 'Contactgegevens wijziging geannuleerd'
+        reason = cancel_serializer.validated_data.get('reason')
+        if reason is None:
+            description += '.'
+        else:
+            description += f': {reason}'
 
         try:
-            self.perform_destroy(instance)
+            self.perform_cancel(instance)
+
+            instance.history_log.create(
+                action=Log.ACTION_UPDATE,
+                created_by=request.user,
+                created_at=timezone.now(),
+                description=description,
+                _signal=instance._signal,
+            )
         except TransitionNotAllowed:
             return Response(
                 data={'non_field_errors': ['Cancelling this reporter is not possible.']},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
 
     @transaction.atomic()
-    def perform_destroy(self, instance: Reporter) -> None:
+    def perform_cancel(self, instance: Reporter) -> None:
         instance.cancel()
         instance.save()

--- a/app/signals/apps/api/views/signals/private/signal_reporters.py
+++ b/app/signals/apps/api/views/signals/private/signal_reporters.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2023 Gemeente Amsterdam
+from django.db import transaction
+from django_fsm import TransitionNotAllowed
+from rest_framework import status
 from rest_framework.exceptions import NotFound
 from rest_framework.mixins import CreateModelMixin, ListModelMixin
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
@@ -32,3 +37,26 @@ class PrivateSignalReporterViewSet(CreateModelMixin, ListModelMixin, NestedViewS
             raise NotFound()
 
         return reporter._signal
+
+    def destroy(self, request: Request, *args, **kwargs):
+        """
+        Cancel a reporter, this allows cancelling a reporter update.
+        Cancelling is allowed, when the state of the reporter is "new" or "verification_email_sent"
+        and the reporter is not the original/first reporter of the signal.
+        """
+        instance = self.get_object()
+
+        try:
+            self.perform_destroy(instance)
+        except TransitionNotAllowed:
+            return Response(
+                data={'non_field_errors': ['Cancelling this reporter is not possible.']},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @transaction.atomic()
+    def perform_destroy(self, instance: Reporter) -> None:
+        instance.cancel()
+        instance.save()


### PR DESCRIPTION
## Description

Allow cancelling a reporter through an API endpoint.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
