### PR TITLE
Do not display history about externals

### DIFF
--- a/app/signals/apps/my_signals/rest_framework/views/signals.py
+++ b/app/signals/apps/my_signals/rest_framework/views/signals.py
@@ -137,7 +137,7 @@ class MySignalsViewSet(DetailSerializerMixin, ReadOnlyModelViewSet):
             flat=True
         ).order_by())
 
-        history_log_qs = signal.history_log.exclude(Q(excluded_q))
+        history_log_qs = signal.history_log.exclude(Q(excluded_q)).exclude(action=Log.ACTION_RECEIVE)
 
         what = self.request.query_params.get('what', None)
         if what:

--- a/app/signals/apps/my_signals/rest_framework/views/signals.py
+++ b/app/signals/apps/my_signals/rest_framework/views/signals.py
@@ -93,7 +93,7 @@ class MySignalsViewSet(DetailSerializerMixin, ReadOnlyModelViewSet):
         - Do not return logs about Priority  
         - Do not return logs about Status changes to LEEG, AFWACHTING, ON_HOLD, GEANNULEERD, GESPLITST, 
           VERZOEK_TOT_AFHANDELING, INGEPLAND, VERZOEK_TOT_HEROPENEN, TE_VERZENDEN, VERZONDEN, VERZENDEN_MISLUKT, 
-          AFGEHANDELD_EXTERN  
+          DOORGEZET_NAAR_EXTERN, AFGEHANDELD_EXTERN
         - Status changes are translated to a more reporter friendly name  
         -- GEANNULEERD, AFGEHANDELD -> Afgesloten    
         -- HEROPEND -> Heropend  
@@ -110,12 +110,18 @@ class MySignalsViewSet(DetailSerializerMixin, ReadOnlyModelViewSet):
 
         # Some Status transactions are excluded
         status_type = ContentType.objects.get_for_model(Status)
-        excluded_q |= Q(Q(content_type=status_type) & Q(extra__in=[workflow.LEEG, workflow.AFWACHTING, workflow.ON_HOLD,
-                                                                   workflow.GEANNULEERD, workflow.GESPLITST,
-                                                                   workflow.VERZOEK_TOT_AFHANDELING, workflow.INGEPLAND,
+        excluded_q |= Q(Q(content_type=status_type) & Q(extra__in=[workflow.LEEG,
+                                                                   workflow.AFWACHTING,
+                                                                   workflow.ON_HOLD,
+                                                                   workflow.GEANNULEERD,
+                                                                   workflow.GESPLITST,
+                                                                   workflow.VERZOEK_TOT_AFHANDELING,
+                                                                   workflow.INGEPLAND,
                                                                    workflow.VERZOEK_TOT_HEROPENEN,
-                                                                   workflow.TE_VERZENDEN, workflow.VERZONDEN,
+                                                                   workflow.TE_VERZENDEN,
+                                                                   workflow.VERZONDEN,
                                                                    workflow.VERZENDEN_MISLUKT,
+                                                                   workflow.DOORGEZET_NAAR_EXTERN,
                                                                    workflow.AFGEHANDELD_EXTERN, ]))
 
         # The first occurrence in the history log of a Location, CategoryAssignment or Type transition are excluded


### PR DESCRIPTION
## Description

Currently a reporter can see the communication with external parties in the "my signals" signal history.
This is undesirable and this PR makes sure that no longer happens. 

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
