### PR TITLE
Do not display external email address in history

### DIFF
--- a/app/signals/apps/history/services/signal_log.py
+++ b/app/signals/apps/history/services/signal_log.py
@@ -190,9 +190,8 @@ class SignalLogService:
 
         tz = pytz.timezone(settings.TIME_ZONE)
 
-        external_user = session._signal_status.email_override
         when = session._signal_status.created_at.astimezone(tz).strftime('%d-%m-%Y %H:%M')
-        description = f'Toelichting door behandelaar {external_user} op vraag van {when} {reaction}'
+        description = f'Toelichting externe behandelaar op vraag van {when} {reaction}'
 
         session.history_log.create(
             action=Log.ACTION_RECEIVE,

--- a/app/signals/apps/questionnaires/tests/services/test_forward_to_external.py
+++ b/app/signals/apps/questionnaires/tests/services/test_forward_to_external.py
@@ -196,7 +196,7 @@ class TestForwardToExternalSessionService(TestCase):
             # Status update causes no log entry because they use Django Signals fired in on_commit callback that is
             # not active in this test. So we only get one extra log entry containing the external reaction.
             self.assertEqual(Log.objects.count(), n_log + 1)
-            msg = f'Toelichting door behandelaar a@example.com op vraag van {question_timestamp} {answer.payload}'
+            msg = f'Toelichting externe behandelaar op vraag van {question_timestamp} {answer.payload}'
             log_entry = Log.objects.first()
             self.assertEqual(log_entry.description, msg)
 
@@ -236,7 +236,7 @@ class TestForwardToExternalSessionService(TestCase):
             # In the case of a status change after forwarding a signal we get no status change but we do get a log
             # entry containing the external reaction.
             self.assertEqual(Log.objects.count(), n_log + 1)
-            msg = f'Toelichting door behandelaar a@example.com op vraag van {question_timestamp} {answer.payload}'
+            msg = f'Toelichting externe behandelaar op vraag van {question_timestamp} {answer.payload}'
             log_entry = Log.objects.first()
             self.assertEqual(log_entry.description, msg)
 


### PR DESCRIPTION
## Description

Do not display external email address in history.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
