### PR TITLE
Force elasticsearch index to refresh on changes to status messages

### DIFF
--- a/app/signals/apps/search/signal_receivers.py
+++ b/app/signals/apps/search/signal_receivers.py
@@ -42,7 +42,7 @@ def status_message_post_save_receiver(sender: str, instance: StatusMessageModel,
         The instance of the StatusMessage model that was saved to the database.
     """
     document = transform(instance)
-    document.save()
+    document.save(refresh='true')
 
 
 @receiver(post_delete, sender=StatusMessageModel, dispatch_uid='status_message_post_delete_receiver')
@@ -59,4 +59,4 @@ def status_message_post_delete_receiver(sender: str, instance: StatusMessageMode
         The instance of the StatusMessage model that was saved to the database.
     """
     document = StatusMessageDocument.get(instance.id)
-    document.delete()
+    document.delete(refresh='true')


### PR DESCRIPTION
## Description

Force elasticsearch index to refresh on changes to status messages

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
