### PR TITLE
Remove raven dependency

### DIFF
--- a/app/logs/config.py
+++ b/app/logs/config.py
@@ -23,10 +23,6 @@ BASE_LOGGING = {
         },
     },
     'handlers': {
-        'sentry': {
-            'level': 'WARNING',
-            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
-        },
         'colorize': {
             'class': 'logs.handlers.ColoredHandler',
             'formatter': 'elaborate'

--- a/app/requirements/requirements.in
+++ b/app/requirements/requirements.in
@@ -44,7 +44,6 @@ psycopg2-binary
 pypdf
 python-dateutil
 python-magic
-raven
 requests
 textX
 types-cryptography

--- a/app/requirements/requirements.txt
+++ b/app/requirements/requirements.txt
@@ -331,8 +331,6 @@ pyyaml==6.0.1
     # via
     #   drf-spectacular
     #   flex
-raven==6.10.0
-    # via -r requirements/requirements.in
 referencing==0.30.2
     # via
     #   jsonschema

--- a/app/requirements/requirements_dev.txt
+++ b/app/requirements/requirements_dev.txt
@@ -562,8 +562,6 @@ pyyaml==6.0.1
     #   -r requirements/requirements_test.txt
     #   drf-spectacular
     #   flex
-raven==6.10.0
-    # via -r requirements/requirements_test.txt
 referencing==0.30.2
     # via
     #   -r requirements/requirements_test.txt

--- a/app/requirements/requirements_test.txt
+++ b/app/requirements/requirements_test.txt
@@ -530,8 +530,6 @@ pyyaml==6.0.1
     #   -r requirements/requirements.txt
     #   drf-spectacular
     #   flex
-raven==6.10.0
-    # via -r requirements/requirements.txt
 referencing==0.30.2
     # via
     #   -r requirements/requirements.txt

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -84,7 +84,6 @@ INSTALLED_APPS = [
     'django_filters',
     'djcelery_email',
     'markdownx',
-    'raven.contrib.django.raven_compat',
     'rest_framework',
     'rest_framework_gis',
     'storages',
@@ -328,11 +327,6 @@ if celery_email_task_config_max_retries:
 celery_email_task_config_default_retry_delay = os.getenv('CELERY_EMAIL_TASK_CONFIG_DEFAULT_RETRY_DELAY')
 if celery_email_task_config_default_retry_delay:
     CELERY_EMAIL_TASK_CONFIG['default_retry_delay'] = celery_email_task_config_default_retry_delay
-
-# Sentry logging
-RAVEN_CONFIG = {
-    'dsn': os.getenv('SENTRY_RAVEN_DSN'),
-}
 
 # Azure Application insights logging
 AZURE_APPLICATION_INSIGHTS_ENABLED = os.getenv('AZURE_APPLICATION_INSIGHTS_ENABLED', False) in TRUE_VALUES


### PR DESCRIPTION
## Description

Since we no longer use Sentry and it was confirmed that other municipalities also no longer use Sentry, we're dropping Sentry support with this PR.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
