### PR TITLE
Phone number changes not in history

### DIFF
--- a/app/signals/apps/api/features/update_signal_reporters.feature
+++ b/app/signals/apps/api/features/update_signal_reporters.feature
@@ -14,10 +14,15 @@ Feature: Updating the reporter of signal
     Then the response status code should be 201
     And the reporter with email address joep@example.com should receive an email with template key notify_current_reporter
     And the reporter with email address jan@example.com should receive an email with template key verify_email_reporter
+    And the history should state E-mail verificatie verzonden.
     When I verify the token of jan@example.com
     Then the response status code should be 200
     And the reporter with email address jan@example.com should receive an email with template key confirm_reporter_updated
     And the reporter of the signal should have phone number 0200000001, email address jan@example.com and state approved
+    And the history should state E-mailadres is geverifieerd door de melder.
+    And the history should state E-mailadres is gewijzigd.
+    And the history should state Telefoonnummer is gewijzigd.
+
 
   Scenario: Update reporter phone and email of signal with reporter that has only phone number
     Given there is a signal with reporter phone number 0200000000 and email address null

--- a/app/signals/apps/api/features/update_signal_reporters.feature
+++ b/app/signals/apps/api/features/update_signal_reporters.feature
@@ -97,6 +97,7 @@ Feature: Updating the reporter of signal
     When I create a new reporter for the signal with phone number 0200000001 and email address null
     Then the response status code should be 201
     And the reporter of the signal should have phone number 0200000001, email address null and state approved
+    And the history should state Telefoonnummer is gewijzigd.
 
   Scenario: Update reporter phone of signal with reporter that has only email
     Given there is a signal with reporter phone number null and email address joep@example.com

--- a/app/signals/apps/api/serializers/signal_reporter.py
+++ b/app/signals/apps/api/serializers/signal_reporter.py
@@ -94,14 +94,15 @@ class SignalReporterSerializer(serializers.ModelSerializer):
         # we can transition to approved
         if not verify_email_successful:
             try:
+                old_reporter = reporter._signal.reporter
                 reporter.approve()
                 reporter.save()
 
-                if reporter._signal.reporter.phone != reporter.phone:
+                if old_reporter.phone != reporter.phone:
                     self._log_to_history(reporter, 'Telefoonnummer is gewijzigd.', signal)
 
                 # This can happen when the e-mail address is removed or blanked
-                if reporter._signal.reporter.email != reporter.email:
+                if old_reporter.email != reporter.email:
                     self._log_to_history(reporter, 'E-mailadres is gewijzigd.', signal)
             except TransitionNotAllowed:
                 # If everything fails the change request is not valid and should be

--- a/app/signals/apps/api/tests/scenarios/context/history.py
+++ b/app/signals/apps/api/tests/scenarios/context/history.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2023 Gemeente Amsterdam
-from pytest_bdd import then, parsers
+from pytest_bdd import parsers, then
 
 from signals.apps.signals.models import Signal
 

--- a/app/signals/apps/api/tests/scenarios/context/history.py
+++ b/app/signals/apps/api/tests/scenarios/context/history.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam
+from pytest_bdd import then, parsers
+
+from signals.apps.signals.models import Signal
+
+
+@then(parsers.parse('the history should state {statement}'))
+def then_history_should_state(statement: str, signal: Signal) -> None:
+    history = signal.history_log.all()
+    found = False
+    for log in history:
+        if log.description == statement:
+            found = True
+            break
+
+    assert found

--- a/app/signals/apps/api/tests/scenarios/update_signal_reporter/test_signal_reporter_updates.py
+++ b/app/signals/apps/api/tests/scenarios/update_signal_reporter/test_signal_reporter_updates.py
@@ -5,6 +5,7 @@ from pytest_bdd import scenario
 
 from signals.apps.api.tests.scenarios.context.api import * # noqa
 from signals.apps.api.tests.scenarios.context.email import * # noqa
+from signals.apps.api.tests.scenarios.context.history import * # noqa
 from signals.apps.api.tests.scenarios.context.reporter import * # noqa
 from signals.apps.api.tests.scenarios.context.signal import * # noqa
 from signals.apps.api.tests.scenarios.context.user import * # noqa

--- a/app/signals/apps/api/views/email_verification.py
+++ b/app/signals/apps/api/views/email_verification.py
@@ -23,6 +23,8 @@ class EmailVerificationView(APIView):
         validated_data = serializer.validated_data
 
         reporter = serializer.reporter
+        signal = reporter._signal
+        old_reporter = signal.reporter
         reporter.email_verified = True
         reporter.approve()
         reporter.save()
@@ -31,22 +33,22 @@ class EmailVerificationView(APIView):
             action=Log.ACTION_UPDATE,
             created_at=timezone.now(),
             description='E-mailadres is geverifieerd door de melder.',
-            _signal=reporter._signal,
+            _signal=signal,
         )
 
         reporter.history_log.create(
             action=Log.ACTION_UPDATE,
             created_at=timezone.now(),
             description='E-mailadres is gewijzigd.',
-            _signal=reporter._signal,
+            _signal=signal,
         )
 
-        if reporter._signal.reporter.phone != reporter.phone:
+        if old_reporter.phone != reporter.phone:
             reporter.history_log.create(
                 action=Log.ACTION_UPDATE,
                 created_at=timezone.now(),
                 description='Telefoonnummer is gewijzigd.',
-                _signal=reporter._signal,
+                _signal=signal,
             )
 
         return Response(data=validated_data)


### PR DESCRIPTION
## Description

Currently the history log with regards to changes in phone number and email address is incorrect.
This is happening because we're assigning the new reporter to the signal in the `approve()` transition, and are then using that reporter to compare the phone number and email address with the same reporter instead of comparing it with the previous reporter. This PR fixes that. 

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
