### PR TITLE
Make new attachment fields available in private crud endpoints

### DIFF
--- a/app/signals/apps/api/serializers/attachment.py
+++ b/app/signals/apps/api/serializers/attachment.py
@@ -122,3 +122,9 @@ class PrivateSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSeri
         )
 
         extra_kwargs = {'file': {'write_only': True}}
+
+
+class PrivateSignalAttachmentUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Attachment
+        fields = ('public', 'caption')

--- a/app/signals/apps/api/serializers/attachment.py
+++ b/app/signals/apps/api/serializers/attachment.py
@@ -44,7 +44,7 @@ class SignalAttachmentSerializerMixin:
 class PublicSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSerializer):
     serializer_url_field = PublicSignalAttachmentLinksField
     _display = DisplayField()
-    location = serializers.FileField(source='file', required=False)
+    location = serializers.FileField(source='file', required=False, read_only=True)
 
     class Meta:
         model = Attachment
@@ -57,7 +57,7 @@ class PublicSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSeria
             'file',
         )
 
-        read_only = (
+        read_only_fields = (
             '_display',
             '_links',
             'location',
@@ -94,7 +94,9 @@ class PrivateSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSeri
     serializer_url_field = PrivateSignalAttachmentLinksField
 
     _display = DisplayField()
-    location = serializers.FileField(source='file', required=False)
+    location = serializers.FileField(source='file', required=False, read_only=True)
+    public = serializers.BooleanField(required=False)
+    caption = serializers.CharField(required=False)
 
     class Meta:
         model = Attachment
@@ -106,9 +108,11 @@ class PrivateSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSeri
             'created_at',
             'file',
             'created_by',
+            'public',
+            'caption',
         )
 
-        read_only = (
+        read_only_fields = (
             '_display',
             '_links',
             'location',

--- a/app/signals/apps/api/tests/test_attachment_validation.py
+++ b/app/signals/apps/api/tests/test_attachment_validation.py
@@ -103,7 +103,6 @@ class TestAttachmentValidation(SignalsBaseApiTestCase):
         self.assertTrue(body.get('public'))
         self.assertEqual(body.get('caption'), caption)
 
-
     def test_patch_attachment_public_field(self):
         attachment = AttachmentFactory.create(_signal=self.signal, public=False, caption=None)
         self.client.force_authenticate(user=self.superuser)
@@ -117,7 +116,7 @@ class TestAttachmentValidation(SignalsBaseApiTestCase):
         body = response.json()
         self.assertTrue(body.get('public'))
 
-    def  test_patch_attachment_caption_field(self):
+    def test_patch_attachment_caption_field(self):
         caption = 'Allowed'
         attachment = AttachmentFactory.create(_signal=self.signal, public=False, caption=None)
         self.client.force_authenticate(user=self.superuser)

--- a/app/signals/apps/api/views/attachment.py
+++ b/app/signals/apps/api/views/attachment.py
@@ -80,7 +80,7 @@ class PrivateSignalAttachmentsViewSet(NestedViewSetMixin, ModelViewSet):
 
     def get_serializer(self, *args, **kwargs) -> serializers.BaseSerializer:
         if self.request.method in ['PUT', 'PATCH']:
-            return PrivateSignalAttachmentUpdateSerializer()
+            return PrivateSignalAttachmentUpdateSerializer(*args, **kwargs)
 
         return super().get_serializer(*args, **kwargs)
 

--- a/app/signals/apps/api/views/attachment.py
+++ b/app/signals/apps/api/views/attachment.py
@@ -8,11 +8,11 @@ import os
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
-from rest_framework.mixins import CreateModelMixin, DestroyModelMixin
+from rest_framework.mixins import CreateModelMixin
 from rest_framework.response import Response
 from rest_framework.status import HTTP_204_NO_CONTENT
-from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
-from rest_framework_extensions.mixins import DetailSerializerMixin, NestedViewSetMixin
+from rest_framework.viewsets import GenericViewSet, ModelViewSet
+from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from signals.apps.api.serializers import (
     PrivateSignalAttachmentSerializer,
@@ -48,13 +48,16 @@ class PublicSignalAttachmentsViewSet(CreateModelMixin, GenericViewSet):
         return self.get_object()
 
 
-class PrivateSignalAttachmentsViewSet(NestedViewSetMixin, DetailSerializerMixin, CreateModelMixin, DestroyModelMixin,
-                                      ReadOnlyModelViewSet):
+@extend_schema_view(
+    create=extend_schema(
+        request={
+            'multipart/form-data': PrivateSignalAttachmentSerializer
+        }
+    )
+)
+class PrivateSignalAttachmentsViewSet(NestedViewSetMixin, ModelViewSet):
     queryset = Attachment.objects.all()
-
     serializer_class = PrivateSignalAttachmentSerializer
-    serializer_detail_class = PrivateSignalAttachmentSerializer
-
     authentication_classes = (JWTAuthBackend,)
 
     def get_queryset(self, *args, **kwargs):


### PR DESCRIPTION
## Description

Make new attachment fields available in private crud endpoints.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
