### PR TITLE
Attachments uploaded by reporters have no created_by value

### DIFF
--- a/app/signals/apps/signals/migrations/0195_auto_20230821_1059.py
+++ b/app/signals/apps/signals/migrations/0195_auto_20230821_1059.py
@@ -4,17 +4,14 @@ from django.apps.registry import Apps
 from django.db import migrations
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations import RunPython
-from django.db.models import OuterRef, Subquery
 
 
 def _make_attachment_public_when_uploaded_by_reporter(
         apps: Apps,
         schema_editor: BaseDatabaseSchemaEditor
 ) -> None:
-    Reporter = apps.get_model('signals', 'Reporter')
     Attachment = apps.get_model('signals', 'Attachment')
-    reporters = Reporter.objects.filter(_signal=OuterRef('_signal'))
-    attachments = Attachment.objects.filter(created_by__in=Subquery(reporters.values('email')))
+    attachments = Attachment.objects.filter(created_by__isnull=True)
     for attachment in attachments:
         attachment.public = True
         attachment.save()


### PR DESCRIPTION
## Description
The current data migration logic is incorrect. I assumed that the created_by value would be the email address of the reporters, but it turns out that is not the case.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations