### PR TITLE
Set public to true by default for attachments uploaded using the public endpoint

### DIFF
--- a/app/signals/apps/api/serializers/attachment.py
+++ b/app/signals/apps/api/serializers/attachment.py
@@ -21,7 +21,7 @@ PUBLIC_UPLOAD_ALLOWED_STATES = (AFGEHANDELD, GEMELD, REACTIE_GEVRAAGD)
 
 
 class SignalAttachmentSerializerMixin:
-    def create(self, validated_data):
+    def create(self, validated_data: dict) -> Attachment:
         user = self.context['request'].user
         signal = self.context['view'].get_signal()
 
@@ -67,7 +67,7 @@ class PublicSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSeria
 
         extra_kwargs = {'file': {'write_only': True}}
 
-    def create(self, validated_data):
+    def create(self, validated_data: dict) -> Attachment:
         signal = self.context['view'].get_signal()
         if signal.status.state not in PUBLIC_UPLOAD_ALLOWED_STATES:
             msg = 'Public uploads not allowed in current signal state.'
@@ -87,7 +87,11 @@ class PublicSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSeria
                 msg = 'No feedback expected for this signal hence no uploads allowed.'
                 raise ValidationError(msg)
 
-        return super().create(validated_data)
+        attachment = super().create(validated_data)
+        attachment.public = True
+        attachment.save()
+
+        return attachment
 
 
 class PrivateSignalAttachmentSerializer(SignalAttachmentSerializerMixin, HALSerializer):

--- a/app/signals/apps/api/tests/test_public_signal_endpoint.py
+++ b/app/signals/apps/api/tests/test_public_signal_endpoint.py
@@ -267,6 +267,18 @@ class TestPublicSignalViewSet(SignalsBaseApiTestCase):
             response = self.client.post(self.attachment_endpoint.format(uuid=signal.uuid), data)
             self.assertEqual(response.status_code, 201)
 
+    def test_attachment_is_public_by_default(self):
+        signal = SignalFactory.create(status__state=GEMELD)
+        data = {"file": SimpleUploadedFile('image.gif', small_gif, content_type='image/gif')}
+
+        response = self.client.post(self.attachment_endpoint.format(uuid=signal.uuid), data)
+        self.assertEqual(response.status_code, 201)
+
+        attachments = signal.attachments.all()
+        self.assertEqual(len(attachments), 1)
+        attachment = attachments[0]
+        self.assertTrue(attachment.public)
+
     @patch('signals.apps.api.serializers.attachment.PUBLIC_UPLOAD_ALLOWED_STATES', new=(AFGEHANDELD,))
     def test_add_attachment_in_state_AFGEHANDELD(self):
         # When a nuisance complaint is handled it transitions to the state


### PR DESCRIPTION
## Description

Set public to true by default for attachments uploaded using the public endpoint.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
