### PR TITLE
Only public attachments in my signals with caption field included

### DIFF
--- a/app/signals/apps/my_signals/rest_framework/fields/signals.py
+++ b/app/signals/apps/my_signals/rest_framework/fields/signals.py
@@ -117,7 +117,7 @@ class MySignalDetailLinksField(HyperlinkedIdentityField):
             ('archives', dict(href=self.get_url(value, 'my_signals:my-signals-history', request, _format))),
         ])
 
-        attachment_qs = value.attachments.filter(created_by__isnull=True, is_image=True)
+        attachment_qs = value.attachments.filter(public=True)
         if attachment_qs.exists():
             # A list URI's of all the attachments
             representation.update({
@@ -126,6 +126,7 @@ class MySignalDetailLinksField(HyperlinkedIdentityField):
                         'href': request.build_absolute_uri(attachment.file.url),
                         'created_by': attachment.created_by,
                         'created_at': attachment.created_at,
+                        'caption': attachment.caption,
                     }
                     for attachment in attachment_qs.all().order_by('-created_at')
                 )),

--- a/app/signals/apps/my_signals/rest_framework/fields/signals.py
+++ b/app/signals/apps/my_signals/rest_framework/fields/signals.py
@@ -98,6 +98,11 @@ class MySignalListLinksField(HyperlinkedIdentityField):
                         'type': 'string',
                         'format': 'date-time',
                         'example': '2023-06-01T00:00:00Z'
+                    },
+                    'caption': {
+                        'type': 'string',
+                        'nullable': True,
+                        'example': 'This is a caption',
                     }
                 }
             }


### PR DESCRIPTION
## Description

Display only public attachments in my signals and include caption field in output.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
