### PR TITLE
Enable SSL verification when fetching files from CBS

### DIFF
--- a/app/signals/apps/dataset/sources/shape.py
+++ b/app/signals/apps/dataset/sources/shape.py
@@ -42,7 +42,7 @@ class ShapeBoundariesLoader(AreaLoader):
         if os.path.exists(zip_fullpath):
             return  # Datafile already downloaded.
 
-        with requests.get(self.DATASET_URL, stream=True, verify=False) as r:
+        with requests.get(self.DATASET_URL, stream=True) as r:
             r.raise_for_status()
             with open(zip_fullpath, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=8192):


### PR DESCRIPTION
## Description

Currently when fetching the CBS data, we get the following error:

```bash
/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py:1056: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.cbs.nl'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
```

Disabling SSL verification is not recommended. This PR fixes this error.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
