### PR TITLE
Make status messages index configurable

### DIFF
--- a/app/signals/apps/search/documents/status_message.py
+++ b/app/signals/apps/search/documents/status_message.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2023 Gemeente Amsterdam
 from elasticsearch_dsl import Boolean, Document, Integer, Keyword, Text
 
+from signals.apps.search.settings import app_settings
+
 
 class StatusMessage(Document):
     id = Integer()
@@ -11,4 +13,4 @@ class StatusMessage(Document):
     active = Boolean()
 
     class Index:
-        name = 'status_messages'
+        name = app_settings.CONNECTION['STATUS_MESSAGE_INDEX']

--- a/app/signals/settings/base.py
+++ b/app/signals/settings/base.py
@@ -372,6 +372,7 @@ SEARCH = {
     'CONNECTION': {
         'HOST': os.getenv('ELASTICSEARCH_HOST', 'elastic-index.service.consul:9200'),
         'INDEX': os.getenv('ELASTICSEARCH_INDEX', 'signals'),
+        'STATUS_MESSAGE_INDEX': os.getenv('ELASTICSEARCH_STATUS_MESSAGE_INDEX', 'status_messages'),
     },
 }
 


### PR DESCRIPTION
## Description

We would like to propose to make the new status messages index name configurable, as the other Signalen municipalities typically share one Elasticsearch cluster for multiple environments (acceptance, production).

By making the status message index name configurable, we support this deployment scenario.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
