### PR TITLE
Bugfix/concurrency fault in public attachment uploading

### DIFF
--- a/app/signals/apps/signals/managers.py
+++ b/app/signals/apps/signals/managers.py
@@ -379,22 +379,16 @@ class SignalManager(models.Manager):
 
         return note
 
-    def create_note(self, data, signal):
-        """Create a new `Note` object for a given `Signal` object.
-
-        :param data: deserialized data dict
-        :returns: Note object
-        """
-        from signals.apps.signals.models import Signal
-
+    def create_note(self, data: dict, signal):
+        """Create a new `Note` object for a given `Signal` object."""
         # Added for completeness of the internal API, and firing of Django
         # signals upon creation of a Note.
-        with transaction.atomic():
-            locked_signal = Signal.objects.select_for_update(nowait=True).get(pk=signal.pk)  # Lock the Signal
 
-            note = self._create_note_no_transaction(data, locked_signal)
+        with transaction.atomic():
+            note = self._create_note_no_transaction(data, signal)
+
             transaction.on_commit(lambda: create_note.send_robust(sender=self.__class__,
-                                                                  signal_obj=locked_signal,
+                                                                  signal_obj=signal,
                                                                   note=note))
 
         return note


### PR DESCRIPTION
## Description

Prevent row lock errors when the reporter uploads attachments by not acquiring a row lock for the signal when adding notes.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
