### PR TITLE
Update task references after restructuring tasks

### DIFF
--- a/app/signals/apps/signals/migrations/0196_fix_signals_celery_tasks.py
+++ b/app/signals/apps/signals/migrations/0196_fix_signals_celery_tasks.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2023 Gemeente Amsterdam
+from django.apps.registry import Apps
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations import RunPython
+
+
+FORWARD_MAPPING = {
+    'signals.apps.signals.tasks.anonymize_reporter': 'signals.apps.signals.tasks.anonymize_reporter.anonymize_reporter',
+    'signals.apps.signals.tasks.anonymize_reporters': 'signals.apps.signals.tasks.anonymize_reporter.anonymize_reporters',
+    'signals.apps.signals.tasks.apply_auto_create_children': 'signals.apps.signals.tasks.child_signals.apply_auto_create_children',
+    'signals.apps.signals.tasks.update_status_children_based_on_parent': 'signals.apps.signals.tasks.child_signals.update_status_children_based_on_parent',
+    'signals.apps.signals.tasks.clearsessions': 'signals.apps.signals.tasks.clear_sessions.clearsessions',
+    'signals.apps.signals.tasks.refresh_materialized_view_public_signals_geography_feature_collection': 'signals.apps.signals.tasks.refresh_database_view.refresh_materialized_view_public_signals_geography_feature_collection',
+    'signals.apps.signals.tasks.apply_routing': 'signals.apps.signals.tasks.signal_routing.apply_routing',
+}  # noqa
+
+REVERSED_MAPPING = {
+    'signals.apps.signals.tasks.anonymize_reporter.anonymize_reporter': 'signals.apps.signals.tasks.anonymize_reporter',
+    'signals.apps.signals.tasks.anonymize_reporter.anonymize_reporters': 'signals.apps.signals.tasks.anonymize_reporters',
+    'signals.apps.signals.tasks.child_signals.apply_auto_create_children': 'signals.apps.signals.tasks.apply_auto_create_children',
+    'signals.apps.signals.tasks.child_signals.update_status_children_based_on_parent': 'signals.apps.signals.tasks.update_status_children_based_on_parent',
+    'signals.apps.signals.tasks.clear_sessions.clearsessions': 'signals.apps.signals.tasks.clearsessions',
+    'signals.apps.signals.tasks.refresh_database_view.refresh_materialized_view_public_signals_geography_feature_collection': 'signals.apps.signals.tasks.refresh_materialized_view_public_signals_geography_feature_collection',
+    'signals.apps.signals.tasks.signal_routing.apply_routing': 'signals.apps.signals.tasks.apply_routing',
+}  # noqa
+
+def _fix_celery_tasks(
+        apps: Apps,
+        schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    PeriodicTask = apps.get_model(
+        app_label='django_celery_beat',
+        model_name='PeriodicTask'
+    )
+
+    # Loop through the keys in the FORWARD_MAPPING dictionary
+    for key, value in FORWARD_MAPPING.items():
+        PeriodicTask.objects.filter(task=key).update(task=value)
+
+def _reverse_fix_celery_tasks(
+        apps: Apps,
+        schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    PeriodicTask = apps.get_model(
+        app_label='django_celery_beat',
+        model_name='PeriodicTask'
+    )
+
+    # Loop through the keys in the REVERSED_MAPPING dictionary
+    for key, value in REVERSED_MAPPING.items():
+        PeriodicTask.objects.filter(task=key).update(task=value)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('signals', '0195_auto_20230821_1059'),
+    ]
+
+    operations = [
+        RunPython(
+            code=_fix_celery_tasks,
+            reverse_code=_reverse_fix_celery_tasks
+        )
+    ]


### PR DESCRIPTION
## Description

This migration updates the Celery task references in the database to match the new folder structure for tasks. Previously, all tasks were located in a single tasks.py file, but they have now been refactored into individual files within a 'tasks' folder.

The FORWARD_MAPPING and REVERSED_MAPPING dictionaries are used to map old task references to new ones. The migration script loops through these mappings, updating the task references in the 'PeriodicTask' model of the 'django_celery_beat' app.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
