### PR TITLE
Make status messages index configurable (part 2)

### DIFF
--- a/app/signals/apps/search/elasticsearch_dsl/search.py
+++ b/app/signals/apps/search/elasticsearch_dsl/search.py
@@ -3,6 +3,7 @@
 from elasticsearch_dsl import FacetedSearch, Search, TermsFacet
 
 from signals.apps.search.documents.status_message import StatusMessage
+from signals.apps.search.settings import app_settings
 
 
 class StatusMessagesSearch(FacetedSearch):
@@ -10,7 +11,7 @@ class StatusMessagesSearch(FacetedSearch):
     configure a faceted search, which allows us to use filters and provides us with
     counts for each possible filter option.
     """
-    index = 'status_messages'
+    index = app_settings.CONNECTION['STATUS_MESSAGE_INDEX']
     doc_types = (StatusMessage,)
     fields = ('title', 'text',)
     facets = {

--- a/app/signals/apps/search/management/commands/delete_status_messages_index.py
+++ b/app/signals/apps/search/management/commands/delete_status_messages_index.py
@@ -3,10 +3,12 @@
 from django.core.management import BaseCommand
 from elasticsearch_dsl import Index
 
+from signals.apps.search.settings import app_settings
+
 
 class Command(BaseCommand):
     help = 'Manage status messages index'
 
     def handle(self, *args, **options):
-        index = Index('status_messages')
+        index = Index(app_settings.CONNECTION['STATUS_MESSAGE_INDEX'])
         index.delete()


### PR DESCRIPTION
## Description

We would like to propose to make the new status messages index name configurable, as the other Signalen municipalities typically share one Elasticsearch cluster for multiple environments (acceptance, production).

By making the status message index name configurable, we support this deployment scenario.

In addition to #1362 we found two other hardcoded references to "status_messages". This PR also makes these configurable.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
