### PR TITLE
Don't save signal when creating a note as nothing has changed on the …

### DIFF
--- a/app/signals/apps/signals/managers.py
+++ b/app/signals/apps/signals/managers.py
@@ -375,7 +375,6 @@ class SignalManager(models.Manager):
         from .models import Note
 
         note = Note.objects.create(**data, _signal_id=signal.id)
-        signal.save()
 
         return note
 

--- a/app/signals/apps/signals/tests/test_models.py
+++ b/app/signals/apps/signals/tests/test_models.py
@@ -235,10 +235,6 @@ class TestSignalManager(TransactionTestCase):
         self.assertEqual(Note.objects.count(), 1)
         self.assertEqual(signal.notes.count(), 1)
 
-        # signal updated_at field should be updated
-        new_updated_at = Signal.objects.get(id=signal.id).updated_at
-        self.assertNotEqual(old_updated_at, new_updated_at)
-
         # check that the relevant Django signal fired
         patched_create_note.send_robust.assert_called_once_with(
             sender=Signal.actions.__class__,

--- a/app/signals/apps/signals/tests/test_models.py
+++ b/app/signals/apps/signals/tests/test_models.py
@@ -226,7 +226,6 @@ class TestSignalManager(TransactionTestCase):
     @mock.patch('signals.apps.signals.managers.create_note')
     def test_create_note(self, patched_create_note):
         signal = factories.SignalFactory.create()
-        old_updated_at = signal.updated_at
 
         # add note to signal via internal actions API
         note = Signal.actions.create_note(self.note_data, signal)


### PR DESCRIPTION
## Description

Don't save signal when creating a note as nothing has changed on the actual signal.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
