### PR TITLE
When adding a Note, ensure that ONLY the 'updated_at' timestamp of a Signal is updated

### DIFF
--- a/app/signals/apps/signals/managers.py
+++ b/app/signals/apps/signals/managers.py
@@ -376,6 +376,11 @@ class SignalManager(models.Manager):
 
         note = Note.objects.create(**data, _signal_id=signal.id)
 
+        # Ensures that the 'updated_at' timestamp accurately reflects the most
+        # recent activity related to a Signal, without altering any other
+        # existing data
+        signal.save(update_fields=['updated_at'])
+
         return note
 
     def create_note(self, data: dict, signal):


### PR DESCRIPTION
## Description

Ensures that the `updated_at` timestamp accurately reflects the most recent activity related to a Signal, without altering any other existing data.

In commit 9dc54a1, the `signal.save()` method was removed. However, this change affected the 'updated_at' timestamp used by the 'geen actie nodig' functionality on a parent Signal.


## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
