### PR TITLE
Delete translation file before uploading the updated version

### DIFF
--- a/app/signals/apps/api/views/translations.py
+++ b/app/signals/apps/api/views/translations.py
@@ -39,12 +39,11 @@ class PrivateCreateI18NextTranslationFileView(APIView):
             latest_file_content = latest_file_content.encode('utf-8')
 
         if default_storage.exists(I18NEXT_TRANSLATION_FILE_PATH):
-            # Overwrite the JSON data to storage
-            with default_storage.open(I18NEXT_TRANSLATION_FILE_PATH, 'wb') as translation_file:
-                translation_file.write(latest_file_content)
-        else:
-            # Save JSON data to storage
-            default_storage.save(I18NEXT_TRANSLATION_FILE_PATH, ContentFile(latest_file_content))
+            # Delete the old file
+            default_storage.delete(I18NEXT_TRANSLATION_FILE_PATH)
+
+        # Save JSON data to storage
+        default_storage.save(I18NEXT_TRANSLATION_FILE_PATH, ContentFile(latest_file_content))
 
         return Response(data=request.data, status=HTTP_201_CREATED)
 


### PR DESCRIPTION
## Description

Due to Azure's limitations, we are unable to overwrite the translation file directly. To work around this, we delete the existing file before uploading the updated version.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
