### PR TITLE
Always create a new token and delete the old ones

### DIFF
--- a/app/signals/apps/my_signals/rest_framework/views/token.py
+++ b/app/signals/apps/my_signals/rest_framework/views/token.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Gemeente Amsterdam
+# Copyright (C) 2023 Gemeente Amsterdam
+from typing import Any
+
 from datapunt_api.rest import DEFAULT_RENDERERS
-from django.utils.timezone import now
+from django.db import transaction
+from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.serializers import BaseSerializer
 from rest_framework.views import APIView
 
 from signals.apps.my_signals.mail import send_token_mail
@@ -20,26 +24,25 @@ class ObtainMySignalsTokenViewSet(APIView):
     renderer_classes = DEFAULT_RENDERERS
     serializer_class = MySignalsTokenSerializer
 
-    def get_serializer_context(self):
+    def get_serializer_context(self) -> dict[str, Any]:
         return {'request': self.request, 'format': self.format_kwarg, 'view': self}
 
-    def get_serializer(self, *args, **kwargs):
+    def get_serializer(self, *args, **kwargs) -> BaseSerializer:
         kwargs['context'] = self.get_serializer_context()
         return self.serializer_class(*args, **kwargs)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args, **kwargs) -> Response:
         """
-        Always return an HTTP 200 response with no body
+        Always return an HTTP 200 response without body
         """
         serializer = self.get_serializer(data=request.data)
         if serializer.is_valid():
             reporter_email = serializer.validated_data['reporter_email']
-            try:
-                # Do we want to reuse any previous token if it is still valid? Or do we want to create a new token
-                # and expire/remove old tokens?
-                token = Token.objects.get(reporter_email=reporter_email, expires_at__gte=now())
-            except Token.DoesNotExist:
+
+            with transaction.atomic():
+                Token.objects.filter(reporter_email=reporter_email).delete()
                 token = Token.objects.create(reporter_email=reporter_email)
+
             send_token_mail(token)
 
         return Response()


### PR DESCRIPTION
## Description

Always create a new token and delete the old ones when a new token is requested.
This should prevent the error we've seen in production where sometimes multiple tokens already exist.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
