### PR TITLE
Implemented 'sia_can_view_contact_details' permission check on signal reporter endpoints

### DIFF
--- a/app/signals/apps/api/generics/permissions.py
+++ b/app/signals/apps/api/generics/permissions.py
@@ -135,10 +135,16 @@ class SIAUserPermissions(SIABasePermission):
 class ReporterPermission(BasePermission):
     def has_permission(self, request: Request, view: View) -> bool:
         """
+        The user must have the permission to view contact details in general
+        AND at one of the following permissions:
+
         If the user has the permission to view all categories, they can view all reporters of that Signal
         OR
         If the user has the permission to view the category of the Signal, they can view all reporters of that Signal.
         """
+        if not request.user.has_perm('signals.sia_can_view_contact_details'):
+            return False
+
         return SignalPermissionService.has_signal_permission(
             user=request.user,
             signal=view.get_signal()
@@ -149,10 +155,16 @@ class ReporterPermission(BasePermission):
 
     def has_object_permission(self, request: Request, view: View, obj: Reporter) -> bool:
         """
+        The user must have the permission to view contact details in general
+        AND at one of the following permissions:
+
         If the user has the permission to view all categories, they can view a reporter of that Signal
         OR
         If the user has the permission to view the category of the Signal, they can view a reporter of that Signal.
         """
+        if not request.user.has_perm('signals.sia_can_view_contact_details'):
+            return False
+
         return SignalPermissionService.has_signal_permission(
             user=request.user,
             signal=obj._signal

--- a/app/signals/apps/api/tests/scenarios/context/user.py
+++ b/app/signals/apps/api/tests/scenarios/context/user.py
@@ -21,7 +21,8 @@ def given_read_write_user() -> User:
         'sia_signal_create_initial',
         'sia_signal_create_note',
         'sia_signal_change_status',
-        'sia_signal_change_category'
+        'sia_signal_change_category',
+        'sia_can_view_contact_details',
     ))
     sia_test_group = GroupFactory.create(name='Test Group')
     sia_test_group.permissions.add(*permissions)

--- a/app/signals/apps/api/tests/test_private_signal_reporters.py
+++ b/app/signals/apps/api/tests/test_private_signal_reporters.py
@@ -9,7 +9,8 @@ from rest_framework.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
     HTTP_400_BAD_REQUEST,
-    HTTP_401_UNAUTHORIZED
+    HTTP_401_UNAUTHORIZED,
+    HTTP_403_FORBIDDEN,
 )
 from rest_framework.test import APITestCase
 
@@ -17,6 +18,7 @@ from signals.apps.email_integrations.factories import EmailTemplateFactory
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.signals.factories import ReporterFactory, SignalFactory
 from signals.apps.signals.models import Reporter
+from signals.apps.users.factories import UserFactory
 from signals.test.utils import SIAReadWriteUserMixin
 
 
@@ -36,6 +38,8 @@ class TestPrivateSignalReportersEndpointUnAuthorized(APITestCase):
 class TestPrivateSignalReportersEndpoint(SIAReadWriteUserMixin, APITestCase):
     def setUp(self) -> None:
         self.sia_read_write_user.user_permissions.add(Permission.objects.get(codename='sia_can_view_all_categories'))
+        self.sia_read_write_user.user_permissions.add(Permission.objects.get(codename='sia_can_view_contact_details'))
+
         self.client.force_authenticate(user=self.sia_read_write_user)
 
     def test_list(self) -> None:
@@ -151,3 +155,49 @@ class TestPrivateSignalReportersEndpoint(SIAReadWriteUserMixin, APITestCase):
         self.assertIsNotNone(non_field_errors)
         self.assertEqual(len(non_field_errors), 1)
         self.assertEqual(non_field_errors[0], 'Cancelling this reporter is not possible.')
+
+    def test_403_forbidden(self):
+        """
+        A user without the permission "sia_can_view_contact_details" should not be allowed to create a new Reporter OR
+        update a transition to a new Reporter.
+        """
+        user_incorrect_permissions = UserFactory.create()
+        user_incorrect_permissions.user_permissions.add(self.sia_read)
+        user_incorrect_permissions.user_permissions.add(self.sia_write)
+        user_incorrect_permissions.user_permissions.add(Permission.objects.get(codename='sia_can_view_all_categories'))
+
+        self.client.force_authenticate(user_incorrect_permissions)
+
+        signal = SignalFactory.create(reporter__state=Reporter.REPORTER_STATE_APPROVED)
+
+        # Create
+        response = self.client.post(
+            f'/signals/v1/private/signals/{signal.pk}/reporters/',
+            data={'email': 'test@example.com', 'phone': '0612345678', 'sharing_allowed': True},
+            format='json'
+        )
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
+        # Cancel, signal not found
+        response = self.client.post(
+            '/signals/v1/private/signals/11145/reporters/1/cancel',
+            data={},
+            format='json',
+        )
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
+        # Cancel, reporter not found
+        response = self.client.post(
+            f'/signals/v1/private/signals/{signal.pk}/reporters/11145/cancel',
+            data={},
+            format='json',
+        )
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
+        # Cancel
+        response = self.client.post(
+            f'/signals/v1/private/signals/{signal.pk}/reporters/{signal.reporter.pk}/cancel',
+            data={},
+            format='json',
+        )
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)

--- a/app/signals/apps/api/tests/test_private_signal_reporters.py
+++ b/app/signals/apps/api/tests/test_private_signal_reporters.py
@@ -10,7 +10,7 @@ from rest_framework.status import (
     HTTP_201_CREATED,
     HTTP_400_BAD_REQUEST,
     HTTP_401_UNAUTHORIZED,
-    HTTP_403_FORBIDDEN,
+    HTTP_403_FORBIDDEN
 )
 from rest_framework.test import APITestCase
 


### PR DESCRIPTION
## Description

Implemented 'sia_can_view_contact_details' permission check on signal reporter endpoints and updated/added tests

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
