### PR TITLE
Limit elasticsearch heap to 4gb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,9 @@ services:
   elasticsearch:
     image: elasticsearch:7.17.9
     shm_size: '512m'
-    command: elasticsearch -Ehttp.host=0.0.0.0 -Etransport.host=127.0.0.1
+    command: elasticsearch -Ehttp.host=0.0.0.0 -Etransport.host=127.0.0.1 -Expack.security.enabled=false
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx4g"
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
## Description

Limit elasticsearch heap to 4gb.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
