### PR TITLE
Small refactor of the OIDC admin

### DIFF
--- a/app/signals/admin/oidc/backends.py
+++ b/app/signals/admin/oidc/backends.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Delta10 B.V.
+# Copyright (C) 2022 - 2023 Delta10 B.V., Gemeente Amsterdam
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
 
@@ -13,6 +13,3 @@ class AuthenticationBackend(OIDCAuthenticationBackend):
 
     def create_user(self, claims):
         return None  # do not create users when they do not exist in the database
-
-    def update_user(self, user, claims):
-        return user  # do not update any attributes in the database based on claims

--- a/app/signals/admin/oidc/tests/test_backends.py
+++ b/app/signals/admin/oidc/tests/test_backends.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Delta10 B.V.
+# Copyright (C) 2022 - 2023 Delta10 B.V., Gemeente Amsterdam
 from django.test import TestCase
 
 from signals.admin.oidc.backends import AuthenticationBackend
@@ -18,6 +18,17 @@ class BackendsTest(TestCase):
         users_from_backend = backend.filter_users_by_claims(claims)
 
         self.assertEqual(user, users_from_backend[0])
+
+    def test_filter_users_by_claims_empty_claim(self):
+        for empty_value in [None, '', False, 0]:
+            claims = {
+                'email': empty_value
+            }
+
+            backend = AuthenticationBackend()
+            users_from_backend = backend.filter_users_by_claims(claims)
+
+            self.assertEqual(users_from_backend.count(), 0)
 
     def test_create_user(self):
         backend = AuthenticationBackend()

--- a/app/signals/admin/oidc/views.py
+++ b/app/signals/admin/oidc/views.py
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Delta10 B.V.
-from django.shortcuts import render
-
-
-def login_failure(request):
-    return render(request, 'admin/oidc/login_failure.html')

--- a/app/signals/urls.py
+++ b/app/signals/urls.py
@@ -3,9 +3,9 @@
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, re_path
+from django.views.generic import TemplateView
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-from signals.admin.oidc import views as admin_oidc_views
 from signals.apps.api.generics.routers import BaseSignalsAPIRootView
 
 # Remove "view website" button in the Django admin
@@ -35,7 +35,7 @@ if settings.DEBUG:
 
 if settings.OIDC_RP_CLIENT_ID:
     urlpatterns += [
-        path('signals/oidc/login_failure/', admin_oidc_views.login_failure),
+        path('signals/oidc/login_failure/', TemplateView.as_view(template_name='admin/oidc/login_failure.html')),
         path('signals/oidc/', include('mozilla_django_oidc.urls')),
     ]
 


### PR DESCRIPTION
## Description

Small refactor of the OIDC admin

- Removed the `views.py` and now use the TemplateView for the url path `signals/oidc/login_failure/`
- Removed the `update_user` method of the `AuthenticationBackend`. It is already defined (the same way) in the mozilla_django_oidc `OIDCAuthenticationBackend` https://github.com/mozilla/mozilla-django-oidc/blob/main/mozilla_django_oidc/auth.py#L112
- Added tests to get 100% coverage

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
