### PR TITLE
Added the `OIDC_CREATE_USER` setting to prevent user creation by the `mozilla-django-oidc` package

### DIFF
--- a/app/signals/admin/oidc/backends.py
+++ b/app/signals/admin/oidc/backends.py
@@ -10,6 +10,3 @@ class AuthenticationBackend(OIDCAuthenticationBackend):
             return self.UserModel.objects.none()
 
         return self.UserModel.objects.filter(username__iexact=email)
-
-    def create_user(self, claims):
-        return None  # do not create users when they do not exist in the database

--- a/app/signals/admin/oidc/tests/test_backends.py
+++ b/app/signals/admin/oidc/tests/test_backends.py
@@ -29,17 +29,3 @@ class BackendsTest(TestCase):
             users_from_backend = backend.filter_users_by_claims(claims)
 
             self.assertEqual(users_from_backend.count(), 0)
-
-    def test_create_user(self):
-        backend = AuthenticationBackend()
-        result = backend.create_user({})
-
-        self.assertEqual(result, None)
-
-    def test_update_user(self):
-        user = UserFactory.create()
-
-        backend = AuthenticationBackend()
-        result = backend.update_user(user, {})
-
-        self.assertEqual(result, user)

--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -165,6 +165,7 @@ OIDC_OP_USER_ENDPOINT: str | None = os.getenv('OIDC_OP_USER_ENDPOINT')
 OIDC_OP_JWKS_ENDPOINT: str | None = os.getenv('OIDC_OP_JWKS_ENDPOINT')
 if OIDC_OP_JWKS_ENDPOINT is not None:
     OIDC_RP_SIGN_ALGO: str = 'RS256'
+OIDC_CREATE_USER = False
 
 AUTHENTICATION_BACKENDS: list[str] = [
     'signals.admin.oidc.backends.AuthenticationBackend',


### PR DESCRIPTION
## Description

Added the `OIDC_CREATE_USER` setting (set to `False`) to prevent user creation. This commits also removes the custom code that was created to prevent this behaviour. This change is made in accordance with the `mozilla-django-oidc` the [documentation](https://mozilla-django-oidc.readthedocs.io/en/stable/installation.html#preventing-mozilla-django-oidc-from-creating-new-django-users).

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
