### PR TITLE
Do not include full name in assigned e-mail notification

### DIFF
--- a/app/signals/apps/email_integrations/actions/assigned_action.py
+++ b/app/signals/apps/email_integrations/actions/assigned_action.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2022 - 2023 Gemeente Amsterdam, Delta10 B.V.
 import logging
-from email.utils import formataddr
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -50,9 +49,7 @@ class AssignedAction(AbstractSystemAction):
         """
         assert self.kwargs is not None
 
-        return [
-            formataddr((self.kwargs['recipient'].get_full_name(), self.kwargs['recipient'].email))
-        ]
+        return [self.kwargs['recipient'].email]
 
     def render_mail_data(self, context: dict) -> tuple[str, str, str]:
         """

--- a/app/signals/apps/email_integrations/tests/test_action_assigned.py
+++ b/app/signals/apps/email_integrations/tests/test_action_assigned.py
@@ -25,7 +25,7 @@ class TestActionAssigned(TestCase):
 
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, f'Melding {self.signal.get_id_display()} is toegewezen aan jou')
-        self.assertEqual(mail.outbox[0].to, [f'{self.user.get_full_name()} <{self.user.email}>'])
+        self.assertEqual(mail.outbox[0].to, [self.user.email])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)
 
     def test_mail_assigned_to_department(self):
@@ -42,5 +42,5 @@ class TestActionAssigned(TestCase):
         self.assertEqual(mail.outbox[0].subject,
                          f'Melding {self.signal.get_id_display()} is toegewezen aan {self.department}'
                          )
-        self.assertEqual(mail.outbox[0].to, [f'{self.user.get_full_name()} <{self.user.email}>'])
+        self.assertEqual(mail.outbox[0].to, [self.user.email])
         self.assertEqual(mail.outbox[0].from_email, settings.DEFAULT_FROM_EMAIL)


### PR DESCRIPTION
## Description

For some e-mail providers (like the REST backend and django-o365mail) adding a full name to a recipient seems to be not supported and results in an error:

```
  File "/usr/local/lib/python3.11/site-packages/O365/connection.py", line 754, in _internal_request
    response.raise_for_status()  # raise 4XX and 5XX error codes.
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://graph.microsoft.com/v1.0/users/noreply@municipality.nl/sendMail
```

Therefore I propose to omit the full name from the recipients list.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code

## References

- https://github.com/evyd13/django-o365mail/blob/main/src/django_o365mail/backend.py#L113
- https://github.com/delta10/signalen-backend/blob/87ee56b7e880fc1b2623eda0d32f685afdcd0248/app/signals/apps/email_integrations/custom_backends/rest_email_endpoint.py#L86