### PR TITLE
Add configurable timeout to search app

### DIFF
--- a/app/signals/apps/search/apps.py
+++ b/app/signals/apps/search/apps.py
@@ -14,4 +14,4 @@ class SearchConfig(AppConfig):
         from .settings import app_settings
 
         host = app_settings.CONNECTION['HOST'] or 'localhost'
-        connections.create_connection(hosts=[host, ])
+        connections.create_connection(hosts=[host, ], timeout=app_settings.TIMEOUT)

--- a/app/signals/apps/search/settings.py
+++ b/app/signals/apps/search/settings.py
@@ -9,6 +9,7 @@ DEFAULTS = dict(
         HOST='http://127.0.0.1:9200',
         INDEX='signals',
     ),
+    TIMEOUT=10,
 )
 
 

--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -395,6 +395,7 @@ SEARCH: dict[str, int | dict[str, str]] = {
         'INDEX': os.getenv('ELASTICSEARCH_INDEX', 'signals'),
         'STATUS_MESSAGE_INDEX': os.getenv('ELASTICSEARCH_STATUS_MESSAGE_INDEX', 'status_messages'),
     },
+    'TIMEOUT': int(os.getenv('ELASTICSEARCH_TIMEOUT', 10)),
 }
 
 API_DETERMINE_STADSDEEL_ENABLED_AREA_TYPE: str = 'sia-stadsdeel'


### PR DESCRIPTION
## Description

We had some issues with management commands failing due to a request timeout in the Elasticsearch library. In particular:
```python manage.py delete_status_messages_index```
and
```python manage.py init_status_messages_index```

This PR adds an environment variable that changes the timeout of elasticsearch requests.The previous default of 10 seconds is now explicitly configured in the Signalen code instead of using the default value from the Elasticsearch library.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

Tested on the Delta10 cluster in a production environment.

- [ ] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
