### PR TITLE
Sigmax, fix for XML external entity expansion

### DIFF
--- a/app/signals/apps/sigmax/stuf_protocol/incoming/actualiseerZaakstatus_Lk01.py
+++ b/app/signals/apps/sigmax/stuf_protocol/incoming/actualiseerZaakstatus_Lk01.py
@@ -29,7 +29,9 @@ def _parse_actualiseerZaakstatus_Lk01(xml):
 
     # strip the relevant information from the return message
     assert type(xml) == type(b'a')  # noqa: E721
-    tree = etree.fromstring(xml)
+
+    parser = etree.XMLParser(resolve_entities=False, no_network=True)
+    tree = etree.fromstring(xml, parser=parser)
 
     def xpath(expression):
         found = tree.xpath(expression, namespaces=namespaces)

--- a/app/signals/apps/sigmax/stuf_protocol/incoming/actualiseerZaakstatus_Lk01.py
+++ b/app/signals/apps/sigmax/stuf_protocol/incoming/actualiseerZaakstatus_Lk01.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2018 - 2021 Gemeente Amsterdam
+# Copyright (C) 2018 - 2023 Gemeente Amsterdam
 """
 Support for actualiseerZaakstatus_Lk01 messages from CityControl.
 """
@@ -30,7 +30,7 @@ def _parse_actualiseerZaakstatus_Lk01(xml):
     # strip the relevant information from the return message
     assert type(xml) == type(b'a')  # noqa: E721
 
-    parser = etree.XMLParser(resolve_entities=False, no_network=True)
+    parser = etree.XMLParser(resolve_entities=False)
     tree = etree.fromstring(xml, parser=parser)
 
     def xpath(expression):

--- a/app/signals/apps/sigmax/tests/xxe_test_file.txt
+++ b/app/signals/apps/sigmax/tests/xxe_test_file.txt
@@ -1,0 +1,1 @@
+XXE Test File


### PR DESCRIPTION
## Description

The lxml `etree.fromstring()` function has a security risk of XXE attacks. A custom XML parser is now used that disables resolving entities and blocks network access.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
