### PR TITLE
Throttling ident fix

### DIFF
--- a/app/signals/throttling.py
+++ b/app/signals/throttling.py
@@ -27,6 +27,11 @@ class PostOnlyNoUserRateThrottle(SimpleRateThrottle):
 
         return allow
 
+    def get_ident(self, request: Request) -> str:
+        ident = super().get_ident(request=request)
+        last_colon_index = ident.rfind(":")
+        return ident[:last_colon_index] if last_colon_index != -1 else ident
+
     def get_cache_key(self, request, view) -> str:
         return self.cache_format % {
             'scope': self.scope,


### PR DESCRIPTION
## Description

In this commit the `get_ident` method, in the `PostOnlyNoUserRateThrottle` class, is updated to ensure that the identification string is stripped of the colon and port number

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
