### PR TITLE
Use database cache backend

### DIFF
--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -216,7 +216,9 @@ DATABASES: dict[str, dict[str, str | int | None]] = {
 # Django cache settings
 CACHES: dict[str, dict[str, str | int]] = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'signals_cache',
+        'TIMEOUT': os.getenv('CACHE_TIMEOUT', 3900),
     }
 }
 

--- a/docker-compose/scripts/initialize.sh
+++ b/docker-compose/scripts/initialize.sh
@@ -12,6 +12,9 @@ python manage.py shell -c "from django.contrib.auth import get_user_model; User 
 # Collect static
 python manage.py collectstatic --no-input
 
+# Create cache table
+python manage.py createcachetable
+
 if [[ ${INITIALIZE_WITH_DUMMY_DATA:-0} == 1 ]]; then
   if python manage.py shell -c "import sys; from django.db import connection; cursor = connection.cursor(); cursor.execute('select count(*) from signals_signal'); sys.exit(cursor.fetchone()[0])"; then
     echo "Load dummy data"


### PR DESCRIPTION
## Description
Use the database cache backend instead of the local memory cache backend. We need this in order for the api request throttling to work correctly.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
