### PR TITLE
Added ordering on the areas public and private endpoint

### DIFF
--- a/app/signals/apps/api/views/area.py
+++ b/app/signals/apps/api/views/area.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2020 - 2023 Gemeente Amsterdam
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.decorators import action
+from rest_framework.filters import OrderingFilter
 from rest_framework.mixins import ListModelMixin
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -15,22 +17,25 @@ from signals.auth.backend import JWTAuthBackend
 
 class PublicAreasViewSet(ListModelMixin, GenericViewSet):
     """
-    A viewset for retrieving areas.
+    A ViewSet for retrieving areas.
     """
+    serializer_class = AreaSerializer
+
+    filter_backends = (DjangoFilterBackend, OrderingFilter,)
+    filterset_class = AreaFilterSet
 
     queryset = Area.objects.all()
-    serializer_class = AreaSerializer
-    filterset_class = AreaFilterSet
+    ordering = ("_type", "name", ) # Order by _type and name by default
 
     @extend_schema(
         parameters=[
-            OpenApiParameter(name='geopage', location=OpenApiParameter.QUERY,
-                             description='A page number within the paginated result set.', required=False, type=int),
-            OpenApiParameter(name='page_size', location=OpenApiParameter.QUERY,
-                             description='Number of results to return per page.', required=False, type=int),
+            OpenApiParameter(name="geopage", location=OpenApiParameter.QUERY,
+                             description="A page number within the paginated result set.", required=False, type=int),
+            OpenApiParameter(name="page_size", location=OpenApiParameter.QUERY,
+                             description="Number of results to return per page.", required=False, type=int),
         ],
     )
-    @action(detail=False, url_path='geography', serializer_class=AreaGeoSerializer,
+    @action(detail=False, url_path="geography", serializer_class=AreaGeoSerializer,
             pagination_class=LinkHeaderPagination)
     def geography(self, *args: list, **kwargs: dict) -> Response:
         """
@@ -40,7 +45,7 @@ class PublicAreasViewSet(ListModelMixin, GenericViewSet):
         """
         filtered_qs = self.filter_queryset(self.get_queryset())
 
-        paginator = LinkHeaderPagination(page_query_param='geopage')
+        paginator = LinkHeaderPagination(page_query_param="geopage")
         page = paginator.paginate_queryset(filtered_qs, self.request, view=self)
         if page is not None:
             serializer = AreaGeoSerializer(page, many=True)
@@ -52,7 +57,7 @@ class PublicAreasViewSet(ListModelMixin, GenericViewSet):
 
 class PrivateAreasViewSet(PublicAreasViewSet):
     """
-    A viewset for retrieving areas.
+    A ViewSet for retrieving areas.
 
     Inherits from PublicAreasViewSet and adds authentication.
     """

--- a/app/signals/apps/api/views/area.py
+++ b/app/signals/apps/api/views/area.py
@@ -25,7 +25,7 @@ class PublicAreasViewSet(ListModelMixin, GenericViewSet):
     filterset_class = AreaFilterSet
 
     queryset = Area.objects.all()
-    ordering = ("_type", "name", ) # Order by _type and name by default
+    ordering = ("_type", "name", )  # Order by _type and name by default
 
     @extend_schema(
         parameters=[


### PR DESCRIPTION
## Description

Added ordering on the areas public and private endpoint + by default order on _type,name + added tests

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
