### PR TITLE
Discontinuing stewardship by Foundation for Public Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,3 @@ section.
 We welcome contributions to Signalen! If you're interested in contributing,
 take a look at our [contribution guide](docs/CONTRIBUTING.md) and our
 [local development guide](./docs/development/local.md).
-
-## Under Foundation for Public Code incubating codebase stewardship
-
-Signalen is in incubation [codebase stewardship](https://publiccode.net/codebase-stewardship/)
-with the [Foundation for Public Code](https://publiccode.net).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,14 +67,3 @@ Contributors may wish to familiarize themselves with the open standards used wit
 * [JSONSchema](https://json-schema.org/)
 * [GeoJSON](https://geojson.org/)
 * [SMTP](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol#Related_requests_for_comments)
-
-## Under Foundation for Public Code incubating codebase stewardship
-
-Signalen is in incubation [codebase stewardship](https://publiccode.net/codebase-stewardship/) with the [Foundation for Public Code](https://publiccode.net).
-
-The [codebase stewardship activities](https://about.publiccode.net/activities/codebase-stewardship/activities.html) by the Foundation for Public Code on this codebase include:
-
-* facilitating the community and its members
-* help all contributors contribute in line with the contributing guidelines and the [Standard for Public Code](https://standard.publiccode.net/)
-* work with the community to tell their stories, create their brand and market their products
-* support the technical and product steering teams


### PR DESCRIPTION
## Description

As stated in the email ( https://lists.publiccode.net/hyperkitty/hyperkitty/list/signalen-discuss@lists.publiccode.net/thread/5Y3FFBD7CBP4A4766HWD7N7EVICRZJ4R/ ) the Foundation for Public Code will be winding down the office in Europe, and therefore, we will no longer be able to steward the Signalen codebase to the level which we aspire.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked
