### PR TITLE
Added/updated help text on the StandardAnswer model

### DIFF
--- a/app/signals/apps/feedback/models.py
+++ b/app/signals/apps/feedback/models.py
@@ -30,7 +30,12 @@ class StandardAnswerTopic(models.Model):
 class StandardAnswer(models.Model):
     is_visible = models.BooleanField(default=True)
     is_satisfied = models.BooleanField(default=True)
-    reopens_when_unhappy = models.BooleanField(default=False)
+    reopens_when_unhappy = models.BooleanField(default=False,
+                                               help_text='Als deze optie is aangevinkt, zal een '
+                                                         'melding heropend worden. Bij het '
+                                                         'heropenen van een melding heeft de optie '
+                                                         '"open_answer" prioriteit boven '
+                                                         'deze optie.')
     text = models.TextField(max_length=1000, unique=True)
     order = models.IntegerField(default=0, null=True, blank=True,
                                 help_text='De volgorde van de antwoorden tijdens het KTO proces. '
@@ -41,10 +46,12 @@ class StandardAnswer(models.Model):
 
     open_answer = models.BooleanField(default=False,
                                       help_text='Als deze optie is aangevinkt, '
-                                                'dan wordt er een open antwoord'
-                                                ' verwacht van de melder en is '
+                                                'dan wordt er een open antwoord '
+                                                'verwacht van de melder en is '
                                                 'de opgegeven text een default '
-                                                'waarde.')
+                                                'waarde. Een open antwoord zorgt er voor dat een '
+                                                'melding wordt heropend, deze optie heeft prioriteit '
+                                                'boven de optie "reopens_when_unhappy".')
 
     def __str__(self) -> str:
         pos_neg = 'POSITIEF' if self.is_satisfied else 'NEGATIEF'


### PR DESCRIPTION
## Description

Added/updated the help text on the "reopens_when_unhappy" and "open_answer" attributes of the StandardAnswer model.

![Screenshot from 2024-03-18 11-40-49](https://github.com/Amsterdam/signals/assets/23056530/e3d1ec66-7151-456a-886f-a61361e2220c)

![Screenshot from 2024-03-18 11-40-53](https://github.com/Amsterdam/signals/assets/23056530/bf09fd0b-487d-4614-b1e4-15e70ec4b26c)


## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
