### PR TITLE
Allow the maximum number of characters

### DIFF
--- a/app/signals/apps/api/serializers/nested/status.py
+++ b/app/signals/apps/api/serializers/nested/status.py
@@ -68,7 +68,7 @@ class _NestedStatusModelSerializer(SIAModelSerializer):
 
     def _validate_state_REACTIE_GEVRAAGD(self, attrs):
         """
-        Validate all info for REACTIE_GEVRAAGS flow is present.
+        Validate all info for REACTIE_GEVRAAGD flow is present.
         """
         if attrs['state'] == workflow.REACTIE_GEVRAAGD:  # SIG-3887
             signal = self.context['view'].get_object()

--- a/app/signals/apps/api/serializers/nested/status.py
+++ b/app/signals/apps/api/serializers/nested/status.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+# Copyright (C) 2019 - 2024 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import MaxLengthValidator
 from rest_framework import serializers
@@ -76,11 +76,8 @@ class _NestedStatusModelSerializer(SIAModelSerializer):
                 msg = 'No email address known for signal with ID={{ signal.id }}.'
                 raise ValidationError({'state': msg})
 
-            # SIG-4511
-            # Check if the given text has a maximum length of 400 characters.
-            # If not, raise a validation error.
             try:
-                MaxLengthValidator(limit_value=400)(attrs['text'])
+                MaxLengthValidator(limit_value=1000)(attrs['text'])
             except DjangoValidationError as e:
                 raise ValidationError({'text': e.messages})
 

--- a/app/signals/apps/api/tests/test_reaction_request_flow_trigger.py
+++ b/app/signals/apps/api/tests/test_reaction_request_flow_trigger.py
@@ -33,16 +33,22 @@ class TestReactionRequestFlowTrigger(SignalsBaseApiTestCase):
 
         self.assertEqual(response.status_code, 400)
 
-    def test_SIG_4511_update_status_more_than_400_characters(self):
+    def test_update_status_more_than_1000_characters(self):
+        text = """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Lorem
+ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
+sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."""
         data = {
             'status': {
-                'text': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut '
-                        'labore et dolore magna aliqua. Morbi tristique senectus et netus et malesuada fames. '
-                        'Vestibulum rhoncus est pellentesque elit ullamcorper dignissim cras tincidunt lobortis. Vitae '
-                        'auctor eu augue ut lectus arcu bibendum at varius. Luctus venenatis lectus magna fringilla '
-                        'urna. Adipiscing commodo elit at imperdiet dui accumsan sit. Venenatis urna cursus eget nunc '
-                        'scelerisque viverra mauris in. Aliquam sem et tortor consequat id porta. Massa enim nec dui '
-                        'nunc. Pellentesque adipiscing commodo elit at imperdiet dui accumsan sit.',
+                'text': text,
                 'state': 'reaction requested'
             }
         }
@@ -51,5 +57,4 @@ class TestReactionRequestFlowTrigger(SignalsBaseApiTestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['status']['text'][0],
-                         'Zorg dat deze waarde niet meer dan 400 tekens bevat (het zijn er nu '
-                         f'{len(data["status"]["text"])}).')
+                         f'Zorg dat deze waarde niet meer dan 1000 tekens bevat (het zijn er nu {len(text)}).')

--- a/app/signals/apps/questionnaires/models/question.py
+++ b/app/signals/apps/questionnaires/models/question.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 -2022 Gemeente Amsterdam
+# Copyright (C) 2021 -2024 Gemeente Amsterdam
 import uuid
 
 from django.contrib.gis.db import models
@@ -22,7 +22,7 @@ class Question(models.Model):
     uuid = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
     created_at = models.DateTimeField(editable=False, auto_now_add=True)
 
-    label = models.CharField(max_length=1000)  # noqa SIG-4511 raised the max length. The ticket states a max length of 400, but to be future proof raised to 1000
+    label = models.CharField(max_length=1000)
     short_label = models.CharField(max_length=255)
     field_type = models.CharField(choices=field_type_choices(), max_length=255)
     required = models.BooleanField(default=False)


### PR DESCRIPTION
## Description

We've been requested to raise the maximum number of characters for the message which is sent when a response is requested of the reporter from 400 characters to 1000 characters.
In the past this has already made possible in the  database model, now the validation will also allow it.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
