### PR TITLE
Upgrade to Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG PYTHON_VERSION=3.11
 ##################################################
 #                   Python                       #
 ##################################################
-FROM python:${PYTHON_VERSION}-slim-buster AS prod
+FROM python:${PYTHON_VERSION}-slim-bookworm AS prod
 
 ENV PYTHONUNBUFFERED 1
 ENV DJANGO_SETTINGS_MODULE=signals.settings
@@ -16,13 +16,13 @@ RUN useradd --no-create-home signals
 
 RUN set -eux;  \
     apt-get update && apt-get install -y \
-        libgeos-3.7 \
+        libgeos3.11.1 \
         gdal-bin \
-        libgdal20 \
+        libgdal32 \
         libspatialite7 \
         libfreexl1 \
-        libgeotiff2 \
-        libwebp6 \
+        libgeotiff5 \
+        libwebp7 \
         proj-bin \
         mime-support \
         gettext \
@@ -30,7 +30,7 @@ RUN set -eux;  \
         libwebpdemux2 \
         libxml2 \
         libfreetype6 \
-        libtiff5 \
+        libtiff6 \
         libgdk-pixbuf2.0-0 \
         libmagic1 \
         libcairo2 \


### PR DESCRIPTION
Yesterday I received the following e-mail from Microsoft:

> In July 2024, we’ll begin updating Azure Database for PostgreSQL Flexible Server to use TLS certificates from [Microsoft RSA Root Certificate Authority 2017](https://www.microsoft.com/pkiops/certs/Microsoft%20RSA%20Root%20Certificate%20Authority%202017.crt). If your apps use certificate pinning, you’ll need to update your trusted root store to accept this root CA in addition to existing  [DigiCert Global Root CA](https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem).

The Microsoft RSA Root Certificate Authority 2017 is not included in Debian Buster. Also the LTS of Debian Buster [expires on June 30th 2024](https://wiki.debian.org/LTS). So I think the best way to solve these problems, is to upgrade to Debian Bookworm.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
