### PR TITLE
safely check if user attribute is inside a request

### DIFF
--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -535,7 +535,12 @@ trace.set_tracer_provider(tracer_provider)
 
 # As required, the user id and name is attached to each request that is recorded as a span
 def response_hook(span, request, response):
-    if all([span, span.is_recording(), request.user, request.user.is_authenticated]):
+    if all([
+        span,
+        span.is_recording(),
+        getattr(request, 'user', None) is not None,
+        getattr(request.user, 'is_authenticated', False)
+    ]):
         span.set_attributes({
             'user_id': request.user.id,
             'username': request.user.username


### PR DESCRIPTION
## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
