### PR TITLE
Add ability to protect media folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ RUN set -eux;  \
         libmagic1 \
         libcairo2 \
         libpango1.0-0 \
+        libpcre3 \
+        libpcre3-dev \
         libpq-dev \
         gcc \
         graphviz \

--- a/app/signals/apps/media/README.md
+++ b/app/signals/apps/media/README.md
@@ -1,0 +1,23 @@
+# Protected media
+
+This app provides the possibility to protect the media folder. To use this functionality in production, specific uWSGI settings are required to use the X-Sendfile header.
+
+You can run uWSGI as follows:
+
+```bash
+uwsgi \
+    --master \
+    --http=0.0.0.0:8000 \
+    --module=signals.wsgi:application \
+    --static-map=/signals/static=./app/static \
+    --static-safe=./app/media \
+    --offload-threads=2 \
+    --collect-header="X-Sendfile X_SENDFILE" \
+    --response-route-if-not="empty:${X_SENDFILE} static:${X_SENDFILE}" \
+    --buffer-size=32768 \
+    --die-on-term \
+    --processes=4 \
+    --threads=2
+```
+
+The relevant settings are `plugins`, `offload-threads`, `collect-header` and `response-route-if-not`. For more information see the [X-Sendfile emulation snippet of the uWSGI documentation](https://uwsgi-docs.readthedocs.io/en/latest/Snippets.html#x-sendfile-emulation).

--- a/app/signals/apps/media/README.md
+++ b/app/signals/apps/media/README.md
@@ -1,8 +1,12 @@
 # Protected media
 
-This app provides the possibility to protect the media folder. To use this functionality in production, specific uWSGI settings are required to use the X-Sendfile header.
+This app provides the possibility to protect the media folder. To use this functionality in production, make sure to configure the PROTECTED_FILE_SYSTEM_STORAGE flag as follows:
 
-You can run uWSGI as follows:
+```bash
+export PROTECTED_FILE_SYSTEM_STORAGE=True
+```
+
+Then specific the following uWSGI settings to protect the media folder:
 
 ```bash
 uwsgi \

--- a/app/signals/apps/media/README.md
+++ b/app/signals/apps/media/README.md
@@ -1,10 +1,6 @@
 # Protected media
 
-This app provides the possibility to protect the media folder. To use this functionality in production, make sure to configure the PROTECTED_FILE_SYSTEM_STORAGE flag as follows:
-
-```bash
-export PROTECTED_FILE_SYSTEM_STORAGE=True
-```
+This app provides the possibility to protect the media folder. To use this functionality in production, make sure to configure the PROTECTED_FILE_SYSTEM_STORAGE setting.
 
 Then specific the following uWSGI settings to protect the media folder:
 

--- a/app/signals/apps/media/apps.py
+++ b/app/signals/apps/media/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class MediaConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "media"

--- a/app/signals/apps/media/apps.py
+++ b/app/signals/apps/media/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class MediaConfig(AppConfig):
-    default_auto_field = "django.db.models.BigAutoField"
-    name = "media"
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'media'

--- a/app/signals/apps/media/storages.py
+++ b/app/signals/apps/media/storages.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2024 Delta10 B.V.
+from urllib.parse import urljoin
+
+from django.core import signing
+from django.core.files.storage import FileSystemStorage
+from django.utils.encoding import filepath_to_uri
+
+signer = signing.TimestampSigner()
+
+
+class ProtectedFileSystemStorage(FileSystemStorage):
+    def url(self, name):
+        if self.base_url is None:
+            raise ValueError("This file is not accessible via a URL.")
+
+        url = filepath_to_uri(name)
+        if url is not None:
+            url = url.lstrip("/")
+
+        signature = signer.sign(url).split(':')
+
+        full_path = urljoin(self.base_url, url)
+        return full_path + f'?t={signature[1]}&s={signature[2]}'

--- a/app/signals/apps/media/storages.py
+++ b/app/signals/apps/media/storages.py
@@ -12,11 +12,11 @@ signer = signing.TimestampSigner()
 class ProtectedFileSystemStorage(FileSystemStorage):
     def url(self, name):
         if self.base_url is None:
-            raise ValueError("This file is not accessible via a URL.")
+            raise ValueError('This file is not accessible via a URL.')
 
         url = filepath_to_uri(name)
         if url is not None:
-            url = url.lstrip("/")
+            url = url.lstrip('/')
 
         signature = signer.sign(url).split(':')
 

--- a/app/signals/apps/media/tests.py
+++ b/app/signals/apps/media/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/app/signals/apps/media/tests.py
+++ b/app/signals/apps/media/tests.py
@@ -1,3 +1,45 @@
-from django.test import TestCase
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2024 Delta10 B.V.
+from django.test import TestCase, override_settings
+from django.http import HttpResponse
+from unittest.mock import patch
 
-# Create your tests here.
+from app.signals.apps.media.storages import ProtectedFileSystemStorage
+
+
+@override_settings(PROTECTED_FILE_SYSTEM_STORAGE=True)
+class DownloadFileTestCase(TestCase):
+    def setUp(self):
+        self.storage = ProtectedFileSystemStorage(base_url='http://localhost:8000/signals/media/')
+
+    def test_missing_signature(self):
+        # Test with missing 't' or 's' parameter
+        response = self.client.get('/signals/media/test.txt')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.content, b'No signature provided')
+
+    def test_bad_signature(self):
+        # Test with an invalid signature
+        response = self.client.get('/signals/media/test.txt?t=some_time&s=some_signature')
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.content, b'Bad signature')
+
+    @override_settings(DEBUG=True)
+    def test_debug_mode_file_serving(self):
+        # Test serving the file in DEBUG mode
+        with patch('signals.apps.media.views.serve') as mock_serve:
+            mock_serve.return_value = HttpResponse('File content')
+            response = self.client.get(self.storage.url('test.txt'))
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.content, b'File content')
+            mock_serve.assert_called_once()
+
+    @override_settings(DEBUG=False)
+    def test_production_mode_file_serving(self):
+        # Test serving the file in production mode
+        with patch('signals.apps.media.views.mimetypes.guess_type') as mock_mimetype:
+            mock_mimetype.return_value = 'text/plain', None
+            response = self.client.get(self.storage.url('test.txt'))
+            self.assertEqual(response.status_code, 200)
+            self.assertIn('test.txt', response['X-Sendfile'])
+            self.assertEqual(response['Content-Type'], 'text/plain')

--- a/app/signals/apps/media/urls.py
+++ b/app/signals/apps/media/urls.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2024 Delta10 B.V.
+from django.urls import re_path
+from . import views
+
+urlpatterns = [
+    re_path(r"^(?P<path>.*)$", views.download_file, name='download_file'),
+]

--- a/app/signals/apps/media/urls.py
+++ b/app/signals/apps/media/urls.py
@@ -4,5 +4,5 @@ from django.urls import re_path
 from . import views
 
 urlpatterns = [
-    re_path(r"^(?P<path>.*)$", views.download_file, name='download_file'),
+    re_path(r'^(?P<path>.*)$', views.download_file, name='download_file'),
 ]

--- a/app/signals/apps/media/views.py
+++ b/app/signals/apps/media/views.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2024 Delta10 B.V.
+from datetime import timedelta
+import mimetypes
+import os
+
+from django.conf import settings
+from django.core import signing
+from django.contrib.staticfiles.views import serve
+from django.http import HttpResponse
+from django.views.static import serve
+
+signer = signing.TimestampSigner()
+
+def download_file(request, path):
+    t = request.GET.get('t')
+    s = request.GET.get('s')
+
+    if not t or not s:
+        return HttpResponse('No signature provided', status=401)
+
+    try:
+        signer.unsign(f'{path}:{t}:{s}', max_age=timedelta(hours=1))
+    except signing.SignatureExpired:
+        return HttpResponse('Signature expired', status=401)
+    except signing.BadSignature:
+        return HttpResponse('Bad signature', status=401)
+
+    if settings.DEBUG:
+        response = serve(request, path, document_root=settings.MEDIA_ROOT, show_indexes=False)
+    else:
+        mimetype, encoding = mimetypes.guess_type(path)
+
+        response = HttpResponse()
+
+        if mimetype:
+            response["Content-Type"] = mimetype
+        if encoding:
+            response["Content-Encoding"] = encoding
+
+        response["X-Sendfile"] = os.path.join(
+            settings.MEDIA_ROOT, path
+        ).encode("utf8")
+
+    return response

--- a/app/signals/apps/media/views.py
+++ b/app/signals/apps/media/views.py
@@ -34,12 +34,12 @@ def download_file(request, path):
         response = HttpResponse()
 
         if mimetype:
-            response["Content-Type"] = mimetype
+            response['Content-Type'] = mimetype
         if encoding:
-            response["Content-Encoding"] = encoding
+            response['Content-Encoding'] = encoding
 
-        response["X-Sendfile"] = os.path.join(
+        response['X-Sendfile'] = os.path.join(
             settings.MEDIA_ROOT, path
-        ).encode("utf8")
+        ).encode('utf8')
 
     return response

--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -242,6 +242,10 @@ STATIC_ROOT: str = os.path.join(os.path.dirname(BASE_DIR), 'static')
 MEDIA_URL: str = '/signals/media/'
 MEDIA_ROOT: str = os.path.join(os.path.dirname(BASE_DIR), 'media')
 
+PROTECTED_FILE_SYSTEM_STORAGE: bool = os.getenv('PROTECTED_FILE_SYSTEM_STORAGE', False) in TRUE_VALUES
+if PROTECTED_FILE_SYSTEM_STORAGE:
+    DEFAULT_FILE_STORAGE: str = 'signals.apps.media.storages.ProtectedFileSystemStorage'
+
 AZURE_STORAGE_ENABLED: bool = os.getenv('AZURE_STORAGE_ENABLED', False) in TRUE_VALUES
 if AZURE_STORAGE_ENABLED:
     # Azure Settings

--- a/app/signals/urls.py
+++ b/app/signals/urls.py
@@ -19,6 +19,10 @@ urlpatterns = [
     path('signals/', BaseSignalsAPIRootView.as_view()),
     path('signals/', include('signals.apps.api.urls')),
 
+    # The media folder is routed with X-Sendfile when DEBUG=False and
+    # with the Django static helper when DEBUG=True
+    path('signals/media/', include('signals.apps.media.urls')),
+
     # The Django admin
     path('signals/admin/', admin.site.urls),
     re_path(r'^signals/markdownx/', include('markdownx.urls')),
@@ -26,12 +30,6 @@ urlpatterns = [
     # SOAP stand-in endpoints
     path('signals/sigmax/', include('signals.apps.sigmax.urls')),
 ]
-
-if settings.DEBUG:
-    from django.conf.urls.static import static
-
-    media_root = static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-    urlpatterns += media_root
 
 if settings.OIDC_RP_CLIENT_ID:
     urlpatterns += [


### PR DESCRIPTION
## Description

This app provides the possibility to protect the media folder. To use this functionality in production, make sure to configure the PROTECTED_FILE_SYSTEM_STORAGE setting.

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
