### PR TITLE
Elastic search index not updated when reporter is anonymized

### DIFF
--- a/app/signals/apps/search/tests/__init__.py
+++ b/app/signals/apps/search/tests/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2024 Gemeente Amsterdam

--- a/app/signals/apps/search/tests/test_signal_receivers.py
+++ b/app/signals/apps/search/tests/test_signal_receivers.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (C) 2024 Gemeente Amsterdam
+from unittest import mock
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from signals.apps.signals.factories import SignalFactory
+from signals.apps.signals.models import Signal
+
+
+class TestSearchSignalReceivers(TestCase):
+    _signal: Signal
+
+    def setUp(self) -> None:
+        self._signal = SignalFactory.create()
+
+    @mock.patch("signals.apps.search.signal_receivers.save_to_elastic")
+    def test_reporter_anonymized_receiver(self, save_to_elastic: MagicMock) -> None:
+        assert self._signal.reporter is not None
+        self._signal.reporter.anonymize()
+
+        save_to_elastic.delay.assert_called_once_with(signal_id=self._signal.id)

--- a/app/signals/apps/signals/models/reporter.py
+++ b/app/signals/apps/signals/models/reporter.py
@@ -1,16 +1,19 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2023 Gemeente Amsterdam
+# Copyright (C) 2019 - 2024 Gemeente Amsterdam
 from typing import Final
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.gis.db import models
 from django.core.exceptions import MultipleObjectsReturned
+from django.dispatch import Signal as DjangoSignal
 from django_fsm import ConcurrentTransitionMixin, FSMField, transition
 
 from signals.apps.email_integrations.models import EmailTemplate
 from signals.apps.email_integrations.renderers.email_template_renderer import EmailTemplateRenderer
 from signals.apps.signals.models.mixins import CreatedUpdatedModel
 from signals.apps.signals.tokens.token_generator import TokenGenerator
+
+reporter_anonymized = DjangoSignal()
 
 
 class Reporter(ConcurrentTransitionMixin, CreatedUpdatedModel):
@@ -198,6 +201,7 @@ class Reporter(ConcurrentTransitionMixin, CreatedUpdatedModel):
 
         if call_save or always_call_save:
             self.save()
+            reporter_anonymized.send(sender=self.__class__, instance=self)
 
     def save(self, *args, **kwargs) -> None:
         """

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   api:
     build:
@@ -10,6 +8,8 @@ services:
         condition: service_healthy
     env_file:
       - docker-compose/environments/.test
+    volumes:
+      - ./app:/app
 
   database:
     # postgis 3.2 is the extension version provided by Azure Database for PostgreSQL Flexible Server at the time of writing

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,8 +8,6 @@ services:
         condition: service_healthy
     env_file:
       - docker-compose/environments/.test
-    volumes:
-      - ./app:/app
 
   database:
     # postgis 3.2 is the extension version provided by Azure Database for PostgreSQL Flexible Server at the time of writing


### PR DESCRIPTION
## Description

Currently the elastic search index is not updated when a reporter is anonymized. This PR aims to resolve that problem by sending a Django signal and handling it in a receiver that triggers a celery task to re-index the signal in the elastic search index.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
