### PR TITLE
Make sure we send `application/json` in the `Content-Type` header

### DIFF
--- a/app/signals/apps/api/ml_tool/client.py
+++ b/app/signals/apps/api/ml_tool/client.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2021 Gemeente Amsterdam
-import json
-
+# Copyright (C) 2019 - 2024 Gemeente Amsterdam
 import requests
 from django.conf import settings
 from django.core import validators
@@ -22,8 +20,7 @@ class MLToolClient:
             validator(text)
 
         try:
-            data = json.dumps({'text': text})
-            response = requests.post(self.endpoint, data=data, timeout=self.timeout)
+            response = requests.post(self.endpoint, json={'text': text}, timeout=self.timeout)
         except (ConnectTimeout, ):
             raise GatewayTimeoutException()
         else:


### PR DESCRIPTION
## Description

Make sure we send `application/json` in the `Content-Type` header, it seems the old Flask version of the legacy classification API was less strict about that.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
