### PR TITLE
don't validate email domain for private signals creations

### DIFF
--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -262,7 +262,7 @@ class PrivateSignalSerializerDetail(HALSerializer, AddressValidationMixin):
         return signal
 
 
-class PrivateSignalSerializerList(SignalParentValidationMixin, AddressValidationMixin, HALSerializer):
+class PrivateSignalSerializerList(SignalReporterEmailValidationMixin, SignalParentValidationMixin, AddressValidationMixin, HALSerializer):
     """
     This serializer is used for the list endpoint and when creating a new instance
     """

--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -262,7 +262,12 @@ class PrivateSignalSerializerDetail(HALSerializer, AddressValidationMixin):
         return signal
 
 
-class PrivateSignalSerializerList(SignalReporterEmailValidationMixin, SignalParentValidationMixin, AddressValidationMixin, HALSerializer):
+class PrivateSignalSerializerList(
+    SignalReporterEmailValidationMixin,
+    SignalParentValidationMixin,
+    AddressValidationMixin,
+    HALSerializer
+):
     """
     This serializer is used for the list endpoint and when creating a new instance
     """

--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -32,7 +32,7 @@ from signals.apps.api.serializers.nested import (
     _NestedTypeModelSerializer
 )
 from signals.apps.api.validation.address.mixin import AddressValidationMixin
-from signals.apps.api.validation.mixin import SignalValidationMixin
+from signals.apps.api.validation.mixin import SignalParentValidationMixin, SignalReporterEmailValidationMixin
 from signals.apps.api.validators.extra_properties import ExtraPropertiesValidator
 from signals.apps.api.validators.source import (
     PrivateSignalSourceValidator,
@@ -259,7 +259,7 @@ class PrivateSignalSerializerDetail(HALSerializer, AddressValidationMixin):
         return signal
 
 
-class PrivateSignalSerializerList(AddressValidationMixin, HALSerializer):
+class PrivateSignalSerializerList(SignalParentValidationMixin, AddressValidationMixin, HALSerializer):
     """
     This serializer is used for the list endpoint and when creating a new instance
     """
@@ -554,7 +554,12 @@ class PublicSignalSerializerDetail(HALSerializer):
         return obj.get_id_display()
 
 
-class PublicSignalCreateSerializer(SignalValidationMixin, serializers.ModelSerializer):
+class PublicSignalCreateSerializer(
+    SignalReporterEmailValidationMixin,
+    AddressValidationMixin,
+    SignalParentValidationMixin,
+    serializers.ModelSerializer
+):
     """
     This serializer allows anonymous users to report `signals.Signals`.
 

--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -32,7 +32,10 @@ from signals.apps.api.serializers.nested import (
     _NestedTypeModelSerializer
 )
 from signals.apps.api.validation.address.mixin import AddressValidationMixin
-from signals.apps.api.validation.mixin import SignalParentValidationMixin, SignalReporterEmailValidationMixin
+from signals.apps.api.validation.mixin import (
+    SignalParentValidationMixin,
+    SignalReporterEmailValidationMixin
+)
 from signals.apps.api.validators.extra_properties import ExtraPropertiesValidator
 from signals.apps.api.validators.source import (
     PrivateSignalSourceValidator,

--- a/app/signals/apps/api/serializers/signal.py
+++ b/app/signals/apps/api/serializers/signal.py
@@ -259,7 +259,7 @@ class PrivateSignalSerializerDetail(HALSerializer, AddressValidationMixin):
         return signal
 
 
-class PrivateSignalSerializerList(SignalValidationMixin, HALSerializer):
+class PrivateSignalSerializerList(AddressValidationMixin, HALSerializer):
     """
     This serializer is used for the list endpoint and when creating a new instance
     """

--- a/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
+++ b/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
@@ -333,7 +333,7 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
 
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation
-    def test_create_initial_signal_interne_melding(self, validate_address):
+    def test_create_initial_signal_should_not_convert_source_to_interne_melding(self, validate_address):
         signal_count = Signal.objects.count()
 
         initial_data = copy.deepcopy(self.initial_data_base)
@@ -345,7 +345,7 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
         self.assertEqual(Signal.objects.count(), signal_count + 1)
 
         data = response.json()
-        self.assertEqual(data['source'], settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE)
+        self.assertNotEqual(data['source'], settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE)
 
     @override_settings(API_TRANSFORM_SOURCE_BASED_ON_REPORTER_EXCEPTIONS=('uitzondering@amsterdam.nl',))
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',

--- a/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
+++ b/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
@@ -333,7 +333,7 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
 
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation
-    def test_create_initial_signal_should_not_convert_source_to_interne_melding(self, validate_address):
+    def test_create_initial_signal_should_not_transform_source(self, validate_address):
         signal_count = Signal.objects.count()
 
         initial_data = copy.deepcopy(self.initial_data_base)

--- a/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
+++ b/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
@@ -380,7 +380,10 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
 
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation
-    def test_create_initial_signal_missing_source_should_give_internal_default_source_if_reporter_of_certain_domain(self, validate_address):
+    def test_create_initial_signal_missing_source_should_give_internal_default_source_if_reporter_of_certain_domain(
+        self,
+        validate_address
+    ):
         signal_count = Signal.objects.count()
 
         SourceFactory.create_batch(5)
@@ -401,8 +404,10 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
 
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation
-    def test_create_initial_signal_missing_source_should_give_internal_default_source_if_reporter_unknown_domain(self,
-                                                                                                      validate_address):
+    def test_create_initial_signal_missing_source_should_give_internal_default_source_if_reporter_unknown_domain(
+        self,
+        validate_address
+    ):
         signal_count = Signal.objects.count()
 
         SourceFactory.create_batch(5)
@@ -417,7 +422,6 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
 
         data = response.json()
         self.assertEqual(data['source'], Signal._meta.get_field('source').get_default())
-
 
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation

--- a/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
+++ b/app/signals/apps/api/tests/test_private_signal_endpoint_create.py
@@ -380,6 +380,24 @@ class TestPrivateSignalViewSetCreate(SIAReadWriteUserMixin, SignalsBaseApiTestCa
 
     @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
            side_effect=AddressValidationUnavailableException)  # Skip address validation
+    def test_create_initial_signal_missing_source_should_give_default_source(self, validate_address):
+        signal_count = Signal.objects.count()
+
+        SourceFactory.create_batch(5)
+
+        initial_data = copy.deepcopy(self.initial_data_base)
+        del initial_data['source']
+
+        response = self.client.post(self.list_endpoint, initial_data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Signal.objects.count(), signal_count + 1)
+
+        data = response.json()
+        self.assertEqual(data['source'], settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE)
+
+    @patch('signals.apps.api.validation.address.base.BaseAddressValidation.validate_address',
+           side_effect=AddressValidationUnavailableException)  # Skip address validation
     def test_create_initial_signal_valid_source(self, validate_address):
         signal_count = Signal.objects.count()
 

--- a/app/signals/apps/api/validation/mixin.py
+++ b/app/signals/apps/api/validation/mixin.py
@@ -18,13 +18,14 @@ class SignalReporterEmailValidationMixin:
                 and attrs['reporter']['email']):
             reporter_email = attrs['reporter']['email']
 
-            if self.__class__.__name__ == 'PrivateSignalSerializerList' and 'source' not in attrs:
-                attrs['source'] = settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE
+            if (reporter_email not in settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_EXCEPTIONS
+                and reporter_email.endswith(settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_DOMAIN_EXTENSIONS)):
 
-            if (self.__class__.__name__ == 'PublicSignalCreateSerializer'
-                    and reporter_email not in settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_EXCEPTIONS
-                    and reporter_email.endswith(settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_DOMAIN_EXTENSIONS)):
-                attrs['source'] = settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE
+                if self.__class__.__name__ == 'PrivateSignalSerializerList' and 'source' not in attrs:
+                    attrs['source'] = settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE
+
+                if self.__class__.__name__ == 'PublicSignalCreateSerializer':
+                    attrs['source'] = settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE
 
         return super().validate(attrs)
 

--- a/app/signals/apps/api/validation/mixin.py
+++ b/app/signals/apps/api/validation/mixin.py
@@ -17,8 +17,13 @@ class SignalReporterEmailValidationMixin:
                 and 'reporter' in attrs and 'email' in attrs['reporter']
                 and attrs['reporter']['email']):
             reporter_email = attrs['reporter']['email']
-            if (reporter_email not in settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_EXCEPTIONS and
-                    reporter_email.endswith(settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_DOMAIN_EXTENSIONS)):
+
+            if self.__class__.__name__ == 'PrivateSignalSerializerList' and 'source' not in attrs:
+                attrs['source'] = settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE
+
+            if (self.__class__.__name__ == 'PublicSignalCreateSerializer'
+                    and reporter_email not in settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_EXCEPTIONS
+                    and reporter_email.endswith(settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_DOMAIN_EXTENSIONS)):
                 attrs['source'] = settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE
 
         return super().validate(attrs)

--- a/app/signals/apps/api/validation/mixin.py
+++ b/app/signals/apps/api/validation/mixin.py
@@ -2,10 +2,7 @@
 # Copyright (C) 2020 - 2021 Gemeente Amsterdam
 from django.conf import settings
 
-from signals.apps.api.validation.address.mixin import AddressValidationMixin
-
-
-class SignalValidationMixin(AddressValidationMixin):
+class SignalReporterEmailValidationMixin:
     @staticmethod
     def feature_enabled(feature_flag_name=None):
         return settings.FEATURE_FLAGS.get(feature_flag_name, True) if feature_flag_name else True
@@ -19,6 +16,14 @@ class SignalValidationMixin(AddressValidationMixin):
                     reporter_email.endswith(settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_DOMAIN_EXTENSIONS)):
                 attrs['source'] = settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE
 
+        return super().validate(attrs)
+
+
+class SignalParentValidationMixin:
+    """
+    If a signal comes from a parent (deelmelding) the source should be set to the source of the parent signal.
+    """
+    def validate(self, attrs):
         if hasattr(settings, 'API_TRANSFORM_SOURCE_OF_CHILD_SIGNAL_TO') and 'parent' in attrs and attrs['parent']:
             attrs['source'] = settings.API_TRANSFORM_SOURCE_OF_CHILD_SIGNAL_TO
 

--- a/app/signals/apps/api/validation/mixin.py
+++ b/app/signals/apps/api/validation/mixin.py
@@ -19,7 +19,7 @@ class SignalReporterEmailValidationMixin:
             reporter_email = attrs['reporter']['email']
 
             if (reporter_email not in settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_EXCEPTIONS
-                and reporter_email.endswith(settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_DOMAIN_EXTENSIONS)):
+                    and reporter_email.endswith(settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_DOMAIN_EXTENSIONS)):
 
                 if self.__class__.__name__ == 'PrivateSignalSerializerList' and 'source' not in attrs:
                     attrs['source'] = settings.API_TRANSFORM_SOURCE_BASED_ON_REPORTER_SOURCE

--- a/app/signals/apps/api/validation/mixin.py
+++ b/app/signals/apps/api/validation/mixin.py
@@ -2,7 +2,12 @@
 # Copyright (C) 2020 - 2021 Gemeente Amsterdam
 from django.conf import settings
 
+
 class SignalReporterEmailValidationMixin:
+    """
+    Checks if reporter email is part of a certain domain and transforms the source based on that.
+    """
+
     @staticmethod
     def feature_enabled(feature_flag_name=None):
         return settings.FEATURE_FLAGS.get(feature_flag_name, True) if feature_flag_name else True


### PR DESCRIPTION
## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
