### PR TITLE
adds possibility to add signalering to sigmax description if specific…

### DIFF
--- a/app/signals/apps/sigmax/stuf_protocol/outgoing/creeerZaak_Lk01.py
+++ b/app/signals/apps/sigmax/stuf_protocol/outgoing/creeerZaak_Lk01.py
@@ -7,6 +7,7 @@ import logging
 import os
 from datetime import timedelta
 
+from django.conf import settings
 from django.template.loader import render_to_string
 
 from signals.apps.sigmax.stuf_protocol.outgoing.stuf import _send_stuf_message
@@ -55,6 +56,11 @@ def _generate_omschrijving(signal, seq_no):
         urgent = 'URGENT'
     else:
         urgent = None
+    if (settings.SIGMAX_TRANSFORM_DESCRIPTION_BASED_ON_SOURCE is not None
+            and signal.source == settings.SIGMAX_TRANSFORM_DESCRIPTION_BASED_ON_SOURCE):
+        extra_description = 'Signalering'
+    else:
+        extra_description = None
 
     category = signal.category_assignment.category.name if signal.category_assignment else 'Categorie Onbekend'
 
@@ -72,11 +78,12 @@ def _generate_omschrijving(signal, seq_no):
 
     area = _determine_area_for_omschrijving(signal, buurt, stadsdeel_code_sigmax)
 
-    return '{} SIA-{}.{}{} {}{}'.format(
+    return '{} SIA-{}.{}{}{} {}{}'.format(
         category,
         signal.id,
         seq_no,
         f" {urgent}" if urgent else '',
+        f" {extra_description}" if extra_description else '',
         signal.location.short_address_text,
         f" {area}" if area else ''
     )

--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -383,7 +383,6 @@ SIGMAX_TRANSFORM_DESCRIPTION_BASED_ON_SOURCE: str | None = os.getenv(
     'SIGMAX_TRANSFORM_DESCRIPTION_BASED_ON_SOURCE', None
 )  # If specific source is given the text Signalering will be added to the description to SIGMAX
 
-
 # Child settings
 SIGNAL_MAX_NUMBER_OF_CHILDREN: int = 10
 

--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -379,6 +379,11 @@ SIGMAX_CLIENT_CERT: str | None = os.getenv('SIGMAX_CLIENT_CERT', None)
 SIGMAX_CLIENT_KEY: str | None = os.getenv('SIGMAX_CLIENT_KEY', None)
 SIGMAX_SEND_FAIL_TIMEOUT_MINUTES: str | int = os.getenv('SIGMAX_SEND_FAIL_TIMEOUT_MINUTES', 60*24)  # noqa Default is 24hrs.
 
+SIGMAX_TRANSFORM_DESCRIPTION_BASED_ON_SOURCE: str | None = os.getenv(
+    'SIGMAX_TRANSFORM_DESCRIPTION_BASED_ON_SOURCE', None
+)  # If specific source is given the text Signalering will be added to the description to SIGMAX
+
+
 # Child settings
 SIGNAL_MAX_NUMBER_OF_CHILDREN: int = 10
 


### PR DESCRIPTION
… source is provided

## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
