### PR TITLE
fix: cast EMAIL_PORT and EMAIL_TIMEOUT to int

### DIFF
--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -309,7 +309,7 @@ EMAIL_BACKEND: str = os.getenv('EMAIL_BACKEND', 'djcelery_email.backends.CeleryE
 EMAIL_HOST: str | None = os.getenv('EMAIL_HOST')
 EMAIL_HOST_USER: str | None = os.getenv('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD: str | None = os.getenv('EMAIL_HOST_PASSWORD')
-EMAIL_PORT: int = int(os.getenv('EMAIL_PORT', 465)) # 465 for SSL 587 for TLS
+EMAIL_PORT: int = int(os.getenv('EMAIL_PORT', 465))  # 465 for SSL 587 for TLS
 EMAIL_TIMEOUT: int = int(os.getenv('EMAIL_TIMEOUT', 5))
 EMAIL_USE_TLS: bool = os.getenv('EMAIL_USE_TLS', False) in TRUE_VALUES
 if not EMAIL_USE_TLS:

--- a/app/signals/settings.py
+++ b/app/signals/settings.py
@@ -309,8 +309,8 @@ EMAIL_BACKEND: str = os.getenv('EMAIL_BACKEND', 'djcelery_email.backends.CeleryE
 EMAIL_HOST: str | None = os.getenv('EMAIL_HOST')
 EMAIL_HOST_USER: str | None = os.getenv('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD: str | None = os.getenv('EMAIL_HOST_PASSWORD')
-EMAIL_PORT: str | int = os.getenv('EMAIL_PORT', 465)  # 465 fort SSL 587 for TLS
-EMAIL_TIMEOUT: str | int = os.getenv('EMAIL_TIMEOUT', 5)
+EMAIL_PORT: int = int(os.getenv('EMAIL_PORT', 465)) # 465 for SSL 587 for TLS
+EMAIL_TIMEOUT: int = int(os.getenv('EMAIL_TIMEOUT', 5))
 EMAIL_USE_TLS: bool = os.getenv('EMAIL_USE_TLS', False) in TRUE_VALUES
 if not EMAIL_USE_TLS:
     EMAIL_USE_SSL: bool = os.getenv('EMAIL_USE_SSL', True) in TRUE_VALUES


### PR DESCRIPTION
## Description

Setting `EMAIL_TIMEOUT` currently always results in an exception:

```
ile "/usr/local/lib/python3.11/socket.py", line 845, in create_connection
sock.settimeout(timeout)
TypeError: 'str' object cannot be interpreted as an integer
```

This is because `EMAIL_TIMEOUT` is expected to be an integer, not a string. This changes both `EMAIL_PORT` and `EMAIL_TIMEOUT`.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
