### PR TITLE
fix: return only unique questions via question endpoint

### DIFF
--- a/app/signals/apps/api/views/questions.py
+++ b/app/signals/apps/api/views/questions.py
@@ -9,7 +9,7 @@ from signals.apps.signals.models import Question
 
 
 class PublicQuestionViewSet(ReadOnlyModelViewSet):
-    queryset = Question.objects.all()
+    queryset = Question.objects.all().distinct()
 
     serializer_class = PublicQuestionSerializerDetail
     filter_backends = (DjangoFilterBackend,)


### PR DESCRIPTION
## Description

Previously, when a user made a request to:

`/signals/v1/public/questions/?main_slug=vulhierjehoofdslugin&sub_slug=vulhierjesubslugin`

it was possible for the same question to appear multiple times in the response. This occurred when a question was linked to multiple (sub)categories.

With this update, the response will now only contain **unique** questions.

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
