### PR TITLE
Do not store email address of external party in history

### DIFF
--- a/app/signals/apps/history/services/signal_log.py
+++ b/app/signals/apps/history/services/signal_log.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2021 - 2023 Gemeente Amsterdam
+# Copyright (C) 2021 - 2025 Gemeente Amsterdam
 import pytz
 from django.conf import settings
 from django.utils import timezone
@@ -226,14 +226,11 @@ class SignalLogService:
         if session.frozen or session.invalidated:
             return
 
-        external_user = 'onbekend'
-        if session._signal_status and session._signal_status.email_override:
-            external_user = session._signal_status.email_override
-
         when = 'onbekend'
         if session._signal_status:
             when = session._signal_status.created_at.strftime('%d-%m-%Y %H:%M')
-        description = f'Geen toelichting ontvangen van behandelaar {external_user} op vraag van {when}'
+
+        description = f'Geen toelichting ontvangen van externe behandelaar op vraag van {when}'
 
         session.history_log.create(
             action=Log.ACTION_NOT_RECEIVED,

--- a/app/signals/apps/questionnaires/tests/services/test_forward_to_external.py
+++ b/app/signals/apps/questionnaires/tests/services/test_forward_to_external.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+# Copyright (C) 2022 - 2025 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import os
 from datetime import timedelta
 
@@ -283,7 +283,7 @@ class TestCleanUpForwardToExternal(TestCase):
 
         self.assertEqual(Log.objects.count(), n_log_entries + 5)
         log = Log.objects.first()
-        self.assertIn('Geen toelichting ontvangen van behandelaar', log.description)
+        self.assertIn('Geen toelichting ontvangen van externe behandelaar', log.description)
 
     def test_clean_up_forward_to_external_not_from_DOORGEZET_NAAR_EXTERN(self):
         n_log_entries = Log.objects.count()
@@ -317,7 +317,7 @@ class TestCleanUpForwardToExternal(TestCase):
 
         self.assertEqual(Log.objects.count(), n_log_entries + 1)
         log = Log.objects.first()
-        self.assertIn('Geen toelichting ontvangen van behandelaar', log.description)
+        self.assertIn('Geen toelichting ontvangen van externe behandelaar', log.description)
 
 
 class TestCopyAttachmentsToAttachedFiles(TestCase):


### PR DESCRIPTION
## Description

Do not store email address of external party in history

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
