### PR TITLE
Exclude `ACTION_NOT_RECEIVED` from the signal history in "my signals"

### DIFF
--- a/app/signals/apps/my_signals/rest_framework/views/signals.py
+++ b/app/signals/apps/my_signals/rest_framework/views/signals.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2022 - 2023 Gemeente Amsterdam
+# Copyright (C) 2022 - 2025 Gemeente Amsterdam
 from dateutil.relativedelta import relativedelta
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Min, Q
@@ -137,7 +137,10 @@ class MySignalsViewSet(DetailSerializerMixin, ReadOnlyModelViewSet):
             flat=True
         ).order_by())
 
-        history_log_qs = signal.history_log.exclude(Q(excluded_q)).exclude(action=Log.ACTION_RECEIVE)
+        history_log_qs = (signal.history_log
+                          .exclude(Q(excluded_q))
+                          .exclude(action=Log.ACTION_RECEIVE)
+                          .exclude(action=Log.ACTION_NOT_RECEIVED))
 
         what = self.request.query_params.get('what', None)
         if what:


### PR DESCRIPTION
## Description

This will keep history logs with type `ACTION_NOT_RECEIVED` from being displayed in "my signals".

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code