### PR TITLE
Add SAOA (straatnotes) to valid `target_api` values

### DIFF
--- a/app/signals/apps/signals/models/status.py
+++ b/app/signals/apps/signals/models/status.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# Copyright (C) 2019 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+# Copyright (C) 2019 - 2025 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import logging
 
 from django.contrib.contenttypes.fields import GenericRelation
@@ -15,9 +15,11 @@ logger = logging.getLogger(__name__)
 class Status(CreatedUpdatedModel):
     TARGET_API_SIGMAX = 'sigmax'
     TARGET_API_GISIB = 'gisib'
+    TARGET_API_SAOA = 'straatnotes'
     TARGET_API_CHOICES = (
         (TARGET_API_SIGMAX, 'Sigmax (City Control)'),
         (TARGET_API_GISIB, 'GISIB'),
+        (TARGET_API_SAOA, 'Straatnotes'),
     )
 
     _signal = models.ForeignKey('signals.Signal', related_name='statuses', on_delete=models.CASCADE)


### PR DESCRIPTION
## Description

We need to add `straatnotes` as a valid value for the `target_api` field in order for them to be able to set signals to state `ready to send` so that they can then set the state to `sent`.

## Checklist

- [X] Keep the PR, and the amount of commits to a minimum
- [X] The commit messages are meaningful and descriptive
- [X] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [X] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [X] Check that the branch is based on `main` and is up to date with `main`
- [X] Check that the PR targets `main`
- [X] There are no merge conflicts and no conflicting Django migrations

## How has this been tested?

- [X] Provided unit tests that will prove the change/fix works as intended
- [X] Tested the change/fix locally and all unit tests still pass
- [X] Code coverage is at least 85% (the higher the better)
- [X] No iSort, Flake8 and SPDX issues are present in the code
