### PR TITLE
make sure that authenticate function filters on is_active column

### DIFF
--- a/app/signals/apps/users/factories.py
+++ b/app/signals/apps/users/factories.py
@@ -46,6 +46,7 @@ class SuperUserFactory(BaseUserFactory):
 
     is_superuser = True
     is_staff = True
+    is_active = True
 
 
 class GroupFactory(DjangoModelFactory):

--- a/app/signals/auth/backend.py
+++ b/app/signals/auth/backend.py
@@ -16,7 +16,7 @@ class JWTAuthBackend(OIDCAuthentication):
     def authenticate(self, request: Request) -> tuple[User, str]:
         if settings.SIGNALS_AUTH.get("ALWAYS_OK", False):
             try:
-                user = User.objects.get(username__iexact=settings.TEST_LOGIN)
+                user = User.objects.get(username__iexact=settings.TEST_LOGIN, is_active=True)
             except User.DoesNotExist as e:
                 raise AuthenticationFailed("User not found") from e
 

--- a/app/signals/auth/tests/test_backend.py
+++ b/app/signals/auth/tests/test_backend.py
@@ -29,3 +29,9 @@ class TestJWTAuthBackend(TestCase):
         user, _ = self.backend.authenticate(Mock(Request))
 
         assert user == super_user
+
+    def test_authenticate_inactive_user(self) -> None:
+        SuperUserFactory.create(email='signals.admin@example.com', is_active=False)
+
+        with pytest.raises(AuthenticationFailed):
+            self.backend.authenticate(Mock(Request))

--- a/app/signals/test/utils.py
+++ b/app/signals/test/utils.py
@@ -96,6 +96,14 @@ class SIAReadWriteUserMixin(SIAGroupMixin, SIAReadPermissionMixin, SIAWritePermi
         return user
 
 
+class SIAInactiveUserMixin(SIAReadWriteUserMixin):
+    @property
+    def sia_inactive_read_write_user(self):
+        user = super().sia_read_write_user
+        user.is_active = False
+        return user
+
+
 class SignalsBaseApiTestCase(SuperUserMixin, SimpleUserMixin, APITestCase):
     def assertJsonSchema(self, schema: dict, json_dict: dict):
         """ Validates json_dict against schema. Schema format as defined on json-schema.org . If


### PR DESCRIPTION
## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
