### PR TITLE
fixes login flow by checking if returned user is_active

### DIFF
--- a/app/signals/auth/backend.py
+++ b/app/signals/auth/backend.py
@@ -24,7 +24,10 @@ class JWTAuthBackend(OIDCAuthentication):
 
         user, access_token = super().authenticate(request)
 
-        if isinstance(user, User) and user.is_active is False:
+        if not isinstance(user, User):
+            raise AuthenticationFailed("Unknown error during authentication")
+
+        if user.is_active is False:
             raise AuthenticationFailed("User is inactive")
 
         return user, access_token

--- a/app/signals/auth/backend.py
+++ b/app/signals/auth/backend.py
@@ -22,4 +22,9 @@ class JWTAuthBackend(OIDCAuthentication):
 
             return user, ""
 
-        return super().authenticate(request)
+        user, access_token = super().authenticate(request)
+
+        if isinstance(user, User) and user.is_active is False:
+            raise AuthenticationFailed("User is inactive")
+
+        return user, access_token


### PR DESCRIPTION
## Description

Add a meaningful description explaining the change/fix that is provided in this PR

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
