### PR TITLE
Set delete closed signals to 1825 days by default

### DIFF
--- a/app/signals/apps/signals/tasks/delete_signals.py
+++ b/app/signals/apps/signals/tasks/delete_signals.py
@@ -90,7 +90,7 @@ def delete_signal(signal_id: int, batch_uuid: uuid.UUID | None = None):  # noqa 
 
 
 @app.task
-def delete_closed_signals(days: int = 365):
+def delete_closed_signals(days: int = 1825):
     """
     Delete Signals in one of the Signalen system's closed states
     """


### PR DESCRIPTION
## Description

This change sets the default for `delete_closed_signals` to 1825 days (5 years). This is sane default as this corresponds with the policy that municipalities in The Netherlands adhere to.

With the current default it is very easy to shoot yourself in the foot. We saw 4 misconfigurations on our Signalen production environments.

## Checklist

- [ ] Keep the PR, and the amount of commits to a minimum
- [ ] The commit messages are meaningful and descriptive
- [ ] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [ ] Check that the branch is based on `main` and is up to date with `main`
- [ ] Check that the PR targets `main`
- [ ] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [ ] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code
