### PR TITLE
Fix question field type options

### DIFF
--- a/app/signals/apps/signals/models/question.py
+++ b/app/signals/apps/signals/models/question.py
@@ -4,28 +4,34 @@ from django.contrib.gis.db import models
 
 
 class Question(models.Model):
-    PLAIN_TEXT = 'plain_text'
-    TEXT_INPUT = 'text_input'
-    MULTI_TEXT_INPUT = 'multi_text_input'
+    ASSET_SELECT = 'asset_select'
+    CATERPILLAR_SELECT = 'caterpillar_select'
     CHECKBOX_INPUT = 'checkbox_input'
+    CLOCK_SELECT = 'clock_select'
+    DATE_TIME_INPUT = 'date_time_input'
+    QUESTION_HEADER = 'question_header'
+    LOCATION_SELECT = 'location_select'
+    PLAIN_TEXT = 'plain_text'
     RADIO_INPUT = 'radio_input'
     SELECT_INPUT = 'select_input'
+    STREETLIGHT_SELECT = 'streetlight_select'
+    TEXT_INPUT = 'text_input'
     TEXT_AREA_INPUT = 'text_area_input'
-    ASSET_SELECT = 'asset_select'
-    LOCATION_SELECT = 'location_select'
-    DATE_TIME_INPUT = 'date_time_input'
 
     FIELD_TYPE_CHOICES = (
-        (PLAIN_TEXT, 'PlainText'),
-        (TEXT_INPUT, 'TextInput'),
-        (MULTI_TEXT_INPUT, 'MultiTextInput'),
+        (ASSET_SELECT, 'AssetSelectRenderer'),
+        (CATERPILLAR_SELECT, 'CaterpillarSelectRenderer'),
         (CHECKBOX_INPUT, 'CheckboxInput'),
-        (RADIO_INPUT, 'RadioInput'),
+        (CLOCK_SELECT, 'ClockSelectRenderer'),
+        (DATE_TIME_INPUT, 'DateTimeInput'),
+        (QUESTION_HEADER, 'QuestionHeader'),
+        (LOCATION_SELECT, 'AssetSelectRenderer'),
+        (PLAIN_TEXT, 'PlainText'),
+        (RADIO_INPUT, 'RadioInputGroup'),
         (SELECT_INPUT, 'SelectInput'),
+        (STREETLIGHT_SELECT, 'StreetlightSelectRenderer'),
+        (TEXT_INPUT, 'TextInput'),
         (TEXT_AREA_INPUT, 'TextareaInput'),
-        (ASSET_SELECT, 'AssetSelect'),
-        (LOCATION_SELECT, 'LocationSelect'),
-        (DATE_TIME_INPUT, 'DateTimeInput')
     )
 
     key = models.CharField(max_length=255)

--- a/app/signals/apps/signals/models/question.py
+++ b/app/signals/apps/signals/models/question.py
@@ -13,6 +13,7 @@ class Question(models.Model):
     TEXT_AREA_INPUT = 'text_area_input'
     ASSET_SELECT = 'asset_select'
     LOCATION_SELECT = 'location_select'
+    DATE_TIME_INPUT = 'date_time_input'
 
     FIELD_TYPE_CHOICES = (
         (PLAIN_TEXT, 'PlainText'),
@@ -23,7 +24,8 @@ class Question(models.Model):
         (SELECT_INPUT, 'SelectInput'),
         (TEXT_AREA_INPUT, 'TextareaInput'),
         (ASSET_SELECT, 'AssetSelect'),
-        (LOCATION_SELECT, 'LocationSelect')
+        (LOCATION_SELECT, 'LocationSelect'),
+        (DATE_TIME_INPUT, 'DateTimeInput')
     )
 
     key = models.CharField(max_length=255)

--- a/app/signals/apps/signals/models/question.py
+++ b/app/signals/apps/signals/models/question.py
@@ -11,6 +11,7 @@ class Question(models.Model):
     DATE_TIME_INPUT = 'date_time_input'
     QUESTION_HEADER = 'question_header'
     LOCATION_SELECT = 'location_select'
+    MULTI_TEXT_INPUT = 'multi_text_input'
     PLAIN_TEXT = 'plain_text'
     RADIO_INPUT = 'radio_input'
     SELECT_INPUT = 'select_input'
@@ -26,6 +27,7 @@ class Question(models.Model):
         (DATE_TIME_INPUT, 'DateTimeInput'),
         (QUESTION_HEADER, 'QuestionHeader'),
         (LOCATION_SELECT, 'AssetSelectRenderer'),
+        (MULTI_TEXT_INPUT, 'MultiTextInput'),
         (PLAIN_TEXT, 'PlainText'),
         (RADIO_INPUT, 'RadioInputGroup'),
         (SELECT_INPUT, 'SelectInput'),

--- a/app/signals/apps/signals/models/question.py
+++ b/app/signals/apps/signals/models/question.py
@@ -20,18 +20,17 @@ class Question(models.Model):
     TEXT_AREA_INPUT = 'text_area_input'
 
     FIELD_TYPE_CHOICES = (
-        (ASSET_SELECT, 'AssetSelectRenderer'),
-        (CATERPILLAR_SELECT, 'CaterpillarSelectRenderer'),
+        (ASSET_SELECT, 'AssetSelect'),
+        (CATERPILLAR_SELECT, 'CaterpillarSelect'),
         (CHECKBOX_INPUT, 'CheckboxInput'),
-        (CLOCK_SELECT, 'ClockSelectRenderer'),
+        (CLOCK_SELECT, 'ClockSelect'),
         (DATE_TIME_INPUT, 'DateTimeInput'),
         (QUESTION_HEADER, 'QuestionHeader'),
-        (LOCATION_SELECT, 'AssetSelectRenderer'),
-        (MULTI_TEXT_INPUT, 'MultiTextInput'),
+        (LOCATION_SELECT, 'AssetSelect'),
         (PLAIN_TEXT, 'PlainText'),
         (RADIO_INPUT, 'RadioInputGroup'),
         (SELECT_INPUT, 'SelectInput'),
-        (STREETLIGHT_SELECT, 'StreetlightSelectRenderer'),
+        (STREETLIGHT_SELECT, 'StreetlightSelect'),
         (TEXT_INPUT, 'TextInput'),
         (TEXT_AREA_INPUT, 'TextareaInput'),
     )


### PR DESCRIPTION
## Description

Added five question field types that we use in the frontend for additional question. Since we're moving the additional questions to the django admin now, these types should be available in the admin as well.

Added:
CATERPILLAR_SELECT
CLOCK_SELECT
DATE_TIME_INPUT
QUESTION_HEADER
STREETLIGHT_SELECT

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [ ] Code coverage is at least 85% (the higher the better)
- [ ] No iSort, Flake8 and SPDX issues are present in the code

Example:
<img width="1709" height="873" alt="Screenshot 2026-05-18 at 13 24 39" src="https://github.com/user-attachments/assets/5dda6b31-08fb-42fd-aaa9-ce1a27a92c4e" />

