### PR TITLE
Use correct location_select field type name

### DIFF
--- a/app/signals/apps/signals/models/question.py
+++ b/app/signals/apps/signals/models/question.py
@@ -26,7 +26,7 @@ class Question(models.Model):
         (CLOCK_SELECT, 'ClockSelect'),
         (DATE_TIME_INPUT, 'DateTimeInput'),
         (QUESTION_HEADER, 'QuestionHeader'),
-        (LOCATION_SELECT, 'AssetSelect'),
+        (LOCATION_SELECT, 'LocationSelect'),
         (PLAIN_TEXT, 'PlainText'),
         (RADIO_INPUT, 'RadioInputGroup'),
         (SELECT_INPUT, 'SelectInput'),


### PR DESCRIPTION
## Description

In [this PR](https://github.com/Amsterdam/signals/pull/1602) the name shown in the Django Admin was accidentally changed for the location_select filed type. This PR fixes that.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [x] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [x] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [ ] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
