### PR TITLE
fix: use local incident datetime for routing expressions

### DIFF
--- a/app/signals/apps/services/domain/dsl.py
+++ b/app/signals/apps/services/domain/dsl.py
@@ -54,8 +54,7 @@ class SignalContext:
         return self._areas
 
     def __call__(self, signal: Signal):
-
-        t = timezone.make_naive(signal.incident_date_start).strftime("%H:%M:%S")
+        local_tz = timezone.make_naive(signal.incident_date_start)
 
         assert signal.category_assignment is not None
         assert signal.category_assignment.category is not None
@@ -66,8 +65,8 @@ class SignalContext:
             'main': signal.category_assignment.category.parent.name,
             'location': signal.location.geometrie,
             'stadsdeel': signal.location.stadsdeel,
-            'time': time.strptime(t, "%H:%M:%S"),
-            'day': signal.incident_date_start.strftime("%A"),
+            'time': time.strptime(local_tz.strftime("%H:%M:%S"), "%H:%M:%S"),
+            'day': local_tz.strftime("%A"),
             'areas': self.areas
         }
 

--- a/app/signals/apps/signals/tests/test_routing_mechanism.py
+++ b/app/signals/apps/signals/tests/test_routing_mechanism.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (C) 2020 - 2021 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+import time
+from datetime import datetime
+from datetime import timezone as datetime_timezone
+
 from django.contrib.gis import geos
 from django.test import TestCase
 
@@ -180,3 +184,38 @@ class TestRoutingMechanism(TestCase):
         self.assertTrue("value 3.1" in ctx['key3_list'])
         self.assertTrue("value 3.2" in ctx['key3_list'])
         self.assertEqual(ctx['key4'], "value 4")
+
+    def test_context_uses_local_incident_datetime_for_time_and_day(self):
+        signal = SignalFactory.create(
+            incident_date_start=datetime(2021, 7, 18, 22, 30, 45, tzinfo=datetime_timezone.utc)
+        )
+
+        ctx = SignalContext()(signal)
+
+        self.assertEqual(ctx['time'], time.strptime("00:30:45", "%H:%M:%S"))
+        self.assertEqual(ctx['day'], "Monday")
+
+    def test_routing_with_time_uses_local_incident_datetime(self):
+        expression = ExpressionFactory.create(
+            _type=self.exp_routing_type,
+            name="local time expression",
+            code='time == 00:30:45 and day == "Monday"'
+        )
+        department = DepartmentFactory.create()
+        RoutingExpressionFactory.create(
+            _expression=expression,
+            _department=department,
+            is_active=True,
+            order=1
+        )
+
+        signal = SignalFactory.create(
+            incident_date_start=datetime(2021, 7, 18, 22, 30, 45, tzinfo=datetime_timezone.utc)
+        )
+
+        self.dsl_service.process_routing_rules(signal)
+        signal.refresh_from_db()
+
+        self.assertIsNotNone(signal.routing_assignment)
+        routing_dep = signal.routing_assignment.departments.first()
+        self.assertEqual(routing_dep.id, department.id)


### PR DESCRIPTION
## Description

This PR introduces a fix for an issue we encountered with the Municipality of Utrecht. Until now, the SignalContext `day` property was derived from the day of signal.incident_date_start, which is stored in UTC. As a result, signals submitted around midnight could be routed incorrectly due to timezone differences.

For example, a signal submitted on Monday at 01:30 (local time) could still have a UTC timestamp that falls on Sunday, causing an expression configured for Sunday between 22:00 and 00:00 to match incorrectly.

This change ensures that the day property is based on the correct local date, preventing incorrect routing for signals submitted around midnight.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [ ] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
