### PR TITLE
feat: geography endpoint include category, status and priority

### DIFF
--- a/app/signals/apps/api/tests/test_private_signal_endpoint.py
+++ b/app/signals/apps/api/tests/test_private_signal_endpoint.py
@@ -174,7 +174,19 @@ class TestPrivateSignalViewSet(SIAInactiveUserMixin, SIAReadUserMixin, SIAReadWr
     def test_geo_list_endpoint(self):
         response = self.client.get(self.geo_list_endpoint)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()['features']), 2)
+        features = response.json()['features']
+        self.assertEqual(len(features), 2)
+
+        features_by_signal_id = {feature['properties']['id']: feature for feature in features}
+        for signal in [self.signal_no_image, self.signal_with_image]:
+            properties = features_by_signal_id[signal.id]['properties']
+            category = properties['category']
+            self.assertEqual(category['name'], signal.category_assignment.category.name)
+            self.assertEqual(category['slug'], signal.category_assignment.category.slug)
+            self.assertEqual(category['parent']['name'], signal.category_assignment.category.parent.name)
+            self.assertEqual(category['parent']['slug'], signal.category_assignment.category.parent.slug)
+            self.assertEqual(properties['status'], signal.status.state)
+            self.assertEqual(properties['priority'], signal.priority.priority)
 
         # Check headers
         self.assertTrue(response.has_header('Link'))

--- a/app/signals/apps/api/tests/test_private_signal_endpoint.py
+++ b/app/signals/apps/api/tests/test_private_signal_endpoint.py
@@ -174,7 +174,16 @@ class TestPrivateSignalViewSet(SIAInactiveUserMixin, SIAReadUserMixin, SIAReadWr
     def test_geo_list_endpoint(self):
         response = self.client.get(self.geo_list_endpoint)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()['features']), 2)
+        features = response.json()['features']
+        self.assertEqual(len(features), 2)
+
+        features_by_signal_id = {feature['properties']['id']: feature for feature in features}
+        for signal in [self.signal_no_image, self.signal_with_image]:
+            properties = features_by_signal_id[signal.id]['properties']
+            self.assertEqual(properties['sub_category'], signal.category_assignment.category.slug)
+            self.assertEqual(properties['main_category'], signal.category_assignment.category.parent.slug)
+            self.assertEqual(properties['status'], signal.status.state)
+            self.assertEqual(properties['priority'], signal.priority.priority)
 
         # Check headers
         self.assertTrue(response.has_header('Link'))

--- a/app/signals/apps/api/views/signals/private/signals.py
+++ b/app/signals/apps/api/views/signals/private/signals.py
@@ -235,6 +235,44 @@ class PrivateSignalViewSet(DetailSerializerMixin, CreateModelMixin, UpdateModelM
                                             'type': 'string',
                                             'format': 'date-time',
                                             'example': '2023-06-01T00:00:00.000000+00:00'
+                                        },
+                                        'category': {
+                                            'type': 'object',
+                                            'nullable': True,
+                                            'properties': {
+                                                'name': {
+                                                    'type': 'string',
+                                                    'example': 'Dumping'
+                                                },
+                                                'slug': {
+                                                    'type': 'string',
+                                                    'example': 'dumping'
+                                                },
+                                                'parent': {
+                                                    'type': 'object',
+                                                    'nullable': True,
+                                                    'properties': {
+                                                        'name': {
+                                                            'type': 'string',
+                                                            'example': 'Afval'
+                                                        },
+                                                        'slug': {
+                                                            'type': 'string',
+                                                            'example': 'afval'
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        'status': {
+                                            'type': 'string',
+                                            'nullable': True,
+                                            'example': 'm'
+                                        },
+                                        'priority': {
+                                            'type': 'string',
+                                            'nullable': True,
+                                            'example': 'normal'
                                         }
                                     }
                                 }
@@ -269,6 +307,16 @@ class PrivateSignalViewSet(DetailSerializerMixin, CreateModelMixin, UpdateModelM
                     properties=JSONObject(
                         id='id',
                         created_at='created_at',
+                        category=JSONObject(
+                            name='category_assignment__category__name',
+                            slug='category_assignment__category__slug',
+                            parent=JSONObject(
+                                name='category_assignment__category__parent__name',
+                                slug='category_assignment__category__parent__slug',
+                            ),
+                        ),
+                        status='status__state',
+                        priority='priority__priority',
                     ),
                 )
             ).filter_for_user(

--- a/app/signals/apps/api/views/signals/private/signals.py
+++ b/app/signals/apps/api/views/signals/private/signals.py
@@ -235,6 +235,26 @@ class PrivateSignalViewSet(DetailSerializerMixin, CreateModelMixin, UpdateModelM
                                             'type': 'string',
                                             'format': 'date-time',
                                             'example': '2023-06-01T00:00:00.000000+00:00'
+                                        },
+                                        'sub_category': {
+                                            'type': 'string',
+                                            'nullable': True,
+                                            'example': 'dumping'
+                                        },
+                                        'main_category': {
+                                            'type': 'string',
+                                            'nullable': True,
+                                            'example': 'afval'
+                                        },
+                                        'status': {
+                                            'type': 'string',
+                                            'nullable': True,
+                                            'example': 'm'
+                                        },
+                                        'priority': {
+                                            'type': 'string',
+                                            'nullable': True,
+                                            'example': 'normal'
                                         }
                                     }
                                 }
@@ -269,6 +289,10 @@ class PrivateSignalViewSet(DetailSerializerMixin, CreateModelMixin, UpdateModelM
                     properties=JSONObject(
                         id='id',
                         created_at='created_at',
+                        sub_category='category_assignment__category__slug',
+                        main_category='category_assignment__category__parent__slug',
+                        status='status__state',
+                        priority='priority__priority',
                     ),
                 )
             ).filter_for_user(


### PR DESCRIPTION
## Description

This PR extends the `/signals/v1/private/signals/geography/` endpoint.

Previously, each feature only included the signal `id` and `created_at` timestamp in its `properties`. With this change, the endpoint also returns the signal's `category` (including parent), `status`, and `priority`.

This addition is particularly useful for the ZoHersteld app, where we use this endpoint to display signals on a map. We've received several requests to visualize the status of a signal using different colors and its priority using icons. By exposing this metadata directly in the endpoint, the frontend no longer needs to perform additional requests to retrieve this information, making it much easier and more efficient to render richer map visualizations.

## Checklist

- [x] Keep the PR, and the amount of commits to a minimum
- [x] The commit messages are meaningful and descriptive
- [x] The change/fix is well documented, particularly in hard-to-understand areas of the code / unit tests
- [ ] Are there any breaking changes in the code, if so are they discussed and did the team agreed to these changes
- [x] Check that the branch is based on `main` and is up to date with `main`
- [x] Check that the PR targets `main`
- [x] There are no merge conflicts and no conflicting Django migrations
- [] PR was created with the "[Allow edits and access to secrets by maintainers](https://docs.github.com/en/enterprise-server@3.2/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)" checkbox checked

## How has this been tested?

- [x] Provided unit tests that will prove the change/fix works as intended
- [x] Tested the change/fix locally and all unit tests still pass
- [x] Code coverage is at least 85% (the higher the better)
- [x] No iSort, Flake8 and SPDX issues are present in the code
